### PR TITLE
Declarative calls

### DIFF
--- a/chain/arweave/src/chain.rs
+++ b/chain/arweave/src/chain.rs
@@ -163,8 +163,8 @@ impl Blockchain for Chain {
             .map_err(Into::into)
     }
 
-    fn runtime_adapter(&self) -> Arc<dyn RuntimeAdapterTrait<Self>> {
-        Arc::new(NoopRuntimeAdapter::default())
+    fn runtime(&self) -> (Arc<dyn RuntimeAdapterTrait<Self>>, Self::DecoderHook) {
+        (Arc::new(NoopRuntimeAdapter::default()), NoopDecoderHook)
     }
 
     fn chain_client(&self) -> Arc<ChainClient<Self>> {
@@ -180,10 +180,6 @@ impl Blockchain for Chain {
             self.name.clone(),
         );
         Ok(Box::new(ingestor))
-    }
-
-    fn decoder_hook(&self) -> Self::DecoderHook {
-        NoopDecoderHook
     }
 }
 

--- a/chain/arweave/src/chain.rs
+++ b/chain/arweave/src/chain.rs
@@ -3,7 +3,7 @@ use graph::blockchain::client::ChainClient;
 use graph::blockchain::firehose_block_ingestor::FirehoseBlockIngestor;
 use graph::blockchain::{
     BasicBlockchainBuilder, Block, BlockIngestor, BlockchainBuilder, BlockchainKind,
-    EmptyNodeCapabilities, NoopRuntimeAdapter,
+    EmptyNodeCapabilities, NoopDecoderHook, NoopRuntimeAdapter,
 };
 use graph::cheap_clone::CheapClone;
 use graph::components::store::DeploymentCursorTracker;
@@ -87,6 +87,8 @@ impl Blockchain for Chain {
     type TriggerFilter = crate::adapter::TriggerFilter;
 
     type NodeCapabilities = EmptyNodeCapabilities<Self>;
+
+    type DecoderHook = NoopDecoderHook;
 
     fn triggers_adapter(
         &self,
@@ -178,6 +180,10 @@ impl Blockchain for Chain {
             self.name.clone(),
         );
         Ok(Box::new(ingestor))
+    }
+
+    fn decoder_hook(&self) -> Self::DecoderHook {
+        NoopDecoderHook
     }
 }
 

--- a/chain/arweave/src/data_source.rs
+++ b/chain/arweave/src/data_source.rs
@@ -157,7 +157,7 @@ impl blockchain::DataSource<Chain> for DataSource {
         todo!()
     }
 
-    fn validate(&self) -> Vec<Error> {
+    fn validate(&self, _: &semver::Version) -> Vec<Error> {
         let mut errors = Vec::new();
 
         if self.kind != ARWEAVE_KIND {

--- a/chain/cosmos/src/chain.rs
+++ b/chain/cosmos/src/chain.rs
@@ -157,8 +157,8 @@ impl Blockchain for Chain {
             .map_err(Into::into)
     }
 
-    fn runtime_adapter(&self) -> Arc<dyn RuntimeAdapterTrait<Self>> {
-        Arc::new(NoopRuntimeAdapter::default())
+    fn runtime(&self) -> (Arc<dyn RuntimeAdapterTrait<Self>>, Self::DecoderHook) {
+        (Arc::new(NoopRuntimeAdapter::default()), NoopDecoderHook)
     }
 
     fn chain_client(&self) -> Arc<ChainClient<Self>> {
@@ -174,10 +174,6 @@ impl Blockchain for Chain {
             self.name.clone(),
         );
         Ok(Box::new(ingestor))
-    }
-
-    fn decoder_hook(&self) -> Self::DecoderHook {
-        NoopDecoderHook
     }
 }
 

--- a/chain/cosmos/src/chain.rs
+++ b/chain/cosmos/src/chain.rs
@@ -1,5 +1,5 @@
 use graph::blockchain::firehose_block_ingestor::FirehoseBlockIngestor;
-use graph::blockchain::BlockIngestor;
+use graph::blockchain::{BlockIngestor, NoopDecoderHook};
 use graph::env::EnvVars;
 use graph::prelude::MetricsRegistry;
 use graph::substreams::Clock;
@@ -81,6 +81,8 @@ impl Blockchain for Chain {
     type TriggerFilter = TriggerFilter;
 
     type NodeCapabilities = EmptyNodeCapabilities<Self>;
+
+    type DecoderHook = NoopDecoderHook;
 
     fn is_refetch_block_required(&self) -> bool {
         false
@@ -172,6 +174,10 @@ impl Blockchain for Chain {
             self.name.clone(),
         );
         Ok(Box::new(ingestor))
+    }
+
+    fn decoder_hook(&self) -> Self::DecoderHook {
+        NoopDecoderHook
     }
 }
 

--- a/chain/cosmos/src/data_source.rs
+++ b/chain/cosmos/src/data_source.rs
@@ -193,7 +193,7 @@ impl blockchain::DataSource<Chain> for DataSource {
         Err(anyhow!(DYNAMIC_DATA_SOURCE_ERROR))
     }
 
-    fn validate(&self) -> Vec<Error> {
+    fn validate(&self, _: &semver::Version) -> Vec<Error> {
         let mut errors = Vec::new();
 
         if self.kind != COSMOS_KIND {
@@ -555,7 +555,7 @@ fn duplicate_url_type(message: &str) -> Error {
 mod tests {
     use super::*;
 
-    use graph::blockchain::DataSource as _;
+    use graph::{blockchain::DataSource as _, data::subgraph::LATEST_VERSION};
 
     #[test]
     fn test_event_handlers_origin_validation() {
@@ -597,7 +597,7 @@ mod tests {
         ];
 
         for (data_source, errors) in &cases {
-            let validation_errors = data_source.validate();
+            let validation_errors = data_source.validate(&LATEST_VERSION);
 
             assert_eq!(errors.len(), validation_errors.len());
 
@@ -645,7 +645,7 @@ mod tests {
         ];
 
         for (data_source, errors) in &cases {
-            let validation_errors = data_source.validate();
+            let validation_errors = data_source.validate(&LATEST_VERSION);
 
             assert_eq!(errors.len(), validation_errors.len());
 

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -976,7 +976,8 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     ) -> Result<(Option<Vec<Token>>, call::Source), EthereumContractCallError>;
 
     /// Make multiple contract calls in a single batch. The returned `Vec`
-    /// has results in the same order as the calls in `calls` on input
+    /// has results in the same order as the calls in `calls` on input. The
+    /// calls must all be for the same block
     async fn contract_calls(
         &self,
         logger: &Logger,

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -37,7 +37,7 @@ pub type EventSignature = H256;
 pub type FunctionSelector = [u8; 4];
 
 #[derive(Clone, Debug)]
-pub struct EthereumContractCall {
+pub struct ContractCall {
     pub address: Address,
     pub block_ptr: BlockPtr,
     pub function: Function,
@@ -46,7 +46,7 @@ pub struct EthereumContractCall {
 }
 
 #[derive(Error, Debug)]
-pub enum EthereumGetBalanceError {
+pub enum GetBalanceError {
     #[error("call error: {0}")]
     Web3Error(web3::Error),
     #[error("ethereum node took too long to perform call")]
@@ -54,7 +54,7 @@ pub enum EthereumGetBalanceError {
 }
 
 #[derive(Error, Debug)]
-pub enum EthereumContractCallError {
+pub enum ContractCallError {
     #[error("ABI error: {0}")]
     ABIError(#[from] ABIError),
     /// `Token` is not of expected `ParamType`
@@ -971,9 +971,9 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     async fn contract_call(
         &self,
         logger: &Logger,
-        call: &EthereumContractCall,
+        call: &ContractCall,
         cache: Arc<dyn EthereumCallCache>,
-    ) -> Result<(Option<Vec<Token>>, call::Source), EthereumContractCallError>;
+    ) -> Result<(Option<Vec<Token>>, call::Source), ContractCallError>;
 
     /// Make multiple contract calls in a single batch. The returned `Vec`
     /// has results in the same order as the calls in `calls` on input. The
@@ -981,16 +981,16 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     async fn contract_calls(
         &self,
         logger: &Logger,
-        calls: &[&EthereumContractCall],
+        calls: &[&ContractCall],
         cache: Arc<dyn EthereumCallCache>,
-    ) -> Result<Vec<(Option<Vec<Token>>, call::Source)>, EthereumContractCallError>;
+    ) -> Result<Vec<(Option<Vec<Token>>, call::Source)>, ContractCallError>;
 
     fn get_balance(
         &self,
         logger: &Logger,
         address: H160,
         block_ptr: BlockPtr,
-    ) -> Box<dyn Future<Item = U256, Error = EthereumGetBalanceError> + Send>;
+    ) -> Box<dyn Future<Item = U256, Error = GetBalanceError> + Send>;
 }
 
 #[cfg(test)]

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -968,7 +968,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     async fn contract_call(
         &self,
         logger: &Logger,
-        call: EthereumContractCall,
+        call: &EthereumContractCall,
         cache: Arc<dyn EthereumCallCache>,
     ) -> Result<Vec<Token>, EthereumContractCallError>;
 

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -965,12 +965,12 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send>;
 
     /// Call the function of a smart contract.
-    fn contract_call(
+    async fn contract_call(
         &self,
         logger: &Logger,
         call: EthereumContractCall,
         cache: Arc<dyn EthereumCallCache>,
-    ) -> Box<dyn Future<Item = Vec<Token>, Error = EthereumContractCallError> + Send>;
+    ) -> Result<Vec<Token>, EthereumContractCallError>;
 
     fn get_balance(
         &self,

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -2,6 +2,7 @@ use anyhow::Error;
 use ethabi::{Error as ABIError, Function, ParamType, Token};
 use futures::Future;
 use graph::blockchain::ChainIdentifier;
+use graph::components::store::CallSource;
 use graph::firehose::CallToFilter;
 use graph::firehose::CombinedFilter;
 use graph::firehose::LogFilter;
@@ -963,13 +964,14 @@ pub trait EthereumAdapter: Send + Sync + 'static {
     ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send>;
 
     /// Call the function of a smart contract. A return of `None` indicates
-    /// that the call reverted.
+    /// that the call reverted. The returned `CallSource` indicates where
+    /// the result came from for accounting purposes
     async fn contract_call(
         &self,
         logger: &Logger,
         call: &EthereumContractCall,
         cache: Arc<dyn EthereumCallCache>,
-    ) -> Result<Option<Vec<Token>>, EthereumContractCallError>;
+    ) -> Result<(Option<Vec<Token>>, CallSource), EthereumContractCallError>;
 
     fn get_balance(
         &self,

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -2,7 +2,7 @@ use anyhow::Error;
 use ethabi::{Error as ABIError, Function, ParamType, Token};
 use futures::Future;
 use graph::blockchain::ChainIdentifier;
-use graph::components::store::CallSource;
+use graph::data::store::ethereum::call;
 use graph::firehose::CallToFilter;
 use graph::firehose::CombinedFilter;
 use graph::firehose::LogFilter;
@@ -971,7 +971,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         logger: &Logger,
         call: &EthereumContractCall,
         cache: Arc<dyn EthereumCallCache>,
-    ) -> Result<(Option<Vec<Token>>, CallSource), EthereumContractCallError>;
+    ) -> Result<(Option<Vec<Token>>, call::Source), EthereumContractCallError>;
 
     fn get_balance(
         &self,

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -63,8 +63,6 @@ pub enum EthereumContractCallError {
     EncodingError(ethabi::Error),
     #[error("call error: {0}")]
     Web3Error(web3::Error),
-    #[error("call reverted: {0}")]
-    Revert(String),
     #[error("ethereum node took too long to perform call")]
     Timeout,
 }
@@ -964,13 +962,14 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         block_number: BlockNumber,
     ) -> Box<dyn Future<Item = Option<H256>, Error = Error> + Send>;
 
-    /// Call the function of a smart contract.
+    /// Call the function of a smart contract. A return of `None` indicates
+    /// that the call reverted.
     async fn contract_call(
         &self,
         logger: &Logger,
         call: &EthereumContractCall,
         cache: Arc<dyn EthereumCallCache>,
-    ) -> Result<Vec<Token>, EthereumContractCallError>;
+    ) -> Result<Option<Vec<Token>>, EthereumContractCallError>;
 
     fn get_balance(
         &self,

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -975,6 +975,15 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         cache: Arc<dyn EthereumCallCache>,
     ) -> Result<(Option<Vec<Token>>, call::Source), EthereumContractCallError>;
 
+    /// Make multiple contract calls in a single batch. The returned `Vec`
+    /// has results in the same order as the calls in `calls` on input
+    async fn contract_calls(
+        &self,
+        logger: &Logger,
+        calls: &[&EthereumContractCall],
+        cache: Arc<dyn EthereumCallCache>,
+    ) -> Result<Vec<(Option<Vec<Token>>, call::Source)>, EthereumContractCallError>;
+
     fn get_balance(
         &self,
         logger: &Logger,

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -66,6 +66,8 @@ pub enum EthereumContractCallError {
     Web3Error(web3::Error),
     #[error("ethereum node took too long to perform call")]
     Timeout,
+    #[error("internal error: {0}")]
+    Internal(String),
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]

--- a/chain/ethereum/src/buffered_call_cache.rs
+++ b/chain/ethereum/src/buffered_call_cache.rs
@@ -1,0 +1,92 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use graph::{
+    components::store::EthereumCallCache,
+    prelude::{ethabi, BlockPtr, CachedEthereumCall},
+};
+
+/// A wrapper around an Ethereum call cache that buffers call results in
+/// memory for the duration of a block. If `get_call` or `set_call` are
+/// called with a different block pointer than the one used in the previous
+/// call, the buffer is cleared.
+pub struct BufferedCallCache {
+    call_cache: Arc<dyn EthereumCallCache>,
+    buffer: Arc<Mutex<HashMap<(ethabi::Address, Vec<u8>), Vec<u8>>>>,
+    block: Arc<Mutex<Option<BlockPtr>>>,
+}
+
+impl BufferedCallCache {
+    pub fn new(call_cache: Arc<dyn EthereumCallCache>) -> Self {
+        Self {
+            call_cache,
+            buffer: Arc::new(Mutex::new(HashMap::new())),
+            block: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn check_block(&self, block: &BlockPtr) {
+        let mut self_block = self.block.lock().unwrap();
+        if self_block.as_ref() != Some(block) {
+            *self_block = Some(block.clone());
+            self.buffer.lock().unwrap().clear();
+        }
+    }
+}
+
+impl EthereumCallCache for BufferedCallCache {
+    fn get_call(
+        &self,
+        contract_address: ethabi::Address,
+        encoded_call: &[u8],
+        block: BlockPtr,
+    ) -> Result<Option<Vec<u8>>, graph::prelude::Error> {
+        self.check_block(&block);
+
+        {
+            let buffer = self.buffer.lock().unwrap();
+            if let Some(result) = buffer.get(&(contract_address, encoded_call.to_vec())) {
+                return Ok(Some(result.clone()));
+            }
+        }
+
+        let result = self
+            .call_cache
+            .get_call(contract_address, encoded_call, block)?;
+
+        if let Some(result) = &result {
+            let mut buffer = self.buffer.lock().unwrap();
+            buffer.insert((contract_address, encoded_call.to_vec()), result.clone());
+        }
+        Ok(result)
+    }
+
+    fn get_calls_in_block(
+        &self,
+        block: BlockPtr,
+    ) -> Result<Vec<CachedEthereumCall>, graph::prelude::Error> {
+        self.call_cache.get_calls_in_block(block)
+    }
+
+    fn set_call(
+        &self,
+        contract_address: ethabi::Address,
+        encoded_call: &[u8],
+        block: BlockPtr,
+        return_value: &[u8],
+    ) -> Result<(), graph::prelude::Error> {
+        self.check_block(&block);
+
+        self.call_cache
+            .set_call(contract_address, encoded_call, block, return_value)?;
+
+        let mut buffer = self.buffer.lock().unwrap();
+        buffer.insert(
+            (contract_address, encoded_call.to_vec()),
+            return_value.to_vec(),
+        );
+        Ok(())
+    }
+}

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -2,7 +2,9 @@ use anyhow::{anyhow, bail, Result};
 use anyhow::{Context, Error};
 use graph::blockchain::client::ChainClient;
 use graph::blockchain::firehose_block_ingestor::{FirehoseBlockIngestor, Transforms};
-use graph::blockchain::{BlockIngestor, BlockTime, BlockchainKind, TriggersAdapterSelector};
+use graph::blockchain::{
+    BlockIngestor, BlockTime, BlockchainKind, NoopDecoderHook, TriggersAdapterSelector,
+};
 use graph::components::store::DeploymentCursorTracker;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::firehose::{FirehoseEndpoint, ForkStep};
@@ -354,6 +356,8 @@ impl Blockchain for Chain {
 
     type NodeCapabilities = crate::capabilities::NodeCapabilities;
 
+    type DecoderHook = NoopDecoderHook;
+
     fn triggers_adapter(
         &self,
         loc: &DeploymentLocator,
@@ -503,6 +507,10 @@ impl Blockchain for Chain {
         };
 
         Ok(ingestor)
+    }
+
+    fn decoder_hook(&self) -> Self::DecoderHook {
+        NoopDecoderHook
     }
 }
 

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -42,6 +42,7 @@ use crate::data_source::DataSourceTemplate;
 use crate::data_source::UnresolvedDataSourceTemplate;
 use crate::ingestor::PollingBlockIngestor;
 use crate::network::EthereumNetworkAdapters;
+use crate::runtime::runtime_adapter::eth_call_gas;
 use crate::EthereumAdapter;
 use crate::NodeCapabilities;
 use crate::{
@@ -511,9 +512,12 @@ impl Blockchain for Chain {
     }
 
     fn decoder_hook(&self) -> Self::DecoderHook {
+        let eth_call_gas = eth_call_gas(self.chain_store.chain_identifier());
+
         crate::data_source::DecoderHook::new(
             self.eth_adapters.cheap_clone(),
             self.call_cache.cheap_clone(),
+            eth_call_gas,
         )
     }
 }

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -47,7 +47,7 @@ use crate::adapter::EthereumAdapter as _;
 use crate::chain::Chain;
 use crate::network::EthereumNetworkAdapters;
 use crate::trigger::{EthereumBlockTriggerType, EthereumTrigger, MappingTrigger};
-use crate::{EthereumContractCall, EthereumContractCallError, NodeCapabilities};
+use crate::{ContractCall, ContractCallError, NodeCapabilities};
 
 // The recommended kind is `ethereum`, `ethereum/contract` is accepted for backwards compatibility.
 const ETHEREUM_KINDS: &[&str] = &["ethereum/contract", "ethereum"];
@@ -965,13 +965,9 @@ impl DeclaredCall {
         Ok(calls)
     }
 
-    fn as_eth_call(
-        self,
-        block_ptr: BlockPtr,
-        gas: Option<u32>,
-    ) -> (EthereumContractCall, String, String) {
+    fn as_eth_call(self, block_ptr: BlockPtr, gas: Option<u32>) -> (ContractCall, String, String) {
         (
-            EthereumContractCall {
+            ContractCall {
                 address: self.address,
                 block_ptr,
                 function: self.function,
@@ -1041,7 +1037,7 @@ impl DecoderHook {
                 // Any error reported by the Ethereum node could be due to the block no longer being on
                 // the main chain. This is very unespecific but we don't want to risk failing a
                 // subgraph due to a transient error such as a reorg.
-                Err(EthereumContractCallError::Web3Error(e)) => Err(MappingError::PossibleReorg(anyhow::anyhow!(
+                Err(ContractCallError::Web3Error(e)) => Err(MappingError::PossibleReorg(anyhow::anyhow!(
                     "Ethereum node returned an error when calling function \"{}\" of contract \"{}\": {}",
                     function_name,
                     contract_name,
@@ -1049,7 +1045,7 @@ impl DecoderHook {
                 ))),
 
                 // Also retry on timeouts.
-                Err(EthereumContractCallError::Timeout) => Err(MappingError::PossibleReorg(anyhow::anyhow!(
+                Err(ContractCallError::Timeout) => Err(MappingError::PossibleReorg(anyhow::anyhow!(
                     "Ethereum node did not respond when calling function \"{}\" of contract \"{}\"",
                     function_name,
                     contract_name,

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -6,6 +6,7 @@ use graph::components::subgraph::{HostMetrics, InstanceDSTemplateInfo, MappingEr
 use graph::components::trigger_processor::RunnableTriggers;
 use graph::data::value::Word;
 use graph::data_source::CausalityRegion;
+use graph::env::ENV_VARS;
 use graph::prelude::ethabi::ethereum_types::H160;
 use graph::prelude::ethabi::{StateMutability, Token};
 use graph::prelude::futures03::future::try_join;
@@ -1070,6 +1071,9 @@ impl blockchain::DecoderHook<Chain> for DecoderHook {
         block_ptr: &BlockPtr,
         runnables: Vec<RunnableTriggers<'a, Chain>>,
     ) -> Result<Vec<RunnableTriggers<'a, Chain>>, MappingError> {
+        if ENV_VARS.mappings.disable_declared_calls {
+            return Ok(runnables);
+        }
         let start = Instant::now();
         let calls: Vec<_> = runnables
             .iter()

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -12,7 +12,6 @@ use graph::prelude::ethabi::{StateMutability, Token};
 use graph::prelude::futures03::future::try_join;
 use graph::prelude::futures03::stream::FuturesOrdered;
 use graph::prelude::regex::Regex;
-use graph::prelude::Future01CompatExt;
 use graph::prelude::{Link, SubgraphManifestValidationError};
 use graph::slog::{info, o, trace};
 use lazy_static::lazy_static;
@@ -1010,7 +1009,6 @@ impl DecoderHook {
 
         let result = eth_adapter
             .contract_call(logger, eth_call, self.call_cache.cheap_clone())
-            .compat()
             .await;
 
         let elapsed = start.elapsed();

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -1008,7 +1008,7 @@ impl DecoderHook {
         }))?;
 
         let result = eth_adapter
-            .contract_call(logger, eth_call, self.call_cache.cheap_clone())
+            .contract_call(logger, &eth_call, self.call_cache.cheap_clone())
             .await;
 
         let elapsed = start.elapsed();

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -2,9 +2,10 @@ use anyhow::{anyhow, Error};
 use anyhow::{ensure, Context};
 use graph::blockchain::{BlockPtr, TriggerWithHandler};
 use graph::components::metrics::subgraph::SubgraphInstanceMetrics;
-use graph::components::store::{CallSource, EthereumCallCache, StoredDynamicDataSource};
+use graph::components::store::{EthereumCallCache, StoredDynamicDataSource};
 use graph::components::subgraph::{HostMetrics, InstanceDSTemplateInfo, MappingError};
 use graph::components::trigger_processor::RunnableTriggers;
+use graph::data::store::ethereum::call;
 use graph::data::value::Word;
 use graph::data_source::CausalityRegion;
 use graph::env::ENV_VARS;
@@ -1025,7 +1026,7 @@ impl DecoderHook {
             .await
         {
             Ok((result, source)) => (Ok(result), source),
-            Err(e) => (Err(e), CallSource::Rpc),
+            Err(e) => (Err(e), call::Source::Rpc),
         };
 
         // This error analysis is very much modeled on the one in

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -3,13 +3,17 @@ use anyhow::{ensure, Context};
 use graph::blockchain::TriggerWithHandler;
 use graph::components::store::StoredDynamicDataSource;
 use graph::components::subgraph::InstanceDSTemplateInfo;
+use graph::data::value::Word;
 use graph::data_source::CausalityRegion;
 use graph::prelude::ethabi::ethereum_types::H160;
 use graph::prelude::ethabi::StateMutability;
 use graph::prelude::futures03::future::try_join;
 use graph::prelude::futures03::stream::FuturesOrdered;
+use graph::prelude::regex::Regex;
 use graph::prelude::{Link, SubgraphManifestValidationError};
 use graph::slog::{o, trace};
+use lazy_static::lazy_static;
+use serde::de;
 use std::collections::HashSet;
 use std::num::NonZeroU32;
 use std::str::FromStr;
@@ -30,6 +34,7 @@ use graph::{
 
 use graph::data::subgraph::{
     calls_host_fn, DataSourceContext, Source, MIN_SPEC_VERSION, SPEC_VERSION_0_0_8,
+    SPEC_VERSION_1_2_0,
 };
 
 use crate::chain::Chain;
@@ -268,7 +273,7 @@ impl blockchain::DataSource<Chain> for DataSource {
         })
     }
 
-    fn validate(&self, _: &semver::Version) -> Vec<Error> {
+    fn validate(&self, spec_version: &semver::Version) -> Vec<Error> {
         let mut errors = vec![];
 
         if !ETHEREUM_KINDS.contains(&self.kind.as_str()) {
@@ -347,6 +352,33 @@ impl blockchain::DataSource<Chain> for DataSource {
             }
         }
 
+        if spec_version < &SPEC_VERSION_1_2_0 {
+            for handler in &self.mapping.event_handlers {
+                if !handler.calls.decls.is_empty() {
+                    errors.push(anyhow!(
+                        "handler {}: declaring eth calls on handlers is only supported for specVersion >= 1.2.0", handler.event
+                    ));
+                    break;
+                }
+            }
+        }
+
+        for handler in &self.mapping.event_handlers {
+            for call in handler.calls.decls.as_ref() {
+                match self.mapping.find_abi(&call.expr.abi) {
+                    // TODO: Handle overloaded functions by passing a signature
+                    Ok(abi) => match abi.function(&call.expr.abi, &call.expr.func, None) {
+                        Ok(_) => {}
+                        Err(e) => {
+                            errors.push(e);
+                        }
+                    },
+                    Err(e) => {
+                        errors.push(e);
+                    }
+                }
+            }
+        }
         errors
     }
 
@@ -1210,6 +1242,8 @@ pub struct MappingEventHandler {
     pub handler: String,
     #[serde(default)]
     pub receipt: bool,
+    #[serde(default)]
+    pub calls: CallDecls,
 }
 
 impl MappingEventHandler {
@@ -1236,4 +1270,179 @@ fn string_to_h256(s: &str) -> H256 {
 #[derive(Clone, Debug, Default, Hash, Eq, PartialEq, Deserialize)]
 pub struct TemplateSource {
     pub abi: String,
+}
+
+/// Internal representation of declared calls. In the manifest that's
+/// written as part of an event handler as
+/// ```yaml
+/// calls:
+///   - myCall1: Contract[address].function(arg1, arg2, ...)
+///   - ..
+/// ```
+///
+/// The `address` and `arg` fields can be either `event.address` or
+/// `event.params.<name>`. Each entry under `calls` gets turned into a
+/// `CallDcl`
+#[derive(Clone, Debug, Default, Hash, Eq, PartialEq)]
+pub struct CallDecls {
+    pub decls: Arc<Vec<CallDecl>>,
+    readonly: (),
+}
+
+impl CheapClone for CallDecls {}
+
+/// A single call declaration, like `myCall1:
+/// Contract[address].function(arg1, arg2, ...)`
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub struct CallDecl {
+    /// A user-defined label
+    pub label: String,
+    /// The call expression
+    pub expr: CallExpr,
+    readonly: (),
+}
+
+impl<'de> de::Deserialize<'de> for CallDecls {
+    fn deserialize<D>(deserializer: D) -> Result<CallDecls, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let decls: std::collections::HashMap<String, String> =
+            de::Deserialize::deserialize(deserializer)?;
+        let decls = decls
+            .into_iter()
+            .map(|(name, expr)| {
+                expr.parse::<CallExpr>().map(|expr| CallDecl {
+                    label: name,
+                    expr,
+                    readonly: (),
+                })
+            })
+            .collect::<Result<_, _>>()
+            .map(|decls| Arc::new(decls))
+            .map_err(de::Error::custom)?;
+        Ok(CallDecls {
+            decls,
+            readonly: (),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub struct CallExpr {
+    pub abi: Word,
+    pub address: CallArg,
+    pub func: Word,
+    pub args: Vec<CallArg>,
+    readonly: (),
+}
+
+/// Parse expressions of the form `Contract[address].function(arg1, arg2,
+/// ...)` where the `address` and the args are either `event.address` or
+/// `event.params.<name>`.
+///
+/// The parser is pretty awful as it generates error messages that aren't
+/// very helpful. We should replace all this with a real parser, most likely
+/// `combine` which is what `graphql_parser` uses
+impl FromStr for CallExpr {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        lazy_static! {
+            static ref RE: Regex = Regex::new(
+                r"(?x)
+                (?P<abi>[a-zA-Z0-9_]+)\[
+                    (?P<address>[^]]+)\]
+                \.
+                (?P<func>[a-zA-Z0-9_]+)\(
+                    (?P<args>[^)]*)
+                \)"
+            )
+            .unwrap();
+        }
+        let x = RE
+            .captures(s)
+            .ok_or_else(|| anyhow!("invalid call expression `{s}`"))?;
+        let abi = Word::from(x.name("abi").unwrap().as_str());
+        let address = x.name("address").unwrap().as_str().parse()?;
+        let func = Word::from(x.name("func").unwrap().as_str());
+        let args: Vec<CallArg> = x
+            .name("args")
+            .unwrap()
+            .as_str()
+            .split(',')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.trim().parse::<CallArg>())
+            .collect::<Result<_, _>>()?;
+        Ok(CallExpr {
+            abi,
+            address,
+            func,
+            args,
+            readonly: (),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub enum CallArg {
+    Address,
+    Param(Word),
+}
+
+impl FromStr for CallArg {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        fn invalid(s: &str) -> Result<CallArg, anyhow::Error> {
+            Err(anyhow!("invalid call argument `{}`", s))
+        }
+
+        let mut parts = s.split(".");
+        match parts.next() {
+            Some("event") => { /* ok */ }
+            Some(_) => return Err(anyhow!("call arguments must start with `event`")),
+            None => return Err(anyhow!("empty call argument")),
+        }
+        match parts.next() {
+            Some("address") => Ok(CallArg::Address),
+            Some("params") => match parts.next() {
+                Some(s) => Ok(CallArg::Param(Word::from(s))),
+                None => invalid(s),
+            },
+            Some(s) => invalid(s),
+            None => invalid(s),
+        }
+    }
+}
+
+#[test]
+fn test_call_expr() {
+    let expr: CallExpr = "ERC20[event.address].balanceOf(event.params.token)"
+        .parse()
+        .unwrap();
+    assert_eq!(expr.abi, "ERC20");
+    assert_eq!(expr.address, CallArg::Address);
+    assert_eq!(expr.func, "balanceOf");
+    assert_eq!(expr.args, vec![CallArg::Param("token".into())]);
+
+    let expr: CallExpr = "Pool[event.params.pool].fees(event.params.token0, event.params.token1)"
+        .parse()
+        .unwrap();
+    assert_eq!(expr.abi, "Pool");
+    assert_eq!(expr.address, CallArg::Param("pool".into()));
+    assert_eq!(expr.func, "fees");
+    assert_eq!(
+        expr.args,
+        vec![
+            CallArg::Param("token0".into()),
+            CallArg::Param("token1".into())
+        ]
+    );
+
+    let expr: CallExpr = "Pool[event.address].growth()".parse().unwrap();
+    assert_eq!(expr.abi, "Pool");
+    assert_eq!(expr.address, CallArg::Address);
+    assert_eq!(expr.func, "growth");
+    assert_eq!(expr.args, vec![]);
 }

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -1001,7 +1001,6 @@ impl DecoderHook {
     ) -> Result<usize, MappingError> {
         let start = Instant::now();
         let function_name = call.function.name.clone();
-        let address = call.address;
         let (eth_call, contract_name) = call.as_eth_call(block_ptr.clone());
         let eth_adapter = self.eth_adapters.call_or_cheapest(Some(&NodeCapabilities {
             archive: true,
@@ -1025,14 +1024,7 @@ impl DecoderHook {
         // make them the same but there are subtle differences (return
         // type, error type)
         match result {
-                Ok(_) => Ok(0),
-                Err(EthereumContractCallError::Revert(reason)) => {
-                    info!(logger, "Declared contract call reverted";
-                          "reason" => reason,
-                          "contract" => format!("0x{:x}", address),
-                          "call" => format!("{}.{}", contract_name, function_name));
-                    Ok(1)
-                }
+                Ok(r) => Ok(if r.is_some() { 0 } else { 1 }),
 
                 // Any error reported by the Ethereum node could be due to the block no longer being on
                 // the main chain. This is very unespecific but we don't want to risk failing a

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -268,7 +268,7 @@ impl blockchain::DataSource<Chain> for DataSource {
         })
     }
 
-    fn validate(&self) -> Vec<Error> {
+    fn validate(&self, _: &semver::Version) -> Vec<Error> {
         let mut errors = vec![];
 
         if !ETHEREUM_KINDS.contains(&self.kind.as_str()) {

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1337,7 +1337,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
             Err(e) => return Err(EthereumContractCallError::EncodingError(e)),
         };
 
-        debug!(logger, "eth_call";
+        trace!(logger, "eth_call";
             "fn" => &call.function.name,
             "address" => hex::encode(call.address),
             "data" => hex::encode(&call_data),

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1393,7 +1393,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
             logger: &Logger,
             resp: call::Response,
             call: &ContractCall,
-        ) -> Result<(Option<Vec<Token>>, call::Source), ContractCallError> {
+        ) -> (Option<Vec<Token>>, call::Source) {
             let call::Response {
                 retval,
                 source,
@@ -1402,13 +1402,13 @@ impl EthereumAdapterTrait for EthereumAdapter {
             use call::Retval::*;
             match retval {
                 Value(output) => match call.function.decode_output(&output) {
-                    Ok(tokens) => Ok((Some(tokens), source)),
+                    Ok(tokens) => (Some(tokens), source),
                     Err(e) => {
                         // Decode failures are reverts. The reasoning is that if Solidity fails to
                         // decode an argument, that's a revert, so the same goes for the output.
                         let reason = format!("failed to decode output: {}", e);
                         info!(logger, "Contract call reverted"; "reason" => reason);
-                        Ok((None, call::Source::Rpc))
+                        (None, call::Source::Rpc)
                     }
                 },
                 Null => {
@@ -1416,7 +1416,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
                     // that the contract actually returned an empty response. A view call is meant
                     // to return something, so we treat empty responses the same as reverts.
                     info!(logger, "Contract call reverted"; "reason" => "empty response");
-                    Ok((None, call::Source::Rpc))
+                    (None, call::Source::Rpc)
                 }
             }
         }
@@ -1461,7 +1461,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
                 let call = &calls[res.req.index as usize];
                 decode(logger, res, call)
             })
-            .collect::<Result<_, _>>()?;
+            .collect();
 
         Ok(decoded)
     }

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1306,7 +1306,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
     async fn contract_call(
         &self,
         logger: &Logger,
-        call: EthereumContractCall,
+        call: &EthereumContractCall,
         cache: Arc<dyn EthereumCallCache>,
     ) -> Result<Vec<Token>, EthereumContractCallError> {
         // Emit custom error for type mismatches.

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -1,4 +1,5 @@
 mod adapter;
+mod buffered_call_cache;
 mod capabilities;
 pub mod codec;
 mod data_source;
@@ -13,6 +14,8 @@ pub use self::ethereum_adapter::EthereumAdapter;
 pub use self::runtime::RuntimeAdapter;
 pub use self::transport::Transport;
 pub use env::ENV_VARS;
+
+pub use buffered_call_cache::BufferedCallCache;
 
 // ETHDEP: These concrete types should probably not be exposed.
 pub use data_source::{

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -28,7 +28,7 @@ pub mod network;
 pub mod trigger;
 
 pub use crate::adapter::{
-    EthereumAdapter as EthereumAdapterTrait, EthereumContractCall, EthereumContractCallError,
+    ContractCall, ContractCallError, EthereumAdapter as EthereumAdapterTrait,
     ProviderEthRpcMetrics, SubgraphEthRpcMetrics, TriggerFilter,
 };
 pub use crate::chain::Chain;

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -25,7 +25,7 @@ use graph::{
     },
     runtime::{asc_get, asc_new, AscPtr, HostExportError},
     semver::Version,
-    slog::{info, trace, Logger},
+    slog::{trace, Logger},
 };
 use graph_runtime_wasm::asc_abi::class::{AscBigInt, AscEnumArray, EthereumValueKind};
 
@@ -237,11 +237,7 @@ fn eth_call(
     let result = match graph::block_on(
             eth_adapter.contract_call(&logger1, &call, call_cache)
         ) {
-            Ok(tokens) => Ok(Some(tokens)),
-            Err(EthereumContractCallError::Revert(reason)) => {
-                info!(logger, "Contract call reverted"; "reason" => reason);
-                Ok(None)
-            }
+            Ok(res) => Ok(res),
 
             // Any error reported by the Ethereum node could be due to the block no longer being on
             // the main chain. This is very unespecific but we don't want to risk failing a

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -235,7 +235,7 @@ fn eth_call(
     let logger1 = logger.clone();
     let call_cache = call_cache.clone();
     let result = match graph::block_on(
-            eth_adapter.contract_call(&logger1, call, call_cache).compat()
+            eth_adapter.contract_call(&logger1, call, call_cache)
         ) {
             Ok(tokens) => Ok(Some(tokens)),
             Err(EthereumContractCallError::Revert(reason)) => {

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -10,8 +10,8 @@ use crate::{
 use anyhow::{anyhow, Context, Error};
 use blockchain::HostFn;
 use graph::blockchain::ChainIdentifier;
-use graph::components::store::CallSource;
 use graph::components::subgraph::HostMetrics;
+use graph::data::store::ethereum::call;
 use graph::data::store::scalar::BigInt;
 use graph::data::subgraph::API_VERSION_0_0_9;
 use graph::prelude::web3::types::H160;
@@ -256,7 +256,7 @@ fn eth_call(
     let (result, source) =
         match graph::block_on(eth_adapter.contract_call(&logger1, &call, call_cache)) {
             Ok((result, source)) => (Ok(result), source),
-            Err(e) => (Err(e), CallSource::Rpc),
+            Err(e) => (Err(e), call::Source::Rpc),
         };
     let result = match result {
             Ok(res) => Ok(res),

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -242,6 +242,7 @@ fn eth_call(
         .map_err(HostExportError::Deterministic)?;
 
     let call = ContractCall {
+        contract_name: unresolved_call.contract_name.clone(),
         address: unresolved_call.contract_address,
         block_ptr: block_ptr.cheap_clone(),
         function: function.clone(),

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -235,7 +235,7 @@ fn eth_call(
     let logger1 = logger.clone();
     let call_cache = call_cache.clone();
     let result = match graph::block_on(
-            eth_adapter.contract_call(&logger1, call, call_cache)
+            eth_adapter.contract_call(&logger1, &call, call_cache)
         ) {
             Ok(tokens) => Ok(Some(tokens)),
             Err(EthereumContractCallError::Revert(reason)) => {

--- a/chain/ethereum/src/trigger.rs
+++ b/chain/ethereum/src/trigger.rs
@@ -28,6 +28,7 @@ use graph_runtime_wasm::module::ToAscPtr;
 use std::ops::Deref;
 use std::{cmp::Ordering, sync::Arc};
 
+use crate::data_source::DeclaredCall;
 use crate::runtime::abi::AscEthereumBlock;
 use crate::runtime::abi::AscEthereumBlock_0_0_6;
 use crate::runtime::abi::AscEthereumCall;
@@ -48,6 +49,7 @@ pub enum MappingTrigger {
         log: Arc<Log>,
         params: Vec<LogParam>,
         receipt: Option<Arc<TransactionReceipt>>,
+        calls: Vec<DeclaredCall>,
     },
     Call {
         block: Arc<LightEthereumBlock>,
@@ -102,6 +104,7 @@ impl std::fmt::Debug for MappingTrigger {
                 log,
                 params,
                 receipt: _,
+                calls: _,
             } => MappingTriggerWithoutBlock::Log {
                 _transaction: transaction.cheap_clone(),
                 _log: log.cheap_clone(),
@@ -139,6 +142,7 @@ impl ToAscPtr for MappingTrigger {
                 log,
                 params,
                 receipt,
+                calls: _,
             } => {
                 let api_version = heap.api_version();
                 let ethereum_event_data = EthereumEventData {

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -3,7 +3,8 @@ use graph::blockchain::client::ChainClient;
 use graph::blockchain::firehose_block_ingestor::FirehoseBlockIngestor;
 use graph::blockchain::substreams_block_stream::SubstreamsBlockStream;
 use graph::blockchain::{
-    BasicBlockchainBuilder, BlockIngestor, BlockchainBuilder, BlockchainKind, NoopRuntimeAdapter,
+    BasicBlockchainBuilder, BlockIngestor, BlockchainBuilder, BlockchainKind, NoopDecoderHook,
+    NoopRuntimeAdapter,
 };
 use graph::cheap_clone::CheapClone;
 use graph::components::store::DeploymentCursorTracker;
@@ -209,6 +210,8 @@ impl Blockchain for Chain {
 
     type NodeCapabilities = EmptyNodeCapabilities<Chain>;
 
+    type DecoderHook = NoopDecoderHook;
+
     fn triggers_adapter(
         &self,
         _loc: &DeploymentLocator,
@@ -300,6 +303,10 @@ impl Blockchain for Chain {
             self.name.clone(),
         );
         Ok(Box::new(ingestor))
+    }
+
+    fn decoder_hook(&self) -> Self::DecoderHook {
+        NoopDecoderHook
     }
 }
 

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -286,8 +286,8 @@ impl Blockchain for Chain {
             .await
     }
 
-    fn runtime_adapter(&self) -> Arc<dyn RuntimeAdapterTrait<Self>> {
-        Arc::new(NoopRuntimeAdapter::default())
+    fn runtime(&self) -> (Arc<dyn RuntimeAdapterTrait<Self>>, Self::DecoderHook) {
+        (Arc::new(NoopRuntimeAdapter::default()), NoopDecoderHook)
     }
 
     fn chain_client(&self) -> Arc<ChainClient<Self>> {
@@ -303,10 +303,6 @@ impl Blockchain for Chain {
             self.name.clone(),
         );
         Ok(Box::new(ingestor))
-    }
-
-    fn decoder_hook(&self) -> Self::DecoderHook {
-        NoopDecoderHook
     }
 }
 

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -565,6 +565,7 @@ mod test {
 
     use graph::{
         blockchain::{block_stream::BlockWithTriggers, DataSource as _, TriggersAdapter as _},
+        data::subgraph::LATEST_VERSION,
         prelude::{tokio, Link},
         semver::Version,
         slog::{self, o, Logger},
@@ -587,7 +588,7 @@ mod test {
     #[test]
     fn validate_empty() {
         let ds = new_data_source(None, None);
-        let errs = ds.validate();
+        let errs = ds.validate(LATEST_VERSION);
         assert_eq!(errs.len(), 1, "{:?}", ds);
         assert_eq!(errs[0].to_string(), "subgraph source address is required");
     }
@@ -595,7 +596,7 @@ mod test {
     #[test]
     fn validate_empty_account_none_partial() {
         let ds = new_data_source(None, Some(PartialAccounts::default()));
-        let errs = ds.validate();
+        let errs = ds.validate(LATEST_VERSION);
         assert_eq!(errs.len(), 1, "{:?}", ds);
         assert_eq!(errs[0].to_string(), "subgraph source address is required");
     }
@@ -609,7 +610,7 @@ mod test {
                 suffixes: vec!["x.near".to_string()],
             }),
         );
-        let errs = ds.validate();
+        let errs = ds.validate(LATEST_VERSION);
         assert_eq!(errs.len(), 0, "{:?}", ds);
     }
 
@@ -623,7 +624,7 @@ mod test {
             }),
         );
         let errs: Vec<String> = ds
-            .validate()
+            .validate(LATEST_VERSION)
             .into_iter()
             .map(|err| err.to_string())
             .collect();
@@ -644,7 +645,7 @@ mod test {
     #[test]
     fn validate_empty_partials() {
         let ds = new_data_source(Some("x.near".to_string()), None);
-        let errs = ds.validate();
+        let errs = ds.validate(LATEST_VERSION);
         assert_eq!(errs.len(), 0, "{:?}", ds);
     }
 

--- a/chain/near/src/data_source.rs
+++ b/chain/near/src/data_source.rs
@@ -226,7 +226,7 @@ impl blockchain::DataSource<Chain> for DataSource {
         todo!()
     }
 
-    fn validate(&self) -> Vec<Error> {
+    fn validate(&self, _: &semver::Version) -> Vec<Error> {
         let mut errors = Vec::new();
 
         if self.kind != NEAR_KIND {

--- a/chain/starknet/src/chain.rs
+++ b/chain/starknet/src/chain.rs
@@ -430,7 +430,7 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
 mod tests {
     use std::sync::Arc;
 
-    use graph::blockchain::DataSource as _;
+    use graph::{blockchain::DataSource as _, data::subgraph::LATEST_VERSION};
 
     use crate::{
         data_source::{
@@ -443,7 +443,7 @@ mod tests {
     fn validate_no_handler() {
         let ds = new_data_source(None);
 
-        let errs = ds.validate();
+        let errs = ds.validate(LATEST_VERSION);
         assert_eq!(errs.len(), 1, "{:?}", ds);
         assert_eq!(
             errs[0].to_string(),
@@ -458,7 +458,7 @@ mod tests {
             handler: "asdf".into(),
         });
 
-        let errs = ds.validate();
+        let errs = ds.validate(LATEST_VERSION);
         assert_eq!(errs.len(), 1, "{:?}", ds);
         assert_eq!(
             errs[0].to_string(),
@@ -474,7 +474,7 @@ mod tests {
             event_selector: [2u8; 32].into(),
         });
 
-        let errs = ds.validate();
+        let errs = ds.validate(LATEST_VERSION);
         assert_eq!(errs.len(), 1, "{:?}", ds);
         assert_eq!(errs[0].to_string(), "subgraph source address is required");
     }

--- a/chain/starknet/src/chain.rs
+++ b/chain/starknet/src/chain.rs
@@ -10,7 +10,7 @@ use graph::{
         firehose_block_ingestor::FirehoseBlockIngestor,
         firehose_block_stream::FirehoseBlockStream,
         BasicBlockchainBuilder, Block, BlockIngestor, BlockPtr, Blockchain, BlockchainBuilder,
-        BlockchainKind, EmptyNodeCapabilities, IngestorError, NoopRuntimeAdapter,
+        BlockchainKind, EmptyNodeCapabilities, IngestorError, NoopDecoderHook, NoopRuntimeAdapter,
         RuntimeAdapter as RuntimeAdapterTrait,
     },
     cheap_clone::CheapClone,
@@ -94,6 +94,8 @@ impl Blockchain for Chain {
 
     type NodeCapabilities = EmptyNodeCapabilities<Self>;
 
+    type DecoderHook = NoopDecoderHook;
+
     fn triggers_adapter(
         &self,
         _log: &DeploymentLocator,
@@ -170,6 +172,10 @@ impl Blockchain for Chain {
             self.name.clone(),
         );
         Ok(Box::new(ingestor))
+    }
+
+    fn decoder_hook(&self) -> Self::DecoderHook {
+        NoopDecoderHook
     }
 }
 

--- a/chain/starknet/src/chain.rs
+++ b/chain/starknet/src/chain.rs
@@ -155,8 +155,8 @@ impl Blockchain for Chain {
             .await
     }
 
-    fn runtime_adapter(&self) -> Arc<dyn RuntimeAdapterTrait<Self>> {
-        Arc::new(NoopRuntimeAdapter::default())
+    fn runtime(&self) -> (Arc<dyn RuntimeAdapterTrait<Self>>, Self::DecoderHook) {
+        (Arc::new(NoopRuntimeAdapter::default()), NoopDecoderHook)
     }
 
     fn chain_client(&self) -> Arc<ChainClient<Self>> {
@@ -172,10 +172,6 @@ impl Blockchain for Chain {
             self.name.clone(),
         );
         Ok(Box::new(ingestor))
-    }
-
-    fn decoder_hook(&self) -> Self::DecoderHook {
-        NoopDecoderHook
     }
 }
 

--- a/chain/starknet/src/data_source.rs
+++ b/chain/starknet/src/data_source.rs
@@ -208,7 +208,7 @@ impl blockchain::DataSource<Chain> for DataSource {
         todo!()
     }
 
-    fn validate(&self) -> Vec<Error> {
+    fn validate(&self, _: &semver::Version) -> Vec<Error> {
         let mut errors = Vec::new();
 
         if self.kind != STARKNET_KIND {

--- a/chain/substreams/src/chain.rs
+++ b/chain/substreams/src/chain.rs
@@ -181,8 +181,8 @@ impl Blockchain for Chain {
             number,
         })
     }
-    fn runtime_adapter(&self) -> Arc<dyn RuntimeAdapterTrait<Self>> {
-        Arc::new(NoopRuntimeAdapter::default())
+    fn runtime(&self) -> (Arc<dyn RuntimeAdapterTrait<Self>>, Self::DecoderHook) {
+        (Arc::new(NoopRuntimeAdapter::default()), NoopDecoderHook)
     }
 
     fn chain_client(&self) -> Arc<ChainClient<Self>> {
@@ -197,10 +197,6 @@ impl Blockchain for Chain {
             "substreams".to_string(),
             self.metrics_registry.cheap_clone(),
         )))
-    }
-
-    fn decoder_hook(&self) -> Self::DecoderHook {
-        NoopDecoderHook
     }
 }
 

--- a/chain/substreams/src/chain.rs
+++ b/chain/substreams/src/chain.rs
@@ -3,7 +3,8 @@ use crate::{data_source::*, EntityChanges, TriggerData, TriggerFilter, TriggersA
 use anyhow::Error;
 use graph::blockchain::client::ChainClient;
 use graph::blockchain::{
-    BasicBlockchainBuilder, BlockIngestor, BlockTime, EmptyNodeCapabilities, NoopRuntimeAdapter,
+    BasicBlockchainBuilder, BlockIngestor, BlockTime, EmptyNodeCapabilities, NoopDecoderHook,
+    NoopRuntimeAdapter,
 };
 use graph::components::store::DeploymentCursorTracker;
 use graph::env::EnvVars;
@@ -120,6 +121,8 @@ impl Blockchain for Chain {
 
     type NodeCapabilities = EmptyNodeCapabilities<Self>;
 
+    type DecoderHook = NoopDecoderHook;
+
     fn triggers_adapter(
         &self,
         _log: &DeploymentLocator,
@@ -194,6 +197,10 @@ impl Blockchain for Chain {
             "substreams".to_string(),
             self.metrics_registry.cheap_clone(),
         )))
+    }
+
+    fn decoder_hook(&self) -> Self::DecoderHook {
+        NoopDecoderHook
     }
 }
 

--- a/chain/substreams/src/data_source.rs
+++ b/chain/substreams/src/data_source.rs
@@ -106,7 +106,7 @@ impl blockchain::DataSource<Chain> for DataSource {
         unimplemented!("{}", DYNAMIC_DATA_SOURCE_ERROR)
     }
 
-    fn validate(&self) -> Vec<Error> {
+    fn validate(&self, _: &semver::Version) -> Vec<Error> {
         let mut errs = vec![];
 
         if &self.kind != SUBSTREAMS_KIND {
@@ -327,11 +327,14 @@ mod test {
     use graph::{
         blockchain::{DataSource as _, UnresolvedDataSource as _},
         components::link_resolver::LinkResolver,
+        data::subgraph::LATEST_VERSION,
         prelude::{async_trait, serde_yaml, JsonValueStream, Link},
         slog::{o, Discard, Logger},
-        substreams::module::{Kind, KindMap, KindStore},
         substreams::{
-            module::input::{Input, Params},
+            module::{
+                input::{Input, Params},
+                Kind, KindMap, KindStore,
+            },
             Module, Modules, Package,
         },
     };
@@ -459,15 +462,19 @@ mod test {
     #[test]
     fn data_source_validation() {
         let mut ds = gen_data_source();
-        assert_eq!(true, ds.validate().is_empty());
+        assert_eq!(true, ds.validate(LATEST_VERSION).is_empty());
 
         ds.network = None;
-        assert_eq!(true, ds.validate().is_empty());
+        assert_eq!(true, ds.validate(LATEST_VERSION).is_empty());
 
         ds.kind = "asdasd".into();
         ds.name = "".into();
         ds.mapping.kind = "asdasd".into();
-        let errs: Vec<String> = ds.validate().into_iter().map(|e| e.to_string()).collect();
+        let errs: Vec<String> = ds
+            .validate(LATEST_VERSION)
+            .into_iter()
+            .map(|e| e.to_string())
+            .collect();
         assert_eq!(
             errs,
             vec![

--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -12,7 +12,6 @@ use graph::{
         subgraph::{MappingError, ProofOfIndexingEvent, SharedProofOfIndexing},
         trigger_processor::HostedTrigger,
     },
-    data_source,
     prelude::{
         anyhow, async_trait, BlockHash, BlockNumber, BlockState, CheapClone, RuntimeHostBuilder,
     },
@@ -200,9 +199,8 @@ where
     async fn process_trigger<'a>(
         &'a self,
         logger: &Logger,
-        _: Box<dyn Iterator<Item = &'a T::Host> + Send + 'a>,
+        _: Vec<HostedTrigger<'a, Chain>>,
         block: &Arc<Block>,
-        _trigger: &data_source::TriggerData<Chain>,
         mut state: BlockState,
         proof_of_indexing: &SharedProofOfIndexing,
         causality_region: &str,

--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -3,13 +3,15 @@ use std::sync::Arc;
 use anyhow::Error;
 use graph::{
     blockchain::{
-        self, block_stream::BlockWithTriggers, BlockPtr, EmptyNodeCapabilities, MappingTriggerTrait,
+        self, block_stream::BlockWithTriggers, BlockPtr, Blockchain, EmptyNodeCapabilities,
+        MappingTriggerTrait,
     },
     components::{
+        metrics::subgraph::SubgraphInstanceMetrics,
         store::{DeploymentLocator, SubgraphFork},
         subgraph::{MappingError, ProofOfIndexingEvent, SharedProofOfIndexing},
     },
-    data_source,
+    data_source::{self, MappingTrigger},
     prelude::{
         anyhow, async_trait, BlockHash, BlockNumber, BlockState, CheapClone, RuntimeHostBuilder,
     },
@@ -197,7 +199,7 @@ where
     async fn process_trigger<'a>(
         &'a self,
         logger: &Logger,
-        _: Box<dyn Iterator<Item = &T::Host> + Send + 'a>,
+        _: Box<dyn Iterator<Item = &'a T::Host> + Send + 'a>,
         block: &Arc<Block>,
         _trigger: &data_source::TriggerData<Chain>,
         mut state: BlockState,
@@ -247,5 +249,22 @@ where
         }
 
         Ok(state)
+    }
+
+    fn match_and_decode<'a>(
+        &'a self,
+        _: &Logger,
+        _: &Arc<<Chain as Blockchain>::Block>,
+        _: &graph::data_source::TriggerData<Chain>,
+        _: Box<dyn Iterator<Item = &'a T::Host> + Send + 'a>,
+        _: &Arc<SubgraphInstanceMetrics>,
+    ) -> Result<
+        Vec<(
+            &'a T::Host,
+            graph::data_source::TriggerWithHandler<MappingTrigger<Chain>>,
+        )>,
+        MappingError,
+    > {
+        Ok(vec![])
     }
 }

--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -3,11 +3,9 @@ use std::sync::Arc;
 use anyhow::Error;
 use graph::{
     blockchain::{
-        self, block_stream::BlockWithTriggers, BlockPtr, Blockchain, EmptyNodeCapabilities,
-        MappingTriggerTrait,
+        self, block_stream::BlockWithTriggers, BlockPtr, EmptyNodeCapabilities, MappingTriggerTrait,
     },
     components::{
-        metrics::subgraph::SubgraphInstanceMetrics,
         store::{DeploymentLocator, SubgraphFork},
         subgraph::{MappingError, ProofOfIndexingEvent, SharedProofOfIndexing},
         trigger_processor::HostedTrigger,
@@ -248,16 +246,5 @@ where
         }
 
         Ok(state)
-    }
-
-    fn match_and_decode<'a>(
-        &'a self,
-        _: &Logger,
-        _: &Arc<<Chain as Blockchain>::Block>,
-        _: &graph::data_source::TriggerData<Chain>,
-        _: Box<dyn Iterator<Item = &'a T::Host> + Send + 'a>,
-        _: &Arc<SubgraphInstanceMetrics>,
-    ) -> Result<Vec<HostedTrigger<'a, Chain>>, MappingError> {
-        Ok(vec![])
     }
 }

--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -10,8 +10,9 @@ use graph::{
         metrics::subgraph::SubgraphInstanceMetrics,
         store::{DeploymentLocator, SubgraphFork},
         subgraph::{MappingError, ProofOfIndexingEvent, SharedProofOfIndexing},
+        trigger_processor::HostedTrigger,
     },
-    data_source::{self, MappingTrigger},
+    data_source,
     prelude::{
         anyhow, async_trait, BlockHash, BlockNumber, BlockState, CheapClone, RuntimeHostBuilder,
     },
@@ -258,13 +259,7 @@ where
         _: &graph::data_source::TriggerData<Chain>,
         _: Box<dyn Iterator<Item = &'a T::Host> + Send + 'a>,
         _: &Arc<SubgraphInstanceMetrics>,
-    ) -> Result<
-        Vec<(
-            &'a T::Host,
-            graph::data_source::TriggerWithHandler<MappingTrigger<Chain>>,
-        )>,
-        MappingError,
-    > {
+    ) -> Result<Vec<HostedTrigger<'a, Chain>>, MappingError> {
         Ok(vec![])
     }
 }

--- a/core/src/subgraph/context/instance/mod.rs
+++ b/core/src/subgraph/context/instance/mod.rs
@@ -13,7 +13,7 @@ use graph::{
 use hosts::{OffchainHosts, OnchainHosts};
 use std::collections::HashMap;
 
-pub(super) struct SubgraphInstance<C: Blockchain, T: RuntimeHostBuilder<C>> {
+pub(crate) struct SubgraphInstance<C: Blockchain, T: RuntimeHostBuilder<C>> {
     subgraph_id: DeploymentHash,
     network: String,
     host_builder: T,

--- a/core/src/subgraph/context/mod.rs
+++ b/core/src/subgraph/context/mod.rs
@@ -76,7 +76,7 @@ where
     pub offchain_monitor: OffchainMonitor,
     pub filter: Option<C::TriggerFilter>,
     pub(crate) trigger_processor: Box<dyn TriggerProcessor<C, T>>,
-    pub(crate) decoder: Box<Decoder>,
+    pub(crate) decoder: Box<Decoder<C, T>>,
 }
 
 impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
@@ -88,7 +88,7 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
         instances: SubgraphKeepAlive,
         offchain_monitor: OffchainMonitor,
         trigger_processor: Box<dyn TriggerProcessor<C, T>>,
-        decoder: Box<Decoder>,
+        decoder: Box<Decoder<C, T>>,
     ) -> Self {
         let instance = SubgraphInstance::new(
             manifest,

--- a/core/src/subgraph/context/mod.rs
+++ b/core/src/subgraph/context/mod.rs
@@ -10,7 +10,6 @@ use graph::{
     components::{
         store::{DeploymentId, SubgraphFork},
         subgraph::{HostMetrics, MappingError, RuntimeHost as _, SharedProofOfIndexing},
-        trigger_processor::Decoder,
     },
     data::subgraph::SubgraphManifest,
     data_source::{
@@ -31,6 +30,8 @@ use std::sync::{Arc, RwLock};
 use std::{collections::HashMap, time::Instant};
 
 use self::instance::SubgraphInstance;
+
+use super::Decoder;
 
 #[derive(Clone, Debug)]
 pub struct SubgraphKeepAlive {
@@ -75,7 +76,7 @@ where
     pub offchain_monitor: OffchainMonitor,
     pub filter: Option<C::TriggerFilter>,
     pub(crate) trigger_processor: Box<dyn TriggerProcessor<C, T>>,
-    pub(crate) decoder: Box<dyn Decoder<C, T>>,
+    pub(crate) decoder: Box<Decoder>,
 }
 
 impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
@@ -87,7 +88,7 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
         instances: SubgraphKeepAlive,
         offchain_monitor: OffchainMonitor,
         trigger_processor: Box<dyn TriggerProcessor<C, T>>,
-        decoder: Box<dyn Decoder<C, T>>,
+        decoder: Box<Decoder>,
     ) -> Self {
         let instance = SubgraphInstance::new(
             manifest,

--- a/core/src/subgraph/context/mod.rs
+++ b/core/src/subgraph/context/mod.rs
@@ -202,12 +202,19 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
         subgraph_metrics: &Arc<SubgraphInstanceMetrics>,
         instrument: bool,
     ) -> Result<BlockState, MappingError> {
+        let triggers: Vec<_> = self.trigger_processor.match_and_decode(
+            logger,
+            block,
+            trigger,
+            hosts,
+            subgraph_metrics,
+        )?;
+
         self.trigger_processor
             .process_trigger(
                 logger,
-                hosts,
+                triggers,
                 block,
-                trigger,
                 state,
                 proof_of_indexing,
                 causality_region,

--- a/core/src/subgraph/context/mod.rs
+++ b/core/src/subgraph/context/mod.rs
@@ -10,6 +10,7 @@ use graph::{
     components::{
         store::{DeploymentId, SubgraphFork},
         subgraph::{HostMetrics, MappingError, RuntimeHost as _, SharedProofOfIndexing},
+        trigger_processor::Decoder,
     },
     data::subgraph::SubgraphManifest,
     data_source::{
@@ -74,6 +75,7 @@ where
     pub offchain_monitor: OffchainMonitor,
     pub filter: Option<C::TriggerFilter>,
     pub(crate) trigger_processor: Box<dyn TriggerProcessor<C, T>>,
+    pub(crate) decoder: Box<dyn Decoder<C, T>>,
 }
 
 impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
@@ -85,6 +87,7 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
         instances: SubgraphKeepAlive,
         offchain_monitor: OffchainMonitor,
         trigger_processor: Box<dyn TriggerProcessor<C, T>>,
+        decoder: Box<dyn Decoder<C, T>>,
     ) -> Self {
         let instance = SubgraphInstance::new(
             manifest,
@@ -99,6 +102,7 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
             offchain_monitor,
             filter: None,
             trigger_processor,
+            decoder,
         }
     }
 

--- a/core/src/subgraph/context/mod.rs
+++ b/core/src/subgraph/context/mod.rs
@@ -15,7 +15,7 @@ use graph::{
     data_source::{
         causality_region::CausalityRegionSeq,
         offchain::{self, Base64},
-        CausalityRegion, DataSource, DataSourceTemplate, TriggerData,
+        CausalityRegion, DataSource, DataSourceTemplate,
     },
     ipfs_client::CidFile,
     prelude::{
@@ -73,7 +73,7 @@ where
     pub instances: SubgraphKeepAlive,
     pub offchain_monitor: OffchainMonitor,
     pub filter: Option<C::TriggerFilter>,
-    trigger_processor: Box<dyn TriggerProcessor<C, T>>,
+    pub(crate) trigger_processor: Box<dyn TriggerProcessor<C, T>>,
 }
 
 impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
@@ -161,41 +161,6 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
         }
 
         Ok(state)
-    }
-    pub async fn process_trigger_in_hosts<'a>(
-        &'a self,
-        logger: &Logger,
-        hosts: Box<dyn Iterator<Item = &'a T::Host> + Send + 'a>,
-        block: &Arc<C::Block>,
-        trigger: &TriggerData<C>,
-        state: BlockState,
-        proof_of_indexing: &SharedProofOfIndexing,
-        causality_region: &str,
-        debug_fork: &Option<Arc<dyn SubgraphFork>>,
-        subgraph_metrics: &Arc<SubgraphInstanceMetrics>,
-        instrument: bool,
-    ) -> Result<BlockState, MappingError> {
-        let triggers: Vec<_> = self.trigger_processor.match_and_decode(
-            logger,
-            block,
-            trigger,
-            hosts,
-            subgraph_metrics,
-        )?;
-
-        self.trigger_processor
-            .process_trigger(
-                logger,
-                triggers,
-                block,
-                state,
-                proof_of_indexing,
-                causality_region,
-                debug_fork,
-                subgraph_metrics,
-                instrument,
-            )
-            .await
     }
 
     /// Removes data sources hosts with a creation block greater or equal to `reverted_block`, so

--- a/core/src/subgraph/context/mod.rs
+++ b/core/src/subgraph/context/mod.rs
@@ -189,10 +189,10 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
 
         Ok(state)
     }
-    pub async fn process_trigger_in_hosts(
-        &self,
+    pub async fn process_trigger_in_hosts<'a>(
+        &'a self,
         logger: &Logger,
-        hosts: Box<dyn Iterator<Item = &T::Host> + Send + '_>,
+        hosts: Box<dyn Iterator<Item = &'a T::Host> + Send + 'a>,
         block: &Arc<C::Block>,
         trigger: &TriggerData<C>,
         state: BlockState,

--- a/core/src/subgraph/context/mod.rs
+++ b/core/src/subgraph/context/mod.rs
@@ -69,7 +69,7 @@ where
     T: RuntimeHostBuilder<C>,
     C: Blockchain,
 {
-    instance: SubgraphInstance<C, T>,
+    pub(crate) instance: SubgraphInstance<C, T>,
     pub instances: SubgraphKeepAlive,
     pub offchain_monitor: OffchainMonitor,
     pub filter: Option<C::TriggerFilter>,
@@ -100,33 +100,6 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
             filter: None,
             trigger_processor,
         }
-    }
-
-    pub async fn process_trigger(
-        &self,
-        logger: &Logger,
-        block: &Arc<C::Block>,
-        trigger: &TriggerData<C>,
-        state: BlockState,
-        proof_of_indexing: &SharedProofOfIndexing,
-        causality_region: &str,
-        debug_fork: &Option<Arc<dyn SubgraphFork>>,
-        subgraph_metrics: &Arc<SubgraphInstanceMetrics>,
-        instrument: bool,
-    ) -> Result<BlockState, MappingError> {
-        self.process_trigger_in_hosts(
-            logger,
-            self.instance.hosts_for_trigger(trigger),
-            block,
-            trigger,
-            state,
-            proof_of_indexing,
-            causality_region,
-            debug_fork,
-            subgraph_metrics,
-            instrument,
-        )
-        .await
     }
 
     pub async fn process_block(

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -2,6 +2,7 @@ use crate::polling_monitor::{ArweaveService, IpfsService};
 use crate::subgraph::context::{IndexingContext, SubgraphKeepAlive};
 use crate::subgraph::inputs::IndexingInputs;
 use crate::subgraph::loader::load_dynamic_data_sources;
+use crate::subgraph::Decoder;
 use std::collections::BTreeSet;
 
 use crate::subgraph::runner::SubgraphRunner;
@@ -408,6 +409,8 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
 
         let instrument = self.subgraph_store.instrument(&deployment)?;
 
+        let decoder = Box::new(Decoder::new(chain.as_ref()));
+
         let inputs = IndexingInputs {
             deployment: deployment.clone(),
             features,
@@ -425,8 +428,6 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
             network,
             instrument,
         };
-
-        let decoder = Box::new(crate::subgraph::Decoder {});
 
         // Initialize the indexing context, including both static and dynamic data sources.
         // The order of inclusion is the order of processing when a same trigger matches

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -390,8 +390,9 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
         let deployment_head = store.block_ptr().map(|ptr| ptr.number).unwrap_or(0) as f64;
         block_stream_metrics.deployment_head.set(deployment_head);
 
+        let (runtime_adapter, decoder_hook) = chain.runtime();
         let host_builder = graph_runtime_wasm::RuntimeHostBuilder::new(
-            chain.runtime_adapter(),
+            runtime_adapter,
             self.link_resolver.cheap_clone(),
             subgraph_store.ens_lookup(),
         );
@@ -409,7 +410,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
 
         let instrument = self.subgraph_store.instrument(&deployment)?;
 
-        let decoder = Box::new(Decoder::new(chain.as_ref()));
+        let decoder = Box::new(Decoder::new(decoder_hook));
 
         let inputs = IndexingInputs {
             deployment: deployment.clone(),

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -426,6 +426,8 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
             instrument,
         };
 
+        let decoder = Box::new(crate::subgraph::Decoder {});
+
         // Initialize the indexing context, including both static and dynamic data sources.
         // The order of inclusion is the order of processing when a same trigger matches
         // multiple data sources.
@@ -438,6 +440,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
                 self.instances.cheap_clone(),
                 offchain_monitor,
                 tp,
+                decoder,
             );
             for data_source in data_sources {
                 ctx.add_dynamic_data_source(&logger, data_source)?;

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -312,13 +312,17 @@ where
 
         // Match and decode all triggers in the block
         let hosts_filter = |trigger: &TriggerData<C>| self.ctx.instance.hosts_for_trigger(trigger);
-        let match_res = self.ctx.decoder.match_and_decode_many::<C, T, _>(
-            &logger,
-            &block,
-            triggers.into_iter().map(TriggerData::Onchain),
-            hosts_filter,
-            &self.metrics.subgraph,
-        );
+        let match_res = self
+            .ctx
+            .decoder
+            .match_and_decode_many(
+                &logger,
+                &block,
+                triggers.into_iter().map(TriggerData::Onchain),
+                hosts_filter,
+                &self.metrics.subgraph,
+            )
+            .await;
 
         // Process events one after the other, passing in entity operations
         // collected previously to every new event being processed
@@ -467,14 +471,17 @@ where
 
                 // Process the triggers in each host in the same order the
                 // corresponding data sources have been created.
-                let match_res: Result<Vec<_>, _> =
-                    self.ctx.decoder.match_and_decode_many::<C, T, _>(
+                let match_res: Result<Vec<_>, _> = self
+                    .ctx
+                    .decoder
+                    .match_and_decode_many(
                         &logger,
                         &block,
                         triggers.into_iter().map(TriggerData::Onchain),
                         |_| Box::new(runtime_hosts.iter().map(Arc::as_ref)),
                         &self.metrics.subgraph,
-                    );
+                    )
+                    .await;
 
                 let mut res = Ok(block_state);
                 match match_res {
@@ -1055,7 +1062,7 @@ where
             let trigger = TriggerData::Offchain(trigger);
             let process_res = {
                 let hosts = self.ctx.instance.hosts_for_trigger(&trigger);
-                let triggers_res = self.ctx.decoder.match_and_decode::<C, T>(
+                let triggers_res = self.ctx.decoder.match_and_decode(
                     &self.logger,
                     block,
                     trigger,

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -311,20 +311,14 @@ where
             .start_section(PROCESS_TRIGGERS_SECTION_NAME);
 
         // Match and decode all triggers in the block
-        let match_res: Result<Vec<_>, _> = triggers
-            .into_iter()
-            .map(TriggerData::Onchain)
-            .map(|trigger| {
-                let hosts = self.ctx.instance.hosts_for_trigger(&trigger);
-                self.ctx.decoder.match_and_decode(
-                    &self.logger,
-                    &block,
-                    trigger,
-                    hosts,
-                    &self.metrics.subgraph,
-                )
-            })
-            .collect::<Result<Vec<_>, _>>();
+        let hosts_filter = |trigger: &TriggerData<C>| self.ctx.instance.hosts_for_trigger(trigger);
+        let match_res = self.ctx.decoder.match_and_decode_many::<C, T, _>(
+            &logger,
+            &block,
+            triggers.into_iter().map(TriggerData::Onchain),
+            hosts_filter,
+            &self.metrics.subgraph,
+        );
 
         // Process events one after the other, passing in entity operations
         // collected previously to every new event being processed
@@ -473,19 +467,14 @@ where
 
                 // Process the triggers in each host in the same order the
                 // corresponding data sources have been created.
-                let match_res: Result<Vec<_>, _> = triggers
-                    .into_iter()
-                    .map(TriggerData::Onchain)
-                    .map(|trigger| {
-                        self.ctx.decoder.match_and_decode(
-                            &self.logger,
-                            &block,
-                            trigger,
-                            Box::new(runtime_hosts.iter().map(Arc::as_ref)),
-                            &self.metrics.subgraph,
-                        )
-                    })
-                    .collect::<Result<Vec<_>, _>>();
+                let match_res: Result<Vec<_>, _> =
+                    self.ctx.decoder.match_and_decode_many::<C, T, _>(
+                        &logger,
+                        &block,
+                        triggers.into_iter().map(TriggerData::Onchain),
+                        |_| Box::new(runtime_hosts.iter().map(Arc::as_ref)),
+                        &self.metrics.subgraph,
+                    );
 
                 let mut res = Ok(block_state);
                 match match_res {
@@ -1066,7 +1055,7 @@ where
             let trigger = TriggerData::Offchain(trigger);
             let process_res = {
                 let hosts = self.ctx.instance.hosts_for_trigger(&trigger);
-                let triggers_res = self.ctx.decoder.match_and_decode(
+                let triggers_res = self.ctx.decoder.match_and_decode::<C, T>(
                     &self.logger,
                     block,
                     trigger,

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -316,7 +316,7 @@ where
             .map(TriggerData::Onchain)
             .map(|trigger| {
                 self.ctx
-                    .trigger_processor
+                    .decoder
                     .match_and_decode(
                         &self.logger,
                         &block,
@@ -479,7 +479,7 @@ where
                 for trigger in triggers {
                     let trigger = TriggerData::Onchain(trigger);
                     let process_res = {
-                        let triggers_res = self.ctx.trigger_processor.match_and_decode(
+                        let triggers_res = self.ctx.decoder.match_and_decode(
                             &logger,
                             &block,
                             &trigger,
@@ -1051,7 +1051,7 @@ where
 
             let trigger = TriggerData::Offchain(trigger);
             let process_res = {
-                let triggers_res = self.ctx.trigger_processor.match_and_decode(
+                let triggers_res = self.ctx.decoder.match_and_decode(
                     &self.logger,
                     block,
                     &trigger,

--- a/core/src/subgraph/trigger_processor.rs
+++ b/core/src/subgraph/trigger_processor.rs
@@ -3,7 +3,7 @@ use graph::blockchain::{Block, Blockchain};
 use graph::cheap_clone::CheapClone;
 use graph::components::store::SubgraphFork;
 use graph::components::subgraph::{MappingError, SharedProofOfIndexing};
-use graph::components::trigger_processor::HostedTrigger;
+use graph::components::trigger_processor::{Decoder as DecoderTrait, HostedTrigger};
 use graph::data_source::TriggerData;
 use graph::prelude::tokio::time::Instant;
 use graph::prelude::{
@@ -86,7 +86,15 @@ where
 
         Ok(state)
     }
+}
 
+pub struct Decoder {}
+
+impl<C, T> DecoderTrait<C, T> for Decoder
+where
+    C: Blockchain,
+    T: RuntimeHostBuilder<C>,
+{
     fn match_and_decode<'a>(
         &'a self,
         logger: &Logger,

--- a/core/src/subgraph/trigger_processor.rs
+++ b/core/src/subgraph/trigger_processor.rs
@@ -182,6 +182,8 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> Decoder<C, T> {
                 Err(e) => return Err(e),
             }
         }
-        self.hook.after_decode(runnables).await
+        self.hook
+            .after_decode(logger, &block.ptr(), runnables)
+            .await
     }
 }

--- a/core/src/subgraph/trigger_processor.rs
+++ b/core/src/subgraph/trigger_processor.rs
@@ -169,7 +169,7 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> Decoder<C, T> {
         block: &Arc<C::Block>,
         triggers: impl Iterator<Item = TriggerData<C>>,
         hosts_filter: F,
-        subgraph_metrics: &Arc<SubgraphInstanceMetrics>,
+        metrics: &Arc<SubgraphInstanceMetrics>,
     ) -> Result<Vec<RunnableTriggers<'a, C>>, MappingError>
     where
         F: Fn(&TriggerData<C>) -> Box<dyn Iterator<Item = &'a T::Host> + Send + 'a>,
@@ -177,13 +177,13 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> Decoder<C, T> {
         let mut runnables = vec![];
         for trigger in triggers {
             let hosts = hosts_filter(&trigger);
-            match self.match_and_decode(logger, block, trigger, hosts, subgraph_metrics) {
+            match self.match_and_decode(logger, block, trigger, hosts, metrics) {
                 Ok(runnable_triggers) => runnables.push(runnable_triggers),
                 Err(e) => return Err(e),
             }
         }
         self.hook
-            .after_decode(logger, &block.ptr(), runnables)
+            .after_decode(logger, &block.ptr(), runnables, metrics)
             .await
     }
 }

--- a/core/src/subgraph/trigger_processor.rs
+++ b/core/src/subgraph/trigger_processor.rs
@@ -107,9 +107,9 @@ where
     C: Blockchain,
     T: RuntimeHostBuilder<C>,
 {
-    pub fn new(chain: &C) -> Self {
+    pub fn new(hook: C::DecoderHook) -> Self {
         Decoder {
-            hook: chain.decoder_hook(),
+            hook,
             _builder: PhantomData,
         }
     }

--- a/docs/subgraph-manifest.md
+++ b/docs/subgraph-manifest.md
@@ -74,6 +74,7 @@ The `mapping` field may be one of the following supported mapping manifests:
 | **event** | *String* | An identifier for an event that will be handled in the mapping script. For Ethereum contracts, this must be the full event signature to distinguish from events that may share the same name. No alias types can be used. For example, uint will not work, uint256 must be used.|
 | **handler** | *String* | The name of an exported function in the mapping script that should handle the specified event. |
 | **topic0** | optional *String* | A `0x` prefixed hex string. If provided, events whose topic0 is equal to this value will be processed by the given handler. When topic0 is provided, _only_ the topic0 value will be matched, and not the hash of the event signature. This is useful for processing anonymous events in Solidity, which can have their topic0 set to anything.  By default, topic0 is equal to the hash of the event signature. |
+| **calls** | optional [*CallDecl*](#153-declaring-calls) | A list of predeclared `eth_calls` that will be made before running the handler |
 
 #### 1.5.2.3 CallHandler
 
@@ -94,6 +95,30 @@ The `mapping` field may be one of the following supported mapping manifests:
 | Field | Type | Description |
 | --- | --- | --- |
 | **kind** | *String* | The selected block handler filter. Only option for now: `call`: This will only run the handler if the block contains at least one call to the data source contract. |
+
+### 1.5.3 Declaring calls
+
+_Available from spec version 1.2.0_
+
+Declared calls are performed in parallel before the handler is run and can
+greatly speed up syncing. Mappings access the call results simply by using
+`ethereum.call` from the mappings. The **calls** are a map of key value pairs:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| **label** | *String* | A label for the call for error messages etc. |
+| **call** | *String* | See below |
+
+Each call is of the form `<ABI>[<address>].<function>(<args>)`:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| **ABI** | *String* | The name of an ABI from the `abis` section |
+| **address** | *Expr* | The address of a contract that follows the `ABI` |
+| **function** | *String* | The name of a view function in the contract |
+| **args** | *[Expr]* | The arguments to pass to the function |
+
+The `Expr` can be either `event.address` or `event.params.<name>`.
 
 ## 1.6 Path
 A path has one field `path`, which either refers to a path of a file on the local dev machine or an [IPLD link](https://github.com/ipld/specs/).

--- a/graph/src/blockchain/mock.rs
+++ b/graph/src/blockchain/mock.rs
@@ -140,7 +140,7 @@ impl<C: Blockchain> DataSource<C> for MockDataSource {
         todo!()
     }
 
-    fn validate(&self) -> Vec<anyhow::Error> {
+    fn validate(&self, _: &semver::Version) -> Vec<anyhow::Error> {
         todo!()
     }
 }

--- a/graph/src/blockchain/mock.rs
+++ b/graph/src/blockchain/mock.rs
@@ -16,7 +16,7 @@ use super::{
     block_stream::{self, BlockStream, FirehoseCursor},
     client::ChainClient,
     BlockIngestor, BlockTime, EmptyNodeCapabilities, HostFn, IngestorError, MappingTriggerTrait,
-    TriggerWithHandler,
+    NoopDecoderHook, TriggerWithHandler,
 };
 
 use super::{
@@ -325,6 +325,8 @@ impl Blockchain for MockBlockchain {
 
     type NodeCapabilities = EmptyNodeCapabilities<Self>;
 
+    type DecoderHook = NoopDecoderHook;
+
     fn triggers_adapter(
         &self,
         _loc: &crate::components::store::DeploymentLocator,
@@ -378,6 +380,10 @@ impl Blockchain for MockBlockchain {
     }
 
     fn block_ingestor(&self) -> anyhow::Result<Box<dyn BlockIngestor>> {
+        todo!()
+    }
+
+    fn decoder_hook(&self) -> Self::DecoderHook {
         todo!()
     }
 }

--- a/graph/src/blockchain/mock.rs
+++ b/graph/src/blockchain/mock.rs
@@ -371,7 +371,7 @@ impl Blockchain for MockBlockchain {
         todo!()
     }
 
-    fn runtime_adapter(&self) -> std::sync::Arc<dyn RuntimeAdapter<Self>> {
+    fn runtime(&self) -> (std::sync::Arc<dyn RuntimeAdapter<Self>>, Self::DecoderHook) {
         todo!()
     }
 
@@ -380,10 +380,6 @@ impl Blockchain for MockBlockchain {
     }
 
     fn block_ingestor(&self) -> anyhow::Result<Box<dyn BlockIngestor>> {
-        todo!()
-    }
-
-    fn decoder_hook(&self) -> Self::DecoderHook {
         todo!()
     }
 }

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -206,13 +206,11 @@ pub trait Blockchain: Debug + Sized + Send + Sync + Unpin + 'static {
 
     fn is_refetch_block_required(&self) -> bool;
 
-    fn runtime_adapter(&self) -> Arc<dyn RuntimeAdapter<Self>>;
+    fn runtime(&self) -> (Arc<dyn RuntimeAdapter<Self>>, Self::DecoderHook);
 
     fn chain_client(&self) -> Arc<ChainClient<Self>>;
 
     fn block_ingestor(&self) -> anyhow::Result<Box<dyn BlockIngestor>>;
-
-    fn decoder_hook(&self) -> Self::DecoderHook;
 }
 
 #[derive(Error, Debug)]

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -381,6 +381,8 @@ pub trait MappingTriggerTrait {
 pub trait DecoderHook<C: Blockchain> {
     async fn after_decode<'a>(
         &self,
+        logger: &Logger,
+        block_ptr: &BlockPtr,
         triggers: Vec<RunnableTriggers<'a, C>>,
     ) -> Result<Vec<RunnableTriggers<'a, C>>, MappingError>;
 }
@@ -393,6 +395,8 @@ pub struct NoopDecoderHook;
 impl<C: Blockchain> DecoderHook<C> for NoopDecoderHook {
     async fn after_decode<'a>(
         &self,
+        _: &Logger,
+        _: &BlockPtr,
         triggers: Vec<RunnableTriggers<'a, C>>,
     ) -> Result<Vec<RunnableTriggers<'a, C>>, MappingError> {
         Ok(triggers)

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -300,7 +300,7 @@ pub trait DataSource<C: Blockchain>: 'static + Sized + Send + Sync + Clone {
     fn as_stored_dynamic_data_source(&self) -> StoredDynamicDataSource;
 
     /// Used as part of manifest validation. If there are no errors, return an empty vector.
-    fn validate(&self) -> Vec<Error>;
+    fn validate(&self, spec_version: &semver::Version) -> Vec<Error>;
 
     fn has_expired(&self, block: BlockNumber) -> bool {
         self.end_block()

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -18,6 +18,7 @@ mod types;
 use crate::{
     cheap_clone::CheapClone,
     components::{
+        metrics::subgraph::SubgraphInstanceMetrics,
         store::{DeploymentCursorTracker, DeploymentLocator, StoredDynamicDataSource},
         subgraph::{HostMetrics, InstanceDSTemplateInfo, MappingError},
         trigger_processor::RunnableTriggers,
@@ -384,6 +385,7 @@ pub trait DecoderHook<C: Blockchain> {
         logger: &Logger,
         block_ptr: &BlockPtr,
         triggers: Vec<RunnableTriggers<'a, C>>,
+        metrics: &Arc<SubgraphInstanceMetrics>,
     ) -> Result<Vec<RunnableTriggers<'a, C>>, MappingError>;
 }
 
@@ -398,6 +400,7 @@ impl<C: Blockchain> DecoderHook<C> for NoopDecoderHook {
         _: &Logger,
         _: &BlockPtr,
         triggers: Vec<RunnableTriggers<'a, C>>,
+        _: &Arc<SubgraphInstanceMetrics>,
     ) -> Result<Vec<RunnableTriggers<'a, C>>, MappingError> {
         Ok(triggers)
     }

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -537,7 +537,7 @@ pub trait EthereumCallCache: Send + Sync + 'static {
         &self,
         call: &call::Request,
         block: BlockPtr,
-    ) -> Result<Option<(call::Retval, call::Source)>, Error>;
+    ) -> Result<Option<call::Response>, Error>;
 
     /// Returns all cached calls for a given `block`. This method does *not*
     /// update the last access time of the returned cached calls.

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -564,6 +564,16 @@ impl CallSource {
     }
 }
 
+impl std::fmt::Display for CallSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            CallSource::Memory => write!(f, "memory"),
+            CallSource::Store => write!(f, "store"),
+            CallSource::Rpc => write!(f, "rpc"),
+        }
+    }
+}
+
 pub trait EthereumCallCache: Send + Sync + 'static {
     /// Returns the return value of the provided Ethereum call, if present
     /// in the cache. A return of `None` indicates that we know nothing

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -539,6 +539,15 @@ pub trait EthereumCallCache: Send + Sync + 'static {
         block: BlockPtr,
     ) -> Result<Option<call::Response>, Error>;
 
+    /// Get the return values of many Ethereum calls. For the ones found in
+    /// the cache, return a `Response`; the ones that were not found are
+    /// returned as the original `Request`
+    fn get_calls(
+        &self,
+        reqs: &[call::Request],
+        block: BlockPtr,
+    ) -> Result<(Vec<call::Response>, Vec<call::Request>), Error>;
+
     /// Returns all cached calls for a given `block`. This method does *not*
     /// update the last access time of the returned cached calls.
     fn get_calls_in_block(&self, block: BlockPtr) -> Result<Vec<CachedEthereumCall>, Error>;

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -531,11 +531,11 @@ pub trait ChainStore: Send + Sync + 'static {
 #[derive(Debug, Clone, PartialEq)]
 pub enum CallResult {
     Null,
-    Value(Vec<u8>),
+    Value(Bytes),
 }
 
 impl CallResult {
-    pub fn unwrap(self) -> Vec<u8> {
+    pub fn unwrap(self) -> Bytes {
         use CallResult::*;
         match self {
             Value(val) => val,

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -582,8 +582,9 @@ pub trait EthereumCallCache: Send + Sync + 'static {
     /// Stores the provided Ethereum call in the cache.
     fn set_call(
         &self,
+        logger: &Logger,
         contract_address: ethabi::Address,
-        encoded_call: &[u8],
+        encoded_call: Arc<Vec<u8>>,
         block: BlockPtr,
         return_value: CallResult,
     ) -> Result<(), Error>;

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -6,7 +6,7 @@ use web3::types::{Address, H256};
 
 use super::*;
 use crate::blockchain::block_stream::FirehoseCursor;
-use crate::blockchain::BlockTime;
+use crate::blockchain::{BlockTime, ChainIdentifier};
 use crate::components::metrics::stopwatch::StopwatchMetrics;
 use crate::components::server::index_node::VersionInfo;
 use crate::components::subgraph::SubgraphVersionSwitchingMode;
@@ -523,6 +523,9 @@ pub trait ChainStore: Send + Sync + 'static {
 
     /// Clears call cache of the chain for the given `from` and `to` block number.
     async fn clear_call_cache(&self, from: BlockNumber, to: BlockNumber) -> Result<(), Error>;
+
+    /// Return the chain identifier for this store.
+    fn chain_identifier(&self) -> &ChainIdentifier;
 }
 
 /// The result of an ethereum call. `Null` indicates that we made the call

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -48,6 +48,15 @@ impl MappingError {
             Unknown(e) => Unknown(e.context(s)),
         }
     }
+
+    pub fn add_trigger_context<C: Blockchain>(mut self, trigger: &TriggerData<C>) -> MappingError {
+        let error_context = trigger.error_context();
+        if !error_context.is_empty() {
+            self = self.context(error_context)
+        }
+        self = self.context("failed to process trigger".to_string());
+        self
+    }
 }
 
 /// Common trait for runtime host implementations.

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -105,6 +105,9 @@ pub trait RuntimeHost<C: Blockchain>: Send + Sync + 'static {
     /// Convenience function to avoid leaking internal representation of
     /// mutable number. Calling this on OnChain Datasources is a noop.
     fn set_done_at(&self, block: Option<BlockNumber>);
+
+    /// Return a metrics object for this host.
+    fn host_metrics(&self) -> Arc<HostMetrics>;
 }
 
 pub struct HostMetrics {

--- a/graph/src/components/trigger_processor.rs
+++ b/graph/src/components/trigger_processor.rs
@@ -24,6 +24,25 @@ where
     pub mapping_trigger: TriggerWithHandler<MappingTrigger<C>>,
 }
 
+pub trait ErrorContext {
+    fn error_context(&self) -> Option<String>;
+}
+
+impl<C: Blockchain> ErrorContext for TriggerData<C> {
+    fn error_context(&self) -> Option<String> {
+        Some(self.error_context())
+    }
+}
+
+impl<'a, C> ErrorContext for HostedTrigger<'a, C>
+where
+    C: Blockchain,
+{
+    fn error_context(&self) -> Option<String> {
+        self.mapping_trigger.trigger.error_context()
+    }
+}
+
 #[async_trait]
 pub trait TriggerProcessor<C, T>: Sync + Send
 where

--- a/graph/src/components/trigger_processor.rs
+++ b/graph/src/components/trigger_processor.rs
@@ -30,15 +30,6 @@ where
     C: Blockchain,
     T: RuntimeHostBuilder<C>,
 {
-    fn match_and_decode<'a>(
-        &'a self,
-        logger: &Logger,
-        block: &Arc<C::Block>,
-        trigger: &TriggerData<C>,
-        hosts: Box<dyn Iterator<Item = &'a T::Host> + Send + 'a>,
-        subgraph_metrics: &Arc<SubgraphInstanceMetrics>,
-    ) -> Result<Vec<HostedTrigger<'a, C>>, MappingError>;
-
     async fn process_trigger<'a>(
         &'a self,
         logger: &Logger,
@@ -51,4 +42,23 @@ where
         subgraph_metrics: &Arc<SubgraphInstanceMetrics>,
         instrument: bool,
     ) -> Result<BlockState, MappingError>;
+}
+
+/// A trait for taking triggers as `TriggerData` (usually from the block
+/// stream) and turning them into `HostedTrigger`s that are ready to run.
+///
+/// The output triggers will be run in the order in which they are returned.
+pub trait Decoder<C, T>: Sync + Send
+where
+    C: Blockchain,
+    T: RuntimeHostBuilder<C>,
+{
+    fn match_and_decode<'a>(
+        &'a self,
+        logger: &Logger,
+        block: &Arc<C::Block>,
+        trigger: &TriggerData<C>,
+        hosts: Box<dyn Iterator<Item = &'a T::Host> + Send + 'a>,
+        subgraph_metrics: &Arc<SubgraphInstanceMetrics>,
+    ) -> Result<Vec<HostedTrigger<'a, C>>, MappingError>;
 }

--- a/graph/src/components/trigger_processor.rs
+++ b/graph/src/components/trigger_processor.rs
@@ -42,9 +42,8 @@ where
     async fn process_trigger<'a>(
         &'a self,
         logger: &Logger,
-        hosts: Box<dyn Iterator<Item = &'a T::Host> + Send + 'a>,
+        triggers: Vec<HostedTrigger<'a, C>>,
         block: &Arc<C::Block>,
-        trigger: &TriggerData<C>,
         mut state: BlockState,
         proof_of_indexing: &SharedProofOfIndexing,
         causality_region: &str,

--- a/graph/src/components/trigger_processor.rs
+++ b/graph/src/components/trigger_processor.rs
@@ -24,6 +24,16 @@ where
     pub mapping_trigger: TriggerWithHandler<MappingTrigger<C>>,
 }
 
+/// The `TriggerData` and the `HostedTriggers` that were derived from it. We
+/// need to hang on to the `TriggerData` solely for error reporting.
+pub struct RunnableTriggers<'a, C>
+where
+    C: Blockchain,
+{
+    pub trigger: TriggerData<C>,
+    pub hosted_triggers: Vec<HostedTrigger<'a, C>>,
+}
+
 #[async_trait]
 pub trait TriggerProcessor<C, T>: Sync + Send
 where
@@ -57,8 +67,8 @@ where
         &'a self,
         logger: &Logger,
         block: &Arc<C::Block>,
-        trigger: &TriggerData<C>,
+        trigger: TriggerData<C>,
         hosts: Box<dyn Iterator<Item = &'a T::Host> + Send + 'a>,
         subgraph_metrics: &Arc<SubgraphInstanceMetrics>,
-    ) -> Result<Vec<HostedTrigger<'a, C>>, MappingError>;
+    ) -> Result<RunnableTriggers<'a, C>, MappingError>;
 }

--- a/graph/src/components/trigger_processor.rs
+++ b/graph/src/components/trigger_processor.rs
@@ -24,25 +24,6 @@ where
     pub mapping_trigger: TriggerWithHandler<MappingTrigger<C>>,
 }
 
-pub trait ErrorContext {
-    fn error_context(&self) -> Option<String>;
-}
-
-impl<C: Blockchain> ErrorContext for TriggerData<C> {
-    fn error_context(&self) -> Option<String> {
-        Some(self.error_context())
-    }
-}
-
-impl<'a, C> ErrorContext for HostedTrigger<'a, C>
-where
-    C: Blockchain,
-{
-    fn error_context(&self) -> Option<String> {
-        self.mapping_trigger.trigger.error_context()
-    }
-}
-
 #[async_trait]
 pub trait TriggerProcessor<C, T>: Sync + Send
 where

--- a/graph/src/data/store/ethereum.rs
+++ b/graph/src/data/store/ethereum.rs
@@ -112,5 +112,21 @@ pub mod call {
                 encoded_call: Arc::new(Bytes::from(encoded_call)),
             }
         }
+
+        /// Create a response struct for this request
+        pub fn response(self, retval: Retval, source: Source) -> Response {
+            Response {
+                req: self,
+                retval,
+                source,
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Response {
+        pub req: Request,
+        pub retval: Retval,
+        pub source: Source,
     }
 }

--- a/graph/src/data/store/ethereum.rs
+++ b/graph/src/data/store/ethereum.rs
@@ -37,3 +37,80 @@ impl From<U64> for Value {
         Value::BigInt(BigInt::from(n))
     }
 }
+
+/// Helper structs for dealing with ethereum calls
+pub mod call {
+    use std::sync::Arc;
+
+    use crate::data::store::scalar::Bytes;
+
+    use super::CheapClone;
+
+    /// The return value of an ethereum call. `Null` indicates that we made
+    /// the call but didn't get a value back (including when we get the
+    /// error 'call reverted')
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum Retval {
+        Null,
+        Value(Bytes),
+    }
+
+    impl Retval {
+        pub fn unwrap(self) -> Bytes {
+            use Retval::*;
+            match self {
+                Value(val) => val,
+                Null => panic!("called `call::Retval::unwrap()` on a `Null` value"),
+            }
+        }
+    }
+
+    /// Indication of where the result of an ethereum call comes from. We
+    /// unfortunately need that so we can avoid double-counting declared calls
+    /// as they are accessed as normal eth calls and we'd count them twice
+    /// without this.
+    #[derive(Debug, Clone, Copy, PartialEq)]
+    pub enum Source {
+        Memory,
+        Store,
+        Rpc,
+    }
+
+    impl Source {
+        /// Return `true` if calls from this source should be observed,
+        /// i.e., counted as actual calls
+        pub fn observe(&self) -> bool {
+            matches!(self, Source::Rpc | Source::Store)
+        }
+    }
+
+    impl std::fmt::Display for Source {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            match self {
+                Source::Memory => write!(f, "memory"),
+                Source::Store => write!(f, "store"),
+                Source::Rpc => write!(f, "rpc"),
+            }
+        }
+    }
+
+    /// The address and encoded name and parms for an `eth_call`, the raw
+    /// ingredients to make an `eth_call` request. Because we cache this, it
+    /// gets cloned a lot and needs to remain cheap to clone.
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    pub struct Request {
+        pub address: ethabi::Address,
+        pub encoded_call: Arc<Bytes>,
+    }
+
+    impl CheapClone for Request {}
+
+    impl Request {
+        pub fn new(address: ethabi::Address, encoded_call: Vec<u8>) -> Self {
+            Request {
+                address,
+                encoded_call: Arc::new(Bytes::from(encoded_call)),
+            }
+        }
+    }
+}

--- a/graph/src/data/store/scalar.rs
+++ b/graph/src/data/store/scalar.rs
@@ -589,7 +589,7 @@ impl GasSizeOf for BigInt {
 }
 
 /// A byte array that's serialized as a hex string prefixed by `0x`.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Bytes(Box<[u8]>);
 
 impl Deref for Bytes {
@@ -675,6 +675,12 @@ impl<const N: usize> From<[u8; N]> for Bytes {
 impl From<Vec<u8>> for Bytes {
     fn from(vec: Vec<u8>) -> Self {
         Bytes(vec.into())
+    }
+}
+
+impl AsRef<[u8]> for Bytes {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
     }
 }
 

--- a/graph/src/data/subgraph/api_version.rs
+++ b/graph/src/data/subgraph/api_version.rs
@@ -51,8 +51,11 @@ pub const SPEC_VERSION_1_0_0: Version = Version::new(1, 0, 0);
 // Enables `id: Int8`
 pub const SPEC_VERSION_1_1_0: Version = Version::new(1, 1, 0);
 
+// Enables eth call declarations
+pub const SPEC_VERSION_1_2_0: Version = Version::new(1, 2, 0);
+
 // The latest spec version available
-pub const LATEST_VERSION: &Version = &SPEC_VERSION_1_1_0;
+pub const LATEST_VERSION: &Version = &SPEC_VERSION_1_2_0;
 
 pub const MIN_SPEC_VERSION: Version = Version::new(0, 0, 2);
 

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -691,7 +691,7 @@ impl<C: Blockchain> UnvalidatedSubgraphManifest<C> {
         }
 
         for ds in &self.0.data_sources {
-            errors.extend(ds.validate().into_iter().map(|e| {
+            errors.extend(ds.validate(&self.0.spec_version).into_iter().map(|e| {
                 SubgraphManifestValidationError::DataSourceValidation(ds.name().to_owned(), e)
             }));
         }

--- a/graph/src/data_source/mod.rs
+++ b/graph/src/data_source/mod.rs
@@ -236,9 +236,9 @@ impl<C: Blockchain> DataSource<C> {
         }
     }
 
-    pub fn validate(&self) -> Vec<Error> {
+    pub fn validate(&self, spec_version: &semver::Version) -> Vec<Error> {
         match self {
-            Self::Onchain(ds) => ds.validate(),
+            Self::Onchain(ds) => ds.validate(spec_version),
             Self::Offchain(_) => vec![],
         }
     }

--- a/graph/src/data_source/mod.rs
+++ b/graph/src/data_source/mod.rs
@@ -492,6 +492,13 @@ impl<C: Blockchain> MappingTrigger<C> {
             Self::Offchain(_) => None, // TODO: Add error context for offchain triggers
         }
     }
+
+    pub fn as_onchain(&self) -> Option<&C::MappingTrigger> {
+        match self {
+            Self::Onchain(trigger) => Some(trigger),
+            Self::Offchain(_) => None,
+        }
+    }
 }
 
 macro_rules! clone_data_source {

--- a/graph/src/env/mappings.rs
+++ b/graph/src/env/mappings.rs
@@ -57,6 +57,11 @@ pub struct EnvVarsMapping {
     /// Set by the flag `GRAPH_ALLOW_NON_DETERMINISTIC_IPFS`. Off by
     /// default.
     pub allow_non_deterministic_ipfs: bool,
+
+    /// Set by the flag `GRAPH_DISABLE_DECLARED_CALLS`. Disables performing
+    /// eth calls before running triggers; instead eth calls happen when
+    /// mappings call `ethereum.call`. Off by default.
+    pub disable_declared_calls: bool,
 }
 
 // This does not print any values avoid accidentally leaking any sensitive env vars
@@ -83,6 +88,7 @@ impl From<InnerMappingHandlers> for EnvVarsMapping {
             max_ipfs_file_bytes: x.max_ipfs_file_bytes.0,
             ipfs_request_limit: x.ipfs_request_limit,
             allow_non_deterministic_ipfs: x.allow_non_deterministic_ipfs.0,
+            disable_declared_calls: x.disable_declared_calls.0,
         }
     }
 }
@@ -115,4 +121,6 @@ pub struct InnerMappingHandlers {
     ipfs_request_limit: u16,
     #[envconfig(from = "GRAPH_ALLOW_NON_DETERMINISTIC_IPFS", default = "false")]
     allow_non_deterministic_ipfs: EnvVarBoolean,
+    #[envconfig(from = "GRAPH_DISABLE_DECLARED_CALLS", default = "false")]
+    disable_declared_calls: EnvVarBoolean,
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -867,9 +867,15 @@ fn ethereum_networks_as_chains(
                 chain_store.clone(),
             );
 
+            // Use a call cache that buffers in memory. It is important that
+            // the `RuntimeAdapter` and the `Chain` use the same call cache
+            // as that is used to pass the results of declared calls into
+            // mappings.
+            let call_cache = Arc::new(ethereum::BufferedCallCache::new(chain_store.cheap_clone()));
+
             let runtime_adapter = Arc::new(RuntimeAdapter {
                 eth_adapters: Arc::new(eth_adapters.clone()),
-                call_cache: chain_store.cheap_clone(),
+                call_cache: call_cache.cheap_clone(),
                 chain_identifier: Arc::new(chain_store.chain_identifier.clone()),
             });
 
@@ -880,7 +886,7 @@ fn ethereum_networks_as_chains(
                 node_id.clone(),
                 registry.clone(),
                 chain_store.cheap_clone(),
-                chain_store,
+                call_cache,
                 client,
                 chain_head_update_listener.clone(),
                 Arc::new(EthereumStreamBuilder {}),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -893,6 +893,7 @@ fn ethereum_networks_as_chains(
                 Arc::new(EthereumBlockRefetcher {}),
                 Arc::new(adapter_selector),
                 runtime_adapter,
+                Arc::new(eth_adapters.clone()),
                 ENV_VARS.reorg_threshold,
                 chain_config.polling_interval,
                 is_ingestible,

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -125,7 +125,7 @@ pub async fn run(
     };
 
     let eth_adapters2 = eth_adapters.clone();
-
+    let eth_adapters3 = eth_adapters.clone();
     let (_, ethereum_idents) = connect_ethereum_networks(&logger, eth_networks).await?;
     // let (near_networks, near_idents) = connect_firehose_networks::<NearFirehoseHeaderOnlyBlock>(
     //     &logger,
@@ -172,6 +172,7 @@ pub async fn run(
             eth_adapters: Arc::new(eth_adapters2),
             chain_identifier: Arc::new(chain_store.chain_identifier.clone()),
         }),
+        Arc::new(eth_adapters3),
         graph::env::ENV_VARS.reorg_threshold,
         chain_config.polling_interval,
         // We assume the tested chain is always ingestible for now

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -147,6 +147,8 @@ pub async fn run(
 
     let client = Arc::new(ChainClient::new(firehose_endpoints, eth_adapters));
 
+    let call_cache = Arc::new(ethereum::BufferedCallCache::new(chain_store.cheap_clone()));
+
     let chain_config = config.chains.chains.get(&network_name).unwrap();
     let chain = ethereum::Chain::new(
         logger_factory.clone(),
@@ -154,7 +156,7 @@ pub async fn run(
         node_id.clone(),
         metrics_registry.clone(),
         chain_store.cheap_clone(),
-        chain_store.cheap_clone(),
+        call_cache.cheap_clone(),
         client.clone(),
         chain_head_update_listener,
         Arc::new(EthereumStreamBuilder {}),
@@ -166,7 +168,7 @@ pub async fn run(
             chain_store.cheap_clone(),
         )),
         Arc::new(EthereumRuntimeAdapter {
-            call_cache: chain_store.cheap_clone(),
+            call_cache,
             eth_adapters: Arc::new(eth_adapters2),
             chain_identifier: Arc::new(chain_store.chain_identifier.clone()),
         }),

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -10,8 +10,11 @@ use crate::config::Config;
 use crate::manager::PanicSubscriptionManager;
 use crate::store_builder::StoreBuilder;
 use crate::MetricsContext;
-use ethereum::chain::{EthereumAdapterSelector, EthereumBlockRefetcher, EthereumStreamBuilder};
-use ethereum::{ProviderEthRpcMetrics, RuntimeAdapter as EthereumRuntimeAdapter};
+use ethereum::chain::{
+    EthereumAdapterSelector, EthereumBlockRefetcher, EthereumRuntimeAdapterBuilder,
+    EthereumStreamBuilder,
+};
+use ethereum::ProviderEthRpcMetrics;
 use graph::anyhow::{bail, format_err};
 use graph::blockchain::client::ChainClient;
 use graph::blockchain::{BlockchainKind, BlockchainMap};
@@ -125,7 +128,6 @@ pub async fn run(
     };
 
     let eth_adapters2 = eth_adapters.clone();
-    let eth_adapters3 = eth_adapters.clone();
     let (_, ethereum_idents) = connect_ethereum_networks(&logger, eth_networks).await?;
     // let (near_networks, near_idents) = connect_firehose_networks::<NearFirehoseHeaderOnlyBlock>(
     //     &logger,
@@ -167,12 +169,8 @@ pub async fn run(
             metrics_registry.clone(),
             chain_store.cheap_clone(),
         )),
-        Arc::new(EthereumRuntimeAdapter {
-            call_cache,
-            eth_adapters: Arc::new(eth_adapters2),
-            chain_identifier: Arc::new(chain_store.chain_identifier.clone()),
-        }),
-        Arc::new(eth_adapters3),
+        Arc::new(EthereumRuntimeAdapterBuilder {}),
+        Arc::new(eth_adapters2),
         graph::env::ENV_VARS.reorg_threshold,
         chain_config.polling_interval,
         // We assume the tested chain is always ingestible for now

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -373,6 +373,10 @@ impl<C: Blockchain> RuntimeHostTrait<C> for RuntimeHost<C> {
             DataSource::Offchain(ds) => ds.set_done_at(block),
         }
     }
+
+    fn host_metrics(&self) -> Arc<HostMetrics> {
+        self.metrics.cheap_clone()
+    }
 }
 
 impl<C: Blockchain> PartialEq for RuntimeHost<C> {

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -2425,8 +2425,9 @@ impl EthereumCallCache for ChainStore {
 
     fn set_call(
         &self,
+        _: &Logger,
         contract_address: ethabi::Address,
-        encoded_call: &[u8],
+        encoded_call: Arc<Vec<u8>>,
         block: BlockPtr,
         return_value: CallResult,
     ) -> Result<(), Error> {
@@ -2437,7 +2438,7 @@ impl EthereumCallCache for ChainStore {
             // where calls first failed and later succeeded
             return Ok(());
         };
-        let id = contract_call_id(&contract_address, encoded_call, &block);
+        let id = contract_call_id(&contract_address, &encoded_call, &block);
         let conn = &mut *self.get_conn()?;
         conn.transaction(|conn| {
             self.storage.set_call(

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -2198,6 +2198,10 @@ impl ChainStoreTrait for ChainStore {
         })
         .await
     }
+
+    fn chain_identifier(&self) -> &ChainIdentifier {
+        &self.chain_identifier
+    }
 }
 
 mod recent_blocks_cache {

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -2476,6 +2476,10 @@ impl EthereumCallCache for ChainStore {
         reqs: &[call::Request],
         block: BlockPtr,
     ) -> Result<(Vec<call::Response>, Vec<call::Request>), Error> {
+        if reqs.is_empty() {
+            return Ok((Vec::new(), Vec::new()));
+        }
+
         let ids: Vec<_> = reqs
             .into_iter()
             .map(|req| contract_call_id(req, &block))

--- a/store/test-store/tests/chain/ethereum/manifest.rs
+++ b/store/test-store/tests/chain/ethereum/manifest.rs
@@ -10,8 +10,8 @@ use graph::data::store::scalar::Bytes;
 use graph::data::store::Value;
 use graph::data::subgraph::schema::SubgraphError;
 use graph::data::subgraph::{
-    Prune, SPEC_VERSION_0_0_4, SPEC_VERSION_0_0_7, SPEC_VERSION_0_0_8, SPEC_VERSION_0_0_9,
-    SPEC_VERSION_1_0_0,
+    Prune, LATEST_VERSION, SPEC_VERSION_0_0_4, SPEC_VERSION_0_0_7, SPEC_VERSION_0_0_8,
+    SPEC_VERSION_0_0_9, SPEC_VERSION_1_0_0,
 };
 use graph::data_source::offchain::OffchainDataSourceKind;
 use graph::data_source::DataSourceTemplate;
@@ -592,7 +592,7 @@ specVersion: 0.0.8
         .collect::<Vec<_>>();
 
     let data_source = onchain_data_sources.get(0).unwrap();
-    let validation_errors = data_source.validate();
+    let validation_errors = data_source.validate(&LATEST_VERSION);
     let filter = data_source.mapping.block_handlers[0].filter.clone();
 
     assert_eq!(0, validation_errors.len());
@@ -688,7 +688,7 @@ specVersion: 0.0.8
         .collect::<Vec<_>>();
 
     let data_source = onchain_data_sources.get(0).unwrap();
-    let validation_errors = data_source.validate();
+    let validation_errors = data_source.validate(LATEST_VERSION);
     let filters = data_source
         .mapping
         .block_handlers
@@ -753,7 +753,7 @@ specVersion: 0.0.8
         .collect::<Vec<_>>();
 
     let data_source = onchain_data_sources.get(0).unwrap();
-    let validation_errors = data_source.validate();
+    let validation_errors = data_source.validate(LATEST_VERSION);
     let filters = data_source
         .mapping
         .block_handlers

--- a/store/test-store/tests/postgres/chain_head.rs
+++ b/store/test-store/tests/postgres/chain_head.rs
@@ -396,6 +396,7 @@ fn eth_call_cache() {
             .get_call(address, &call, BLOCK_ONE.block_ptr())
             .unwrap()
             .unwrap()
+            .0
             .unwrap();
         assert_eq!(&return_value, ret.as_slice());
 
@@ -417,6 +418,7 @@ fn eth_call_cache() {
             .get_call(address, &call, BLOCK_TWO.block_ptr())
             .unwrap()
             .unwrap()
+            .0
             .unwrap();
         assert_eq!(&new_return_value, ret.as_slice());
 

--- a/store/test-store/tests/postgres/chain_head.rs
+++ b/store/test-store/tests/postgres/chain_head.rs
@@ -3,6 +3,7 @@
 
 use graph::blockchain::{BlockHash, BlockPtr};
 use graph::components::store::CallResult;
+use graph::data::store::scalar::Bytes;
 use graph::env::ENV_VARS;
 use graph::prelude::futures03::executor;
 use std::future::Future;
@@ -375,7 +376,7 @@ fn eth_call_cache() {
 
     run_test(chain, |store, _| {
         fn ccr(value: &[u8]) -> CallResult {
-            CallResult::Value(value.to_vec())
+            CallResult::Value(Bytes::from(value))
         }
 
         let address = H160([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);

--- a/store/test-store/tests/postgres/chain_head.rs
+++ b/store/test-store/tests/postgres/chain_head.rs
@@ -401,7 +401,7 @@ fn eth_call_cache() {
             .get_call(&call, BLOCK_ONE.block_ptr())
             .unwrap()
             .unwrap()
-            .0
+            .retval
             .unwrap();
         assert_eq!(&return_value, ret.as_slice());
 
@@ -421,7 +421,7 @@ fn eth_call_cache() {
             .get_call(&call, BLOCK_TWO.block_ptr())
             .unwrap()
             .unwrap()
-            .0
+            .retval
             .unwrap();
         assert_eq!(&new_return_value, ret.as_slice());
 

--- a/store/test-store/tests/postgres/chain_head.rs
+++ b/store/test-store/tests/postgres/chain_head.rs
@@ -384,7 +384,7 @@ fn eth_call_cache() {
         let call: [u8; 6] = [1, 2, 3, 4, 5, 6];
         let return_value: [u8; 3] = [7, 8, 9];
 
-        let call = call::Request::new(address, call.to_vec());
+        let call = call::Request::new(address, call.to_vec(), 0);
         store
             .set_call(
                 &logger,

--- a/store/test-store/tests/postgres/chain_head.rs
+++ b/store/test-store/tests/postgres/chain_head.rs
@@ -2,7 +2,7 @@
 //! the chain head pointer gets updated in various situations
 
 use graph::blockchain::{BlockHash, BlockPtr};
-use graph::components::store::{CallData, CallResult};
+use graph::data::store::ethereum::call;
 use graph::data::store::scalar::Bytes;
 use graph::env::ENV_VARS;
 use graph::prelude::futures03::executor;
@@ -376,15 +376,15 @@ fn eth_call_cache() {
 
     run_test(chain, |store, _| {
         let logger = LOGGER.cheap_clone();
-        fn ccr(value: &[u8]) -> CallResult {
-            CallResult::Value(Bytes::from(value))
+        fn ccr(value: &[u8]) -> call::Retval {
+            call::Retval::Value(Bytes::from(value))
         }
 
         let address = H160([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]);
         let call: [u8; 6] = [1, 2, 3, 4, 5, 6];
         let return_value: [u8; 3] = [7, 8, 9];
 
-        let call = CallData::new(address, call.to_vec());
+        let call = call::Request::new(address, call.to_vec());
         store
             .set_call(
                 &logger,
@@ -430,7 +430,7 @@ fn eth_call_cache() {
                 &logger,
                 call.cheap_clone(),
                 BLOCK_THREE.block_ptr(),
-                CallResult::Null,
+                call::Retval::Null,
             )
             .unwrap();
         let ret = store.get_call(&call, BLOCK_THREE.block_ptr()).unwrap();

--- a/tests/src/fixture/ethereum.rs
+++ b/tests/src/fixture/ethereum.rs
@@ -13,6 +13,7 @@ use graph::prelude::ethabi::ethereum_types::H256;
 use graph::prelude::web3::types::{Address, Log, Transaction, H160};
 use graph::prelude::{ethabi, tiny_keccak, LightEthereumBlock, ENV_VARS};
 use graph::{blockchain::block_stream::BlockWithTriggers, prelude::ethabi::ethereum_types::U64};
+use graph_chain_ethereum::network::EthereumNetworkAdapters;
 use graph_chain_ethereum::trigger::LogRef;
 use graph_chain_ethereum::Chain;
 use graph_chain_ethereum::{
@@ -44,6 +45,8 @@ pub async fn chain(
     let static_block_stream = Arc::new(StaticStreamBuilder { chain: blocks });
     let block_stream_builder = Arc::new(MutexBlockStreamBuilder(Mutex::new(static_block_stream)));
 
+    let eth_adapters = Arc::new(EthereumNetworkAdapters::default());
+
     let chain = Chain::new(
         logger_factory,
         stores.network_name.clone(),
@@ -57,6 +60,7 @@ pub async fn chain(
         Arc::new(StaticBlockRefetcher { x: PhantomData }),
         triggers_adapter,
         Arc::new(NoopRuntimeAdapter { x: PhantomData }),
+        eth_adapters,
         ENV_VARS.reorg_threshold,
         ENV_VARS.ingestor_polling_interval,
         // We assume the tested chain is always ingestible for now

--- a/tests/src/fixture/ethereum.rs
+++ b/tests/src/fixture/ethereum.rs
@@ -3,8 +3,8 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use super::{
-    test_ptr, CommonChainConfig, MutexBlockStreamBuilder, NoopAdapterSelector, NoopRuntimeAdapter,
-    StaticBlockRefetcher, StaticStreamBuilder, Stores, TestChain,
+    test_ptr, CommonChainConfig, MutexBlockStreamBuilder, NoopAdapterSelector,
+    NoopRuntimeAdapterBuilder, StaticBlockRefetcher, StaticStreamBuilder, Stores, TestChain,
 };
 use graph::blockchain::client::ChainClient;
 use graph::blockchain::{BlockPtr, TriggersAdapterSelector};
@@ -59,7 +59,7 @@ pub async fn chain(
         block_stream_builder.clone(),
         Arc::new(StaticBlockRefetcher { x: PhantomData }),
         triggers_adapter,
-        Arc::new(NoopRuntimeAdapter { x: PhantomData }),
+        Arc::new(NoopRuntimeAdapterBuilder {}),
         eth_adapters,
         ENV_VARS.reorg_threshold,
         ENV_VARS.ingestor_polling_interval,

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -20,7 +20,7 @@ use graph::blockchain::{
 use graph::cheap_clone::CheapClone;
 use graph::components::link_resolver::{ArweaveClient, ArweaveResolver, FileSizeLimit};
 use graph::components::metrics::MetricsRegistry;
-use graph::components::store::{BlockStore, DeploymentLocator};
+use graph::components::store::{BlockStore, DeploymentLocator, EthereumCallCache};
 use graph::components::subgraph::Settings;
 use graph::data::graphql::load_manager::LoadManager;
 use graph::data::query::{Query, QueryTarget};
@@ -38,6 +38,8 @@ use graph::prelude::{
     SubgraphStore as _, SubgraphVersionSwitchingMode, TriggerProcessor,
 };
 use graph::schema::InputSchema;
+use graph_chain_ethereum::chain::RuntimeAdapterBuilder;
+use graph_chain_ethereum::network::EthereumNetworkAdapters;
 use graph_chain_ethereum::Chain;
 use graph_core::polling_monitor::{arweave_service, ipfs_service};
 use graph_core::{
@@ -866,6 +868,19 @@ impl<C: Blockchain> RuntimeAdapter<C> for NoopRuntimeAdapter<C> {
         _ds: &<C as Blockchain>::DataSource,
     ) -> Result<Vec<graph::blockchain::HostFn>, Error> {
         Ok(vec![])
+    }
+}
+
+struct NoopRuntimeAdapterBuilder {}
+
+impl RuntimeAdapterBuilder for NoopRuntimeAdapterBuilder {
+    fn build(
+        &self,
+        _: Arc<EthereumNetworkAdapters>,
+        _: Arc<dyn EthereumCallCache + 'static>,
+        _: Arc<ChainIdentifier>,
+    ) -> Arc<dyn graph::blockchain::RuntimeAdapter<graph_chain_ethereum::Chain> + 'static> {
+        Arc::new(NoopRuntimeAdapter { x: PhantomData })
     }
 }
 

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -224,7 +224,9 @@ impl TestContext {
         RuntimeHostBuilder<graph_chain_substreams::Chain>,
     > {
         let (logger, deployment, raw) = self.get_runner_context().await;
-        let tp: Box<dyn TriggerProcessor<_, _>> = Box::new(SubgraphTriggerProcessor {});
+        let tp: Box<dyn TriggerProcessor<_, _>> = Box::new(
+            graph_chain_substreams::TriggerProcessor::new(deployment.clone()),
+        );
 
         self.instance_manager
             .build_subgraph_runner(


### PR DESCRIPTION
Addresses #5262 

This PR is concerned with two things:

* refactoring trigger decoding and processing so that we get the decoded triggers all at once _before_ any of them get processed
* making eth calls for a block once before running handlers and plumbing things in a way that eth calls from handlers retrieve the results from memory

The results of `eth_calls` are injected back into the mappings via a `BufferedCallCache` which keeps the call results for the current block in memory. That way, mapping code does not need to change, and users can reap the benefit of declarative calls simply by, well, declaring them in the manifest. There's a small overhead in this approach as it requires calling a host function; compared to making an actual RPC call or just a database lookup, that's negligible.

When we do eth calls in bulk, we do one query against the store for all the calls we need (rather than one per call) For the calls for which we do not have anything in the database, we make RPC calls in parallel. By declaring eth calls, the time for all calls goes from the sum of the time the calls take to the max. Depending on the number of calls a subgraph makes for a block, that can be a considerable speedup. For one subgraph which did 10-20 eth calls per block, the time to process a block went from ~ 1.2s to ~ 200ms, a sixfold speedup. The environment where this was tested took 70-80ms per call.

Done:
- [x] Actually parallelize the calls
- [x] Deduplicate calls
- [x] Cache failed calls in memory to avoid duplicate calls
- [x] Better error messages when an `eth_call` fails

Still todo:
- Charge gas for the calls (#5331)
- Handle overloaded functions (#5329)
- Allow declaring `eth_calls` for other handlers, not just event handlers. (#5330)


This PR is already pretty big; I will file the remaining open items as separate issues before merging this.