### PR TITLE
store: Increase sleep time in write queue processing

### DIFF
--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, RwLock, TryLockError as RwLockError};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use std::{collections::BTreeMap, sync::Arc};
 
 use graph::blockchain::block_stream::FirehoseCursor;
@@ -888,7 +888,7 @@ impl Queue {
                         // batch should be processed or after some time
                         // passed. The latter is just for safety in case
                         // there is a mistake with notifications.
-                        let sleep = graph::tokio::time::sleep(Duration::from_secs(2));
+                        let sleep = graph::tokio::time::sleep(ENV_VARS.store.write_batch_duration);
                         let notify = batch_stop_notify.notified();
                         select!(
                             () = sleep => (),


### PR DESCRIPTION
We use sleep as a fallback in case the notification to write does not work. Unfortunately, this leads to much smaller write batches than configured for busy subgraphs as the check whether a batch should be written seems to conflict with appending to a batch (we start a new batch in that case)

By raising the safety sleep from 2s to GRAPH_STORE_WRITE_BATCH_DURATION we make these collisions much less likely; there should not be any adverse consequences. If the notifications don't work, we'd still wait at most the configured time to write.

