### PR TITLE
Allow generating a map of section nesting in debug builds

### DIFF
--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -198,10 +198,13 @@ pub struct EnvVars {
     /// The amount of history to keep when using 'min' historyBlocks
     /// in the manifest
     pub min_history_blocks: BlockNumber,
-
     /// Set by the env var `dips_metrics_object_store_url`
     /// The name of the object store bucket to store DIPS metrics
     pub dips_metrics_object_store_url: Option<String>,
+    /// Write a list of how sections are nested to the file `section_map`
+    /// which must be an absolute path. This only has an effect in debug
+    /// builds. Set with `GRAPH_SECTION_MAP`. Defaults to `None`.
+    pub section_map: Option<String>,
 }
 
 impl EnvVars {
@@ -272,6 +275,7 @@ impl EnvVars {
                 .min_history_blocks
                 .unwrap_or(2 * inner.reorg_threshold),
             dips_metrics_object_store_url: inner.dips_metrics_object_store_url,
+            section_map: inner.section_map,
         })
     }
 
@@ -411,6 +415,8 @@ struct Inner {
     min_history_blocks: Option<BlockNumber>,
     #[envconfig(from = "GRAPH_DIPS_METRICS_OBJECT_STORE_URL")]
     dips_metrics_object_store_url: Option<String>,
+    #[envconfig(from = "GRAPH_SECTION_MAP")]
+    section_map: Option<String>,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
With this PR, debug builds (and only debug builds) pay attention to an environment variable `GRAPH_SECTION_MAP` which will make it print a list of the parent/child relations of stopwatch sections. That can then be turned into an image, e.g. with `dot` to visualize the nesting.

![sections](https://github.com/graphprotocol/graph-node/assets/23697/1796f2e0-a143-4d9f-a721-a6d325f3af2f)
