### PR TITLE
ipfs: Stop using the stat API

### DIFF
--- a/core/src/polling_monitor/ipfs_service.rs
+++ b/core/src/polling_monitor/ipfs_service.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Error};
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use graph::{
-    ipfs_client::{CidFile, IpfsClient, StatApi},
+    ipfs_client::{CidFile, IpfsClient},
     prelude::CheapClone,
 };
 use std::time::Duration;
@@ -15,7 +15,7 @@ pub type IpfsService = Buffer<CidFile, BoxFuture<'static, Result<Option<Bytes>, 
 
 pub fn ipfs_service(
     client: IpfsClient,
-    max_file_size: u64,
+    max_file_size: usize,
     timeout: Duration,
     rate_limit: u16,
 ) -> IpfsService {
@@ -38,7 +38,7 @@ pub fn ipfs_service(
 #[derive(Clone)]
 struct IpfsServiceInner {
     client: IpfsClient,
-    max_file_size: u64,
+    max_file_size: usize,
     timeout: Duration,
 }
 
@@ -65,33 +65,20 @@ impl IpfsServiceInner {
             None => cid.to_string(),
         };
 
-        let size = match self
+        let res = self
             .client
-            .stat_size(StatApi::Files, cid_str.clone(), self.timeout)
-            .await
-        {
-            Ok(size) => size,
+            .cat_all(&cid_str, Some(self.timeout), self.max_file_size)
+            .await;
+
+        match res {
+            Ok(file_bytes) => Ok(Some(file_bytes)),
             Err(e) => match e.status().map(|e| e.as_u16()) {
+                // Timeouts in IPFS mean the file is not available, so we return `None`
                 Some(GATEWAY_TIMEOUT) | Some(CLOUDFLARE_TIMEOUT) => return Ok(None),
                 _ if e.is_timeout() => return Ok(None),
                 _ => return Err(e.into()),
             },
-        };
-
-        if size > self.max_file_size {
-            return Err(anyhow!(
-                "IPFS file {} is too large. It can be at most {} bytes but is {} bytes",
-                cid_str,
-                self.max_file_size,
-                size
-            ));
         }
-
-        Ok(self
-            .client
-            .cat_all(&cid_str, self.timeout)
-            .await
-            .map(Some)?)
     }
 }
 

--- a/graph/src/components/link_resolver/ipfs.rs
+++ b/graph/src/components/link_resolver/ipfs.rs
@@ -57,6 +57,10 @@ async fn select_fastest_client(
     timeout: Duration,
     do_retry: bool,
 ) -> Result<IpfsClient, Error> {
+    if clients.len() == 1 {
+        return Ok(clients[0].cheap_clone());
+    }
+
     let mut err: Option<Error> = None;
 
     let mut exists: FuturesUnordered<_> = clients

--- a/graph/src/ipfs_client.rs
+++ b/graph/src/ipfs_client.rs
@@ -30,6 +30,7 @@ impl IpfsError {
         }
     }
 
+    /// Is this error from an HTTP status code?
     pub fn is_status(&self) -> bool {
         match self {
             Self::Request(e) => e.is_status(),
@@ -165,7 +166,7 @@ impl IpfsClient {
                 acc.extend_from_slice(&chunk);
 
                 // Check size limit
-                if acc.len() > max_file_size as usize {
+                if acc.len() > max_file_size {
                     return Err(IpfsError::FileTooLarge(cid.to_string(), max_file_size));
                 }
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -240,7 +240,7 @@ async fn main() {
     let ipfs_client = ipfs_clients.first().cloned().expect("Missing IPFS client");
     let ipfs_service = ipfs_service(
         ipfs_client,
-        ENV_VARS.mappings.max_ipfs_file_bytes as u64,
+        ENV_VARS.mappings.max_ipfs_file_bytes,
         ENV_VARS.mappings.ipfs_timeout,
         ENV_VARS.mappings.ipfs_request_limit,
     );

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -73,7 +73,7 @@ pub async fn run(
     let ipfs_client = ipfs_clients.first().cloned().expect("Missing IPFS client");
     let ipfs_service = ipfs_service(
         ipfs_client,
-        env_vars.mappings.max_ipfs_file_bytes as u64,
+        env_vars.mappings.max_ipfs_file_bytes,
         env_vars.mappings.ipfs_timeout,
         env_vars.mappings.ipfs_request_limit,
     );

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -463,7 +463,7 @@ pub async fn setup<C: Blockchain>(
     ));
     let ipfs_service = ipfs_service(
         ipfs.cheap_clone(),
-        env_vars.mappings.max_ipfs_file_bytes as u64,
+        env_vars.mappings.max_ipfs_file_bytes,
         env_vars.mappings.ipfs_timeout,
         env_vars.mappings.ipfs_request_limit,
     );

--- a/tests/tests/runner_tests.rs
+++ b/tests/tests/runner_tests.rs
@@ -669,7 +669,11 @@ async fn file_data_sources() {
 
     // CID of `file-data-sources/abis/Contract.abi` after being processed by graph-cli.
     let id = "QmQ2REmceVtzawp7yrnxLQXgNNCtFHEnig6fL9aqE1kcWq";
-    let content_bytes = ctx.ipfs.cat_all(id, Duration::from_secs(10)).await.unwrap();
+    let content_bytes = ctx
+        .ipfs
+        .cat_all(id, Some(Duration::from_secs(10)), usize::MAX)
+        .await
+        .unwrap();
     let content = String::from_utf8(content_bytes.into()).unwrap();
     let query_res = ctx
         .query(&format!(r#"{{ ipfsFile(id: "{id}") {{ id, content }} }}"#,))


### PR DESCRIPTION
To reduce the total number of calls to IPFS, and to generally simplify our interface on IPFS, this stops using the `stat` API to check existence and control file size. Both can be achieved efficiently with the more usual cat api.

Relying on files/stat was questionable anyways, since we don't know to what extent IPFS clients actually enforce that the declared metadata size value matches the real file size.

Resolves https://github.com/graphprotocol/graph-node/issues/5087.
