### PR TITLE
store: Check interface uniqueness in bulk

### DIFF
--- a/graph/src/data/store/id.rs
+++ b/graph/src/data/store/id.rs
@@ -306,6 +306,16 @@ impl<'a> IdRef<'a> {
     }
 }
 
+impl<'a> From<&'a Id> for IdRef<'a> {
+    fn from(id: &'a Id) -> Self {
+        match id {
+            Id::String(s) => IdRef::String(s.as_str()),
+            Id::Bytes(b) => IdRef::Bytes(b.as_slice()),
+            Id::Int8(i) => IdRef::Int8(*i),
+        }
+    }
+}
+
 /// A homogeneous list of entity ids, i.e., all ids in the list are of the
 /// same `IdType`
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -50,14 +50,14 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use crate::relational_queries::{
-    ConflictingEntityData, FindChangesQuery, FindDerivedQuery, FindPossibleDeletionsQuery,
-    ReturnedEntityData,
+    ConflictingEntitiesData, ConflictingEntitiesQuery, FindChangesQuery, FindDerivedQuery,
+    FindPossibleDeletionsQuery, ReturnedEntityData,
 };
 use crate::{
     primary::{Namespace, Site},
     relational_queries::{
-        ClampRangeQuery, ConflictingEntityQuery, EntityData, EntityDeletion, FilterCollection,
-        FilterQuery, FindManyQuery, FindQuery, InsertQuery, RevertClampQuery, RevertRemoveQuery,
+        ClampRangeQuery, EntityData, EntityDeletion, FilterCollection, FilterQuery, FindManyQuery,
+        FindQuery, InsertQuery, RevertClampQuery, RevertRemoveQuery,
     },
 };
 use graph::components::store::DerivedEntityQuery;
@@ -606,16 +606,16 @@ impl Layout {
         Ok(())
     }
 
-    pub fn conflicting_entity(
+    pub fn conflicting_entities(
         &self,
         conn: &mut PgConnection,
-        entity_id: &Id,
-        entities: Vec<EntityType>,
-    ) -> Result<Option<String>, StoreError> {
-        Ok(ConflictingEntityQuery::new(self, entities, entity_id)?
+        entities: &[EntityType],
+        group: &RowGroup,
+    ) -> Result<Option<(String, String)>, StoreError> {
+        Ok(ConflictingEntitiesQuery::new(self, entities, group)?
             .load(conn)?
             .pop()
-            .map(|data: ConflictingEntityData| data.entity))
+            .map(|data: ConflictingEntitiesData| (data.entity, data.id)))
     }
 
     /// order is a tuple (attribute, value_type, direction)

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -11,7 +11,7 @@ use diesel::query_dsl::RunQueryDsl;
 use diesel::result::{Error as DieselError, QueryResult};
 use diesel::sql_types::Untyped;
 use diesel::sql_types::{Array, BigInt, Binary, Bool, Int8, Integer, Jsonb, Text, Timestamptz};
-use graph::components::store::write::{EntityWrite, WriteChunk};
+use graph::components::store::write::{EntityWrite, RowGroup, WriteChunk};
 use graph::components::store::{Child as StoreChild, DerivedEntityQuery};
 use graph::data::store::{Id, IdType, NULL};
 use graph::data::store::{IdList, IdRef, QueryObject};
@@ -2456,37 +2456,33 @@ impl<'a> QueryId for InsertQuery<'a> {
 impl<'a, Conn> RunQueryDsl<Conn> for InsertQuery<'a> {}
 
 #[derive(Debug, Clone)]
-pub struct ConflictingEntityQuery<'a> {
-    _layout: &'a Layout,
+pub struct ConflictingEntitiesQuery<'a> {
     tables: Vec<&'a Table>,
-    entity_id: &'a Id,
+    ids: IdList,
 }
-impl<'a> ConflictingEntityQuery<'a> {
+impl<'a> ConflictingEntitiesQuery<'a> {
     pub fn new(
         layout: &'a Layout,
-        entities: Vec<EntityType>,
-        entity_id: &'a Id,
+        entities: &[EntityType],
+        group: &'a RowGroup,
     ) -> Result<Self, StoreError> {
         let tables = entities
             .iter()
             .map(|entity| layout.table_for_entity(entity).map(|table| table.as_ref()))
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(ConflictingEntityQuery {
-            _layout: layout,
-            tables,
-            entity_id,
-        })
+        let ids = IdList::try_from_iter_ref(group.ids().map(|id| IdRef::from(id)))?;
+        Ok(ConflictingEntitiesQuery { tables, ids })
     }
 }
 
-impl<'a> QueryFragment<Pg> for ConflictingEntityQuery<'a> {
+impl<'a> QueryFragment<Pg> for ConflictingEntitiesQuery<'a> {
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
 
         // Construct a query
-        //   select 'Type1' as entity from schema.table1 where id = $1
+        //   select 'Type1' as entity, id from schema.table1 where id = any($1)
         //   union all
-        //   select 'Type2' as entity from schema.table2 where id = $1
+        //   select 'Type2' as entity, id from schema.table2 where id = any($1)
         //   union all
         //   ...
         for (i, table) in self.tables.iter().enumerate() {
@@ -2495,32 +2491,35 @@ impl<'a> QueryFragment<Pg> for ConflictingEntityQuery<'a> {
             }
             out.push_sql("select ");
             out.push_bind_param::<Text, _>(table.object.as_str())?;
-            out.push_sql(" as entity from ");
+            out.push_sql(" as entity, id::text from ");
             out.push_sql(table.qualified_name.as_str());
-            out.push_sql(" where id = ");
-            self.entity_id.push_bind_param(&mut out)?;
+            out.push_sql(" where id = any(");
+            self.ids.push_bind_param(&mut out)?;
+            out.push_sql(")");
         }
         Ok(())
     }
 }
 
-impl<'a> QueryId for ConflictingEntityQuery<'a> {
+impl<'a> QueryId for ConflictingEntitiesQuery<'a> {
     type QueryId = ();
 
     const HAS_STATIC_QUERY_ID: bool = false;
 }
 
 #[derive(QueryableByName)]
-pub struct ConflictingEntityData {
+pub struct ConflictingEntitiesData {
     #[diesel(sql_type = Text)]
     pub entity: String,
+    #[diesel(sql_type = Text)]
+    pub id: String,
 }
 
-impl<'a> Query for ConflictingEntityQuery<'a> {
+impl<'a> Query for ConflictingEntitiesQuery<'a> {
     type SqlType = Untyped;
 }
 
-impl<'a, Conn> RunQueryDsl<Conn> for ConflictingEntityQuery<'a> {}
+impl<'a, Conn> RunQueryDsl<Conn> for ConflictingEntitiesQuery<'a> {}
 
 #[derive(Debug, Clone)]
 enum ParentIds {

--- a/store/test-store/tests/graphql/query.rs
+++ b/store/test-store/tests/graphql/query.rs
@@ -283,6 +283,7 @@ fn test_schema(id: DeploymentHash, id_type: IdType) -> InputSchema {
         reviews: [SongReview!]! @derivedFrom(field: \"song\")
         media: [Media!]!
         release: Release! @derivedFrom(field: \"songs\")
+        stats: [SongStat!]! @derivedFrom(field: \"id\")
     }
 
     type SongStat @entity {


### PR DESCRIPTION
We used to run one query for each entity that was created or updated if it was of a type that implemented an interface. These single-entity queries can become quite time consuming during syncing.

With this change, we check all the entities of a given type with a single query, so that uniqueness checking for interfaces causes as many queries as there are types (with new/updated entities) rather than as many as there are entities of such types.

