### PR TITLE
Resolve block constraints in bulk

### DIFF
--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Error;
 use async_trait::async_trait;
 use web3::types::{Address, H256};
@@ -507,6 +509,12 @@ pub trait ChainStore: Send + Sync + 'static {
         hash: &BlockHash,
     ) -> Result<Option<(String, BlockNumber, Option<u64>, Option<BlockHash>)>, StoreError>;
 
+    /// Do the same lookup as `block_number`, but in bulk
+    async fn block_numbers(
+        &self,
+        hashes: Vec<BlockHash>,
+    ) -> Result<HashMap<BlockHash, BlockNumber>, StoreError>;
+
     /// Tries to retrieve all transactions receipts for a given block.
     async fn transaction_receipts_in_block(
         &self,
@@ -560,6 +568,11 @@ pub trait QueryStore: Send + Sync {
 
     async fn block_number(&self, block_hash: &BlockHash)
         -> Result<Option<BlockNumber>, StoreError>;
+
+    async fn block_numbers(
+        &self,
+        block_hashes: Vec<BlockHash>,
+    ) -> Result<HashMap<BlockHash, BlockNumber>, StoreError>;
 
     /// Returns the blocknumber, timestamp and the parentHash. Timestamp depends on the chain block type
     /// and can have multiple formats, it can also not be prevent. For now this is only available

--- a/graphql/src/query/ext.rs
+++ b/graphql/src/query/ext.rs
@@ -71,6 +71,18 @@ impl Default for BlockConstraint {
     }
 }
 
+impl BlockConstraint {
+    /// Return the `Some(hash)` if this constraint constrains by hash,
+    /// otherwise return `None`
+    pub fn hash(&self) -> Option<&BlockHash> {
+        use BlockConstraint::*;
+        match self {
+            Hash(hash) => Some(hash),
+            Number(_) | Min(_) | Latest => None,
+        }
+    }
+}
+
 impl TryFromValue for BlockConstraint {
     /// `value` should be the output of input object coercion.
     fn try_from_value(value: &r::Value) -> Result<Self, Error> {

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -144,20 +144,21 @@ where
                 query.query_text.as_ref(),
             )
             .to_result()?;
-        let by_block_constraint = query.block_constraint()?;
+        let by_block_constraint =
+            StoreResolver::locate_blocks(store.as_ref(), &state, &query).await?;
         let mut max_block = 0;
         let mut result: QueryResults = QueryResults::empty(query.root_trace(do_trace));
         let mut query_res_futures: Vec<_> = vec![];
         let setup_elapsed = execute_start.elapsed();
 
         // Note: This will always iterate at least once.
-        for (bc, (selection_set, error_policy)) in by_block_constraint {
+        for (ptr, (selection_set, error_policy)) in by_block_constraint {
             let resolver = StoreResolver::at_block(
                 &self.logger,
                 store.cheap_clone(),
                 &state,
                 self.subscription_manager.cheap_clone(),
-                bc,
+                ptr,
                 error_policy,
                 query.schema.id().clone(),
                 metrics.cheap_clone(),

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -168,7 +168,7 @@ where
             query_res_futures.push(execute_query(
                 query.clone(),
                 Some(selection_set),
-                resolver.block_ptr.as_ref().map(Into::into).clone(),
+                resolver.block_ptr.clone(),
                 QueryExecutionOptions {
                     resolver,
                     deadline: ENV_VARS.graphql.query_timeout.map(|t| Instant::now() + t),

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -128,21 +128,13 @@ impl StoreResolver {
 
         match bc {
             BlockConstraint::Hash(hash) => {
-                let ptr = store
-                    .block_number_with_timestamp_and_parent_hash(&hash)
-                    .await
-                    .map_err(Into::into)
-                    .and_then(|result| {
-                        result
-                            .ok_or_else(|| {
-                                QueryExecutionError::ValueParseError(
-                                    "block.hash".to_owned(),
-                                    "no block with that hash found".to_owned(),
-                                )
-                            })
-                            .map(|(number, _, _)| BlockPtr::new(hash, number))
-                    })?;
-
+                let Some(number) = store.block_number(&hash).await? else {
+                    return Err(QueryExecutionError::ValueParseError(
+                        "block.hash".to_owned(),
+                        "no block with that hash found".to_owned(),
+                    ));
+                };
+                let ptr = BlockPtr::new(hash, number);
                 block_queryable(state, ptr.number)?;
                 Ok(ptr)
             }

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -166,23 +166,52 @@ impl StoreResolver {
         }
     }
 
-    async fn lookup_meta(&self) -> Result<r::Value, QueryExecutionError> {
-        // Pretend that the whole `_meta` field was loaded by prefetch. We
-        // load egerly here even though that is only needed if timestamp or
-        // parentHash are used in the query
+    /// Lookup information for the `_meta` field `field`
+    async fn lookup_meta(&self, field: &a::Field) -> Result<r::Value, QueryExecutionError> {
+        // These constants are closely related to the `_Meta_` type in
+        // `graph/src/schema/meta.graphql`
+        const BLOCK: &str = "block";
+        const TIMESTAMP: &str = "timestamp";
+        const PARENT_HASH: &str = "parentHash";
+
+        /// Check if field is of the form `_ { block { X }}` where X is
+        /// either `timestamp` or `parentHash`. In that case, we need to
+        /// query the database
+        fn lookup_needed(field: &a::Field) -> bool {
+            let Some(block) = field
+                .selection_set
+                .fields()
+                .map(|(_, iter)| iter)
+                .flatten()
+                .find(|f| f.name == BLOCK)
+            else {
+                return false;
+            };
+            block
+                .selection_set
+                .fields()
+                .map(|(_, iter)| iter)
+                .flatten()
+                .any(|f| f.name == TIMESTAMP || f.name == PARENT_HASH)
+        }
+
         let Some(block_ptr) = &self.block_ptr else {
             return Err(QueryExecutionError::ResolveEntitiesError(
                 "cannot resolve _meta without a block pointer".to_string(),
             ));
         };
-        let (timestamp, parent_hash) = match self
-            .store
-            .block_number_with_timestamp_and_parent_hash(&block_ptr.hash)
-            .await
-            .map_err(Into::<QueryExecutionError>::into)?
-        {
-            Some((_, ts, parent_hash)) => (ts, parent_hash),
-            _ => (None, None),
+        let (timestamp, parent_hash) = if lookup_needed(field) {
+            match self
+                .store
+                .block_number_with_timestamp_and_parent_hash(&block_ptr.hash)
+                .await
+                .map_err(Into::<QueryExecutionError>::into)?
+            {
+                Some((_, ts, parent_hash)) => (ts, parent_hash),
+                _ => (None, None),
+            }
+        } else {
+            (None, None)
         };
 
         let hash = self
@@ -222,7 +251,8 @@ impl StoreResolver {
             parentHash: parent_hash,
             __typename: BLOCK_FIELD_TYPE
         };
-        map.insert("prefetch:block".into(), r::Value::List(vec![block]));
+        let block_key = Word::from(format!("prefetch:{BLOCK}"));
+        map.insert(block_key, r::Value::List(vec![block]));
         map.insert(
             "deployment".into(),
             r::Value::String(self.deployment.to_string()),
@@ -283,7 +313,7 @@ impl Resolver for StoreResolver {
         object_type: ObjectOrInterface<'_>,
     ) -> Result<r::Value, QueryExecutionError> {
         if object_type.is_meta() {
-            return self.lookup_meta().await;
+            return self.lookup_meta(field).await;
         }
         if let Some(r::Value::List(children)) = prefetched_object {
             if children.len() > 1 {

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -7,11 +7,7 @@ use graph::schema::ApiSchema;
 use graph::{components::store::SubscriptionManager, prelude::*, schema::ErrorPolicy};
 
 use crate::metrics::GraphQLMetrics;
-use crate::{
-    execution::ast as a,
-    execution::*,
-    prelude::{BlockConstraint, StoreResolver},
-};
+use crate::{execution::ast as a, execution::*, prelude::StoreResolver};
 
 /// Options available for subscription execution.
 pub struct SubscriptionExecutionOptions {
@@ -206,7 +202,7 @@ async fn execute_subscription_event(
             store,
             &state,
             subscription_manager,
-            BlockConstraint::Latest,
+            state.latest_block.clone(),
             ErrorPolicy::Deny,
             query.schema.id().clone(),
             metrics,

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -229,7 +229,7 @@ async fn execute_subscription_event(
         Err(e) => return Arc::new(e.into()),
     };
 
-    let block_ptr = resolver.block_ptr.as_ref().map(Into::into);
+    let block_ptr = resolver.block_ptr.clone();
 
     // Create a fresh execution context with deadline.
     let ctx = Arc::new(ExecutionContext {

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::time::Instant;
 
 use crate::deployment_store::{DeploymentStore, ReplicaId};
@@ -102,6 +103,13 @@ impl QueryStoreTrait for QueryStore {
         self.block_number_with_timestamp_and_parent_hash(block_hash)
             .await
             .map(|opt| opt.map(|(number, _, _)| number))
+    }
+
+    async fn block_numbers(
+        &self,
+        block_hashes: Vec<BlockHash>,
+    ) -> Result<HashMap<BlockHash, BlockNumber>, StoreError> {
+        self.chain_store.block_numbers(block_hashes).await
     }
 
     fn wait_stats(&self) -> Result<PoolWaitStats, StoreError> {

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -532,7 +532,9 @@ async fn execute_subgraph_query_internal(
         .await
         .unwrap();
     let state = store.deployment_state().await.unwrap();
-    for (bc, (selection_set, error_policy)) in return_err!(query.block_constraint()) {
+    let by_block_constraint =
+        return_err!(StoreResolver::locate_blocks(store.as_ref(), &state, &query).await);
+    for (ptr, (selection_set, error_policy)) in by_block_constraint {
         let logger = logger.clone();
         let resolver = return_err!(
             StoreResolver::at_block(
@@ -540,7 +542,7 @@ async fn execute_subgraph_query_internal(
                 store.clone(),
                 &state,
                 SUBSCRIPTION_MANAGER.clone(),
-                bc,
+                ptr,
                 error_policy,
                 query.schema.id().clone(),
                 graphql_metrics(),


### PR DESCRIPTION
The lookup needed for block constraints by hash is now done with one query  instead of one query for each such constraint. None of the other types of  constraints need a query any more.