### PR TITLE
Use 'select by specific attributes' by default

### DIFF
--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -150,7 +150,7 @@ pub struct EnvVars {
     pub subgraph_error_retry_jitter: f64,
     /// Experimental feature.
     ///
-    /// Set by the flag `GRAPH_ENABLE_SELECT_BY_SPECIFIC_ATTRIBUTES`. Off by
+    /// Set by the flag `GRAPH_ENABLE_SELECT_BY_SPECIFIC_ATTRIBUTES`. On by
     /// default.
     pub enable_select_by_specific_attributes: bool,
     /// Verbose logging of mapping inputs.
@@ -376,7 +376,7 @@ struct Inner {
     subgraph_error_retry_ceil_in_secs: u64,
     #[envconfig(from = "GRAPH_SUBGRAPH_ERROR_RETRY_JITTER", default = "0.2")]
     subgraph_error_retry_jitter: f64,
-    #[envconfig(from = "GRAPH_ENABLE_SELECT_BY_SPECIFIC_ATTRIBUTES", default = "false")]
+    #[envconfig(from = "GRAPH_ENABLE_SELECT_BY_SPECIFIC_ATTRIBUTES", default = "true")]
     enable_select_by_specific_attributes: EnvVarBoolean,
     #[envconfig(from = "GRAPH_LOG_TRIGGER_DATA", default = "false")]
     log_trigger_data: EnvVarBoolean,

--- a/graphql/src/execution/ast.rs
+++ b/graphql/src/execution/ast.rs
@@ -2,7 +2,6 @@ use std::collections::{BTreeSet, HashSet};
 
 use graph::{
     components::store::{AttributeNames, ChildMultiplicity},
-    constraint_violation,
     data::graphql::ObjectOrInterface,
     env::ENV_VARS,
     prelude::{anyhow, q, r, s, QueryExecutionError, ValueMap},
@@ -334,13 +333,7 @@ impl Field {
             Some(r::Value::Enum(e)) => {
                 column_names.insert(e.clone());
             }
-            Some(v) => {
-                return Err(constraint_violation!(
-                    "'orderBy' attribute must be an enum but is {:?}",
-                    v
-                )
-                .into());
-            }
+            Some(_) => { /* ignore incorrect values */ }
         }
 
         Ok(AttributeNames::Select(column_names))

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -698,6 +698,7 @@ pub(crate) fn collect_entities_from_query_field(
 #[cfg(test)]
 mod tests {
     use graph::components::store::EntityQuery;
+    use graph::env::ENV_VARS;
     use graph::{
         components::store::ChildMultiplicity,
         data::value::Object,
@@ -710,6 +711,7 @@ mod tests {
         },
         schema::{EntityType, InputSchema},
     };
+    use std::collections::BTreeSet;
     use std::{iter::FromIterator, sync::Arc};
 
     use super::{a, build_query};
@@ -863,13 +865,18 @@ mod tests {
 
     #[test]
     fn build_query_uses_the_entity_name() {
+        let attrs = if ENV_VARS.enable_select_by_specific_attributes {
+            AttributeNames::Select(BTreeSet::new())
+        } else {
+            AttributeNames::All
+        };
         assert_eq!(
             query(&field(ENTITY1)).collection,
-            EntityCollection::All(vec![(entity_type(ENTITY1), AttributeNames::All)])
+            EntityCollection::All(vec![(entity_type(ENTITY1), attrs.clone())])
         );
         assert_eq!(
             query(&field(ENTITY2)).collection,
-            EntityCollection::All(vec![(entity_type(ENTITY2), AttributeNames::All)])
+            EntityCollection::All(vec![(entity_type(ENTITY2), attrs)])
         );
     }
 

--- a/graphql/src/store/query.rs
+++ b/graphql/src/store/query.rs
@@ -39,7 +39,7 @@ pub(crate) fn build_query<'a>(
         .object_types()
         .into_iter()
         .map(|entity_type| {
-            let selected_columns = field.selected_attrs(&entity_type);
+            let selected_columns = field.selected_attrs(&entity_type, &order);
             selected_columns.map(|selected_columns| (entity_type, selected_columns))
         })
         .collect::<Result<_, _>>()?;
@@ -707,6 +707,7 @@ pub(crate) fn collect_entities_from_query_field(
 #[cfg(test)]
 mod tests {
     use graph::components::store::EntityQuery;
+    use graph::data::store::ID;
     use graph::env::ENV_VARS;
     use graph::{
         components::store::ChildMultiplicity,
@@ -875,7 +876,10 @@ mod tests {
     #[test]
     fn build_query_uses_the_entity_name() {
         let attrs = if ENV_VARS.enable_select_by_specific_attributes {
-            AttributeNames::Select(BTreeSet::new())
+            // The query uses the default order, i.e., sorting by id
+            let mut attrs = BTreeSet::new();
+            attrs.insert(ID.to_string());
+            AttributeNames::Select(attrs)
         } else {
             AttributeNames::All
         };


### PR DESCRIPTION
With these small fixes, a test run with the setting on and off did not produce any material differences in the query results. The only differences were in a few error messages that contained a debug dump of the query (where we now have a list of column names instead of `*`)