### PR TITLE
Make the ethereum firehose codec less crashy

### DIFF
--- a/chain/ethereum/src/codec.rs
+++ b/chain/ethereum/src/codec.rs
@@ -233,10 +233,9 @@ impl TryInto<EthereumBlockWithCalls> for &Block {
     type Error = Error;
 
     fn try_into(self) -> Result<EthereumBlockWithCalls, Self::Error> {
-        let header = self
-            .header
-            .as_ref()
-            .expect("block header should always be present from gRPC Firehose");
+        let header = self.header.as_ref().ok_or_else(|| {
+            format_err!("block header should always be present from gRPC Firehose")
+        })?;
 
         let block = EthereumBlockWithCalls {
             ethereum_block: EthereumBlock {


### PR DESCRIPTION
The decoder for Ethereum firehose is full of `unwrap`, `expect` and `panic`. This removes two potential crashes that we encountered in production.

The code is still pretty scary as it takes in data from the network and will crash when it doesn't conform to its implicit assumptions. For example, even though the block header is in an `Option` in the protobuf, the code will just panic when it is ever `None`.