### PR TITLE
Add deployment id to firehose connection headers

### DIFF
--- a/chain/ethereum/examples/firehose.rs
+++ b/chain/ethereum/examples/firehose.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Error> {
                 },
                 final_blocks_only: false,
                 ..Default::default()
-            })
+            }, &firehose::ConnectionHeaders::new())
             .await
         {
             Ok(s) => s,

--- a/chain/ethereum/examples/firehose.rs
+++ b/chain/ethereum/examples/firehose.rs
@@ -45,16 +45,19 @@ async fn main() -> Result<(), Error> {
         println!("Connecting to the stream!");
         let mut stream: Streaming<firehose::Response> = match firehose
             .clone()
-            .stream_blocks(firehose::Request {
-                start_block_num: 12369739,
-                stop_block_num: 12369739,
-                cursor: match &cursor {
-                    Some(c) => c.clone(),
-                    None => String::from(""),
+            .stream_blocks(
+                firehose::Request {
+                    start_block_num: 12369739,
+                    stop_block_num: 12369739,
+                    cursor: match &cursor {
+                        Some(c) => c.clone(),
+                        None => String::from(""),
+                    },
+                    final_blocks_only: false,
+                    ..Default::default()
                 },
-                final_blocks_only: false,
-                ..Default::default()
-            }, &firehose::ConnectionHeaders::new())
+                &firehose::ConnectionHeaders::new(),
+            )
             .await
         {
             Ok(s) => s,

--- a/graph/src/blockchain/firehose_block_ingestor.rs
+++ b/graph/src/blockchain/firehose_block_ingestor.rs
@@ -199,7 +199,7 @@ where
                     final_blocks_only: false,
                     transforms: self.default_transforms.iter().map(|t| t.into()).collect(),
                     ..Default::default()
-                })
+                }, &firehose::ConnectionHeaders::new())
                 .await;
 
             match result {

--- a/graph/src/blockchain/firehose_block_ingestor.rs
+++ b/graph/src/blockchain/firehose_block_ingestor.rs
@@ -192,14 +192,17 @@ where
 
             let result = endpoint
                 .clone()
-                .stream_blocks(firehose::Request {
-                    // Starts at current HEAD block of the chain (viewed from Firehose side)
-                    start_block_num: -1,
-                    cursor: latest_cursor.clone(),
-                    final_blocks_only: false,
-                    transforms: self.default_transforms.iter().map(|t| t.into()).collect(),
-                    ..Default::default()
-                }, &firehose::ConnectionHeaders::new())
+                .stream_blocks(
+                    firehose::Request {
+                        // Starts at current HEAD block of the chain (viewed from Firehose side)
+                        start_block_num: -1,
+                        cursor: latest_cursor.clone(),
+                        final_blocks_only: false,
+                        transforms: self.default_transforms.iter().map(|t| t.into()).collect(),
+                        ..Default::default()
+                    },
+                    &firehose::ConnectionHeaders::new(),
+                )
                 .await;
 
             match result {

--- a/graph/src/blockchain/firehose_block_stream.rs
+++ b/graph/src/blockchain/firehose_block_stream.rs
@@ -203,6 +203,8 @@ fn stream_blocks<C: Blockchain, F: FirehoseMapper<C>>(
         debug!(&logger, "Going to check continuity of chain on first block");
     }
 
+    let headers = firehose::ConnectionHeaders::new().with_deployment(deployment.clone());
+
     // Back off exponentially whenever we encounter a connection error or a stream with bad data
     let mut backoff = ExponentialBackoff::new(Duration::from_millis(500), Duration::from_secs(45));
 
@@ -240,7 +242,7 @@ fn stream_blocks<C: Blockchain, F: FirehoseMapper<C>>(
             }
 
             let mut connect_start = Instant::now();
-            let req = endpoint.clone().stream_blocks(request);
+            let req = endpoint.clone().stream_blocks(request, &headers);
             let result = tokio::time::timeout(Duration::from_secs(120), req).await.map_err(|x| x.into()).and_then(|x| x);
 
             match result {

--- a/graph/src/blockchain/substreams_block_stream.rs
+++ b/graph/src/blockchain/substreams_block_stream.rs
@@ -4,6 +4,7 @@ use super::block_stream::{
 use super::client::ChainClient;
 use crate::blockchain::block_stream::{BlockStream, BlockStreamEvent};
 use crate::blockchain::Blockchain;
+use crate::firehose::ConnectionHeaders;
 use crate::prelude::*;
 use crate::substreams::Modules;
 use crate::substreams_rpc::{ModulesProgress, Request, Response};
@@ -174,6 +175,8 @@ fn stream_blocks<C: Blockchain, F: BlockStreamMapper<C>>(
 
     let stop_block_num = manifest_end_block_num as u64;
 
+    let headers = ConnectionHeaders::new().with_deployment(deployment.clone());
+
     // Back off exponentially whenever we encounter a connection error or a stream with bad data
     let mut backoff = ExponentialBackoff::new(Duration::from_millis(500), Duration::from_secs(45));
 
@@ -203,7 +206,7 @@ fn stream_blocks<C: Blockchain, F: BlockStreamMapper<C>>(
             };
 
 
-            let result = endpoint.clone().substreams(request).await;
+            let result = endpoint.clone().substreams(request, &headers).await;
 
             match result {
                 Ok(stream) => {

--- a/graph/src/firehose/endpoints.rs
+++ b/graph/src/firehose/endpoints.rs
@@ -26,10 +26,10 @@ use std::{
 };
 use tonic::codegen::InterceptedService;
 use tonic::{
-    Request,
     codegen::CompressionEncoding,
     metadata::{Ascii, MetadataKey, MetadataValue},
     transport::{Channel, ClientTlsConfig},
+    Request,
 };
 
 use super::{codec as firehose, interceptors::MetricsInterceptor, stream_client::StreamClient};
@@ -63,7 +63,8 @@ impl ConnectionHeaders {
     }
     pub fn with_deployment(mut self, deployment: DeploymentHash) -> Self {
         if let Ok(deployment) = deployment.parse() {
-            self.0.insert("x-deployment-id".parse().unwrap(), deployment);
+            self.0
+                .insert("x-deployment-id".parse().unwrap(), deployment);
         }
         self
     }


### PR DESCRIPTION
Fixes #5098 

When running firehose infrastructure it helps to know which subgraph is consuming substreams modules that are failing.

This PR makes it possible by adding deployment id to firehose/substreams request via `x-deployment-id` header