### PR TITLE
Use `Timestamp` type for the `timestamp` attribute of aggregations

### DIFF
--- a/docs/aggregations.md
+++ b/docs/aggregations.md
@@ -16,13 +16,13 @@ data points are to be aggregated. A very simple aggregation can be declared like
 ```graphql
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")
 }
 ```
@@ -48,8 +48,6 @@ for example, to the beginning of the hour for an hourly aggregation. The
 the aggregation. Which one is chosen is not specified and should not be
 relied on.
 
-**TODO**: add a `Timestamp` type and use that for `timestamp`
-
 **TODO**: figure out whether we should just automatically add `id` and
 `timestamp` and have validation just check that these fields don't exist
 
@@ -65,7 +63,7 @@ type Token @entity { .. }
 # Raw data points
 type TokenData @entity(timeseries: true) {
     id: Bytes!
-    timestamp: Int8!
+    timestamp: Timestamp!
     token: Token!
     amount: BigDecimal!
     priceUSD: BigDecimal!
@@ -74,7 +72,7 @@ type TokenData @entity(timeseries: true) {
 # Aggregations over TokenData
 type TokenStats @aggregation(intervals: ["hour", "day"], source: "TokenData") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   totalVolume: BigDecimal! @aggregate(fn: "sum", arg: "amount")
   priceUSD: BigDecimal! @aggregate(fn: "last", arg: "priceUSD")
@@ -103,9 +101,9 @@ the entire timeseries up to the end of the time interval for the bucket.
 ### Timeseries
 
 A timeseries is an entity type with the annotation `@entity(timeseries:
-true)`. It must have an `id` attribute and a `timestamp` attribute of type
-`Int8`. It must not also be annotated with `immutable: false` as timeseries
-are always immutable.
+true)`. It must have an `id` attribute of type `Int8` and a `timestamp`
+attribute of type `Timestamp`. It must not also be annotated with
+`immutable: false` as timeseries are always immutable.
 
 ### Aggregations
 
@@ -117,8 +115,8 @@ must have two arguments:
 - `source`: the name of a timeseries type. Aggregates are computed based on
   the attributes of the timeseries type.
 
-The aggregation type must have an `id` attribute and a `timestamp` attribute
-of type `Int8`.
+The aggregation type must have an `id` attribute of type `Int8` and a
+`timestamp` attribute of type `Timestamp`.
 
 The aggregation type must have at least one attribute with the `@aggregate`
 annotation. These attributes must be of a numeric type (`Int`, `Int8`,
@@ -188,7 +186,9 @@ accepts the following arguments:
   partially filled bucket in the response. Can be either `ignore` (the
   default) or `include` (still **TODO** and not implemented)
 - Optional `timestamp_{gte|gt|lt|lte|eq|in}` filters to restrict the range
-  of timestamps to return
+  of timestamps to return. The timestamp to filter by must be a string
+  containing microseconds since the epoch. The value `"1704164640000000"`
+  corresponds to `2024-01-02T03:04Z`.
 - Timeseries are always sorted by `timestamp` and `id` in descending order
 
 ```graphql

--- a/graph/src/blockchain/types.rs
+++ b/graph/src/blockchain/types.rs
@@ -1,5 +1,4 @@
 use anyhow::anyhow;
-use chrono::{DateTime, Utc};
 use diesel::deserialize::FromSql;
 use diesel::pg::Pg;
 use diesel::serialize::{Output, ToSql};
@@ -12,6 +11,7 @@ use std::{fmt, str::FromStr};
 use web3::types::{Block, H256};
 
 use crate::data::graphql::IntoValue;
+use crate::data::store::scalar::Timestamp;
 use crate::object;
 use crate::prelude::{r, BigInt, TryFromValue, Value, ValueMap};
 use crate::util::stable_hash_glue::{impl_stable_hash, AsBytes};
@@ -331,23 +331,24 @@ impl fmt::Display for ChainIdentifier {
 
 /// The timestamp associated with a block. This is used whenever a time
 /// needs to be connected to data within the block
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct BlockTime(DateTime<Utc>);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, FromSqlRow, AsExpression)]
+#[diesel(sql_type = Timestamptz)]
+pub struct BlockTime(Timestamp);
 
 impl BlockTime {
     /// A timestamp from a long long time ago used to indicate that we don't
     /// have a timestamp
-    pub const NONE: Self = Self(DateTime::<Utc>::MIN_UTC);
+    pub const NONE: Self = Self(Timestamp::NONE);
 
-    pub const MAX: Self = Self(DateTime::<Utc>::MAX_UTC);
+    pub const MAX: Self = Self(Timestamp::MAX);
 
-    pub const MIN: Self = Self(DateTime::<Utc>::MIN_UTC);
+    pub const MIN: Self = Self(Timestamp::MIN);
 
     /// Construct a block time that is the given number of seconds and
     /// nanoseconds after the Unix epoch
     pub fn since_epoch(secs: i64, nanos: u32) -> Self {
         Self(
-            DateTime::from_timestamp(secs, nanos)
+            Timestamp::since_epoch(secs, nanos)
                 .ok_or_else(|| anyhow!("invalid block time: {}s {}ns", secs, nanos))
                 .unwrap(),
         )
@@ -362,7 +363,7 @@ impl BlockTime {
     }
 
     pub fn as_secs_since_epoch(&self) -> i64 {
-        self.0.timestamp()
+        self.0.as_secs_since_epoch()
     }
 
     /// Return the number of the last bucket that starts before `self`
@@ -385,7 +386,7 @@ impl From<Duration> for BlockTime {
 
 impl From<BlockTime> for Value {
     fn from(block_time: BlockTime) -> Self {
-        Value::Int8(block_time.as_secs_since_epoch())
+        Value::Timestamp(block_time.0)
     }
 }
 
@@ -402,6 +403,6 @@ impl TryFrom<&Value> for BlockTime {
 
 impl ToSql<Timestamptz, Pg> for BlockTime {
     fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> diesel::serialize::Result {
-        <DateTime<Utc> as ToSql<Timestamptz, Pg>>::to_sql(&self.0, out)
+        <Timestamp as ToSql<Timestamptz, Pg>>::to_sql(&self.0, out)
     }
 }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -414,7 +414,7 @@ impl Value {
                         Value::Timestamp(scalar::Timestamp::parse_timestamp(s).map_err(|_| {
                             QueryExecutionError::ValueParseError(
                                 "Timestamp".to_string(),
-                                format!("{}", s),
+                                format!("xxx{}", s),
                             )
                         })?)
                     }
@@ -427,7 +427,7 @@ impl Value {
             (r::Value::Null, _) => Value::Null,
             _ => {
                 return Err(QueryExecutionError::AttributeTypeError(
-                    value.to_string(),
+                    format!("{:?}", value),
                     ty.to_string(),
                 ));
             }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -423,6 +423,7 @@ impl Value {
             }
             (r::Value::Int(i), _) => Value::Int(*i as i32),
             (r::Value::Boolean(b), _) => Value::Bool(b.to_owned()),
+            (r::Value::Timestamp(ts), _) => Value::Timestamp(*ts),
             (r::Value::Null, _) => Value::Null,
             _ => {
                 return Err(QueryExecutionError::AttributeTypeError(

--- a/graph/src/data/store/scalar/timestamp.rs
+++ b/graph/src/data/store/scalar/timestamp.rs
@@ -8,7 +8,7 @@ use std::num::ParseIntError;
 
 use crate::runtime::gas::{Gas, GasSizeOf, SaturatingInto};
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct Timestamp(pub DateTime<Utc>);
 
 #[derive(thiserror::Error, Debug)]

--- a/graph/src/data/store/scalar/timestamp.rs
+++ b/graph/src/data/store/scalar/timestamp.rs
@@ -8,7 +8,7 @@ use std::num::ParseIntError;
 
 use crate::runtime::gas::{Gas, GasSizeOf, SaturatingInto};
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Timestamp(pub DateTime<Utc>);
 
 #[derive(thiserror::Error, Debug)]
@@ -20,6 +20,14 @@ pub enum TimestampError {
 }
 
 impl Timestamp {
+    /// A timestamp from a long long time ago used to indicate that we don't
+    /// have a timestamp
+    pub const NONE: Self = Self(DateTime::<Utc>::MIN_UTC);
+
+    pub const MAX: Self = Self(DateTime::<Utc>::MAX_UTC);
+
+    pub const MIN: Self = Self(DateTime::<Utc>::MIN_UTC);
+
     pub fn parse_timestamp(v: &str) -> Result<Self, TimestampError> {
         let as_num: i64 = v.parse().map_err(TimestampError::StringParseError)?;
         Timestamp::from_microseconds_since_epoch(as_num)
@@ -41,6 +49,18 @@ impl Timestamp {
 
     pub fn as_microseconds_since_epoch(&self) -> i64 {
         self.0.timestamp_micros()
+    }
+
+    pub fn since_epoch(secs: i64, nanos: u32) -> Option<Self> {
+        DateTime::from_timestamp(secs, nanos).map(|dt| Timestamp(dt))
+    }
+
+    pub fn as_secs_since_epoch(&self) -> i64 {
+        self.0.timestamp()
+    }
+
+    pub(crate) fn timestamp_millis(&self) -> i64 {
+        self.0.timestamp_millis()
     }
 }
 

--- a/graph/src/data/value.rs
+++ b/graph/src/data/value.rs
@@ -297,7 +297,7 @@ impl std::fmt::Debug for Object {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum Value {
     Int(i64),
     Float(f64),
@@ -541,6 +541,7 @@ impl From<Value> for q::Value {
     }
 }
 
+/*
 impl std::fmt::Debug for Value {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -558,3 +559,4 @@ impl std::fmt::Debug for Value {
         }
     }
 }
+*/

--- a/graph/src/schema/api.rs
+++ b/graph/src/schema/api.rs
@@ -891,7 +891,8 @@ fn field_filter_ops(set: FilterOpsSet<'_>) -> &'static [&'static str] {
         Aggregation("BigInt")
         | Aggregation("BigDecimal")
         | Aggregation("Int")
-        | Aggregation("Int8") => &["", "gt", "lt", "gte", "lte", "in"],
+        | Aggregation("Int8")
+        | Aggregation("Timestamp") => &["", "gt", "lt", "gte", "lte", "in"],
         Object(_) => &["", "not"],
         Aggregation(_) => &[""],
     }
@@ -2219,13 +2220,13 @@ type Gravatar @entity {
         const SCHEMA: &str = r#"
         type Data @entity(timeseries: true) {
             id: Int8!
-            timestamp: Int8!
+            timestamp: Timestamp!
             value: BigDecimal!
         }
 
         type Stats @aggregation(source: "Data", intervals: ["hour", "day"]) {
             id: Int8!
-            timestamp: Int8!
+            timestamp: Timestamp!
             sum: BigDecimal! @aggregate(fn: "sum", arg: "value")
         }
 

--- a/graph/src/schema/input/mod.rs
+++ b/graph/src/schema/input/mod.rs
@@ -2626,7 +2626,6 @@ mod validations {
         }
 
         /// Aggregations must have a `timestamp` field of type `Timestamp`
-        /// FIXME: introduce a timestamp type and use that
         fn valid_timestamp_field(agg_type: &s::ObjectType) -> Option<Err> {
             let field = match agg_type.field(kw::TIMESTAMP) {
                 Some(field) => field,

--- a/graph/src/schema/input/mod.rs
+++ b/graph/src/schema/input/mod.rs
@@ -2625,7 +2625,7 @@ mod validations {
             errors
         }
 
-        /// Aggregations must have a `timestamp` field of type Int8
+        /// Aggregations must have a `timestamp` field of type `Timestamp`
         /// FIXME: introduce a timestamp type and use that
         fn valid_timestamp_field(agg_type: &s::ObjectType) -> Option<Err> {
             let field = match agg_type.field(kw::TIMESTAMP) {
@@ -2636,7 +2636,7 @@ mod validations {
             };
 
             match field.field_type.value_type() {
-                Ok(ValueType::Int8) => None,
+                Ok(ValueType::Timestamp) => None,
                 Ok(_) | Err(_) => Some(Err::InvalidTimestampType(
                     agg_type.name.to_owned(),
                     field.field_type.get_base_type().to_owned(),
@@ -3096,13 +3096,13 @@ mod tests {
       type HippoData @entity(timeseries: true) {
         id: Int8!
         hippo: Hippo!
-        timestamp: Int8!
+        timestamp: Timestamp!
         weight: BigDecimal!
       }
 
       type HippoStats @aggregation(intervals: ["hour"], source: "HippoData") {
         id: Int8!
-        timestamp: Int8!
+        timestamp: Timestamp!
         hippo: Hippo!
         maxWeight: BigDecimal! @aggregate(fn: "max", arg:"weight")
       }

--- a/graph/src/schema/mod.rs
+++ b/graph/src/schema/mod.rs
@@ -147,7 +147,7 @@ pub enum SchemaValidationError {
     MutableTimeseries(String),
     #[error("Timeseries {0} is missing a `timestamp` field")]
     TimeseriesMissingTimestamp(String),
-    #[error("Type {0} has a `timestamp` field of type {1}, but it must be of type Int8")]
+    #[error("Type {0} has a `timestamp` field of type {1}, but it must be of type Timestamp")]
     InvalidTimestampType(String, String),
     #[error("Aggregaton {0} uses {1} as the source, but there is no timeseries of that name")]
     AggregationUnknownSource(String, String),

--- a/graph/src/schema/test_schemas/no_aggregations.graphql
+++ b/graph/src/schema/test_schemas/no_aggregations.graphql
@@ -1,12 +1,12 @@
 # fail @ 0.0.9: AggregationsNotSupported
 type Data @entity(timeseries: true) {
   id: Bytes!
-  timestamp: Int8!
+  timestamp: Timestamp!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Bytes!
-  timestamp: Int8!
+  timestamp: Timestamp!
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")
 }

--- a/graph/src/schema/test_schemas/ts_data_mutable.graphql
+++ b/graph/src/schema/test_schemas/ts_data_mutable.graphql
@@ -1,12 +1,12 @@
 # fail: MutableTimeseries
 type Data @entity(timeseries: true, immutable: false) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")
 }

--- a/graph/src/schema/test_schemas/ts_data_no_id.graphql
+++ b/graph/src/schema/test_schemas/ts_data_no_id.graphql
@@ -1,11 +1,11 @@
 # fail: IdFieldMissing
 type Data @entity(timeseries: true) {
-  timestamp: Int8!
+  timestamp: Timestamp!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")
 }

--- a/graph/src/schema/test_schemas/ts_data_no_timestamp.graphql
+++ b/graph/src/schema/test_schemas/ts_data_no_timestamp.graphql
@@ -6,6 +6,6 @@ type Data @entity(timeseries: true) {
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")
 }

--- a/graph/src/schema/test_schemas/ts_data_not_timeseries.graphql
+++ b/graph/src/schema/test_schemas/ts_data_not_timeseries.graphql
@@ -1,12 +1,12 @@
 # fail: AggregationNonTimeseriesSource
 type Data @entity {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")
 }

--- a/graph/src/schema/test_schemas/ts_derived_from.graphql
+++ b/graph/src/schema/test_schemas/ts_derived_from.graphql
@@ -6,14 +6,14 @@ type Token @entity {
 
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Bytes!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token! @derivedFrom(field: "stats")
   max: BigDecimal! @aggregate(fn: "max", arg: "price")
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")

--- a/graph/src/schema/test_schemas/ts_empty_intervals.graphql
+++ b/graph/src/schema/test_schemas/ts_empty_intervals.graphql
@@ -6,14 +6,14 @@ type Token @entity {
 
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: [], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   max: BigDecimal! @aggregate(fn: "max", arg: "price")
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")

--- a/graph/src/schema/test_schemas/ts_expr_random.graphql
+++ b/graph/src/schema/test_schemas/ts_expr_random.graphql
@@ -2,13 +2,13 @@
 # Random must not be allowed as it would introduce nondeterministic behavior
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   price0: BigDecimal!
   price1: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   max_price: BigDecimal! @aggregate(fn: "max", arg: "random()")
 }

--- a/graph/src/schema/test_schemas/ts_expr_simple.graphql
+++ b/graph/src/schema/test_schemas/ts_expr_simple.graphql
@@ -1,14 +1,14 @@
 # valid: Minimal example
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   price0: BigDecimal!
   price1: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   max_price: BigDecimal! @aggregate(fn: "max", arg: "greatest(price0, price1)")
   abs_price: BigDecimal! @aggregate(fn: "sum", arg: "abs(price0) + abs(price1)")
   price0_sq: BigDecimal! @aggregate(fn: "sum", arg: "power(price0, 2)")

--- a/graph/src/schema/test_schemas/ts_expr_syntax_err.graphql
+++ b/graph/src/schema/test_schemas/ts_expr_syntax_err.graphql
@@ -1,13 +1,13 @@
 # fail: ExprParseError("sql parser error: Expected an expression:, found: EOF")
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   price0: BigDecimal!
   price1: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   max_price: BigDecimal! @aggregate(fn: "max", arg: "greatest(price0,")
 }

--- a/graph/src/schema/test_schemas/ts_id_type_mismatch.graphql
+++ b/graph/src/schema/test_schemas/ts_id_type_mismatch.graphql
@@ -1,12 +1,12 @@
 # fail: IllegalIdType
 type Data @entity(timeseries: true) {
   id: Bytes!
-  timestamp: Int8!
+  timestamp: Timestamp!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")
 }

--- a/graph/src/schema/test_schemas/ts_invalid_arg.graphql
+++ b/graph/src/schema/test_schemas/ts_invalid_arg.graphql
@@ -6,14 +6,14 @@ type Token @entity {
 
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   max: BigDecimal! @aggregate(fn: "max", arg: "token")
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")

--- a/graph/src/schema/test_schemas/ts_invalid_cumulative.graphql
+++ b/graph/src/schema/test_schemas/ts_invalid_cumulative.graphql
@@ -1,12 +1,12 @@
 # fail: AggregationInvalidCumulative("Stats", "sum")
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price", cumulative: "maybe")
 }

--- a/graph/src/schema/test_schemas/ts_invalid_fn.graphql
+++ b/graph/src/schema/test_schemas/ts_invalid_fn.graphql
@@ -6,14 +6,14 @@ type Token @entity {
 
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   doit: BigDecimal! @aggregate(fn: "doit", arg: "price")
 }

--- a/graph/src/schema/test_schemas/ts_invalid_interval.graphql
+++ b/graph/src/schema/test_schemas/ts_invalid_interval.graphql
@@ -6,14 +6,14 @@ type Token @entity {
 
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["fortnight"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   max: BigDecimal! @aggregate(fn: "max", arg: "price")
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")

--- a/graph/src/schema/test_schemas/ts_invalid_timestamp_aggregation.graphql
+++ b/graph/src/schema/test_schemas/ts_invalid_timestamp_aggregation.graphql
@@ -1,4 +1,4 @@
-# valid: Minimal example
+# fail: InvalidTimestampType("Stats", "Int8")
 type Data @entity(timeseries: true) {
   id: Int8!
   timestamp: Timestamp!
@@ -7,6 +7,6 @@ type Data @entity(timeseries: true) {
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Timestamp!
+  timestamp: Int8!
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")
 }

--- a/graph/src/schema/test_schemas/ts_invalid_timestamp_timeseries.graphql
+++ b/graph/src/schema/test_schemas/ts_invalid_timestamp_timeseries.graphql
@@ -1,7 +1,7 @@
-# valid: Minimal example
+# fail: InvalidTimestampType("Data", "Int8")
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Timestamp!
+  timestamp: Int8!
   price: BigDecimal!
 }
 

--- a/graph/src/schema/test_schemas/ts_missing_arg.graphql
+++ b/graph/src/schema/test_schemas/ts_missing_arg.graphql
@@ -6,14 +6,14 @@ type Token @entity {
 
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   max: BigDecimal! @aggregate(fn: "max")
 }

--- a/graph/src/schema/test_schemas/ts_missing_fn.graphql
+++ b/graph/src/schema/test_schemas/ts_missing_fn.graphql
@@ -6,14 +6,14 @@ type Token @entity {
 
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   max: BigDecimal! @aggregate(arg: "price")
 }

--- a/graph/src/schema/test_schemas/ts_missing_type.graphql
+++ b/graph/src/schema/test_schemas/ts_missing_type.graphql
@@ -1,14 +1,14 @@
 # fail: FieldTypeUnknown
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   max: BigDecimal! @aggregate(fn: "max", arg: "price")
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")

--- a/graph/src/schema/test_schemas/ts_no_aggregate.graphql
+++ b/graph/src/schema/test_schemas/ts_no_aggregate.graphql
@@ -6,13 +6,13 @@ type Token @entity {
 
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
 }

--- a/graph/src/schema/test_schemas/ts_no_id.graphql
+++ b/graph/src/schema/test_schemas/ts_no_id.graphql
@@ -6,13 +6,13 @@ type Token @entity {
 
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   max: BigDecimal! @aggregate(fn: "max", arg: "price")
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")

--- a/graph/src/schema/test_schemas/ts_no_interval.graphql
+++ b/graph/src/schema/test_schemas/ts_no_interval.graphql
@@ -6,14 +6,14 @@ type Token @entity {
 
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   price: BigDecimal!
 }
 
 type Stats @aggregation(source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   max: BigDecimal! @aggregate(fn: "max", arg: "price")
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")

--- a/graph/src/schema/test_schemas/ts_no_timeseries.graphql
+++ b/graph/src/schema/test_schemas/ts_no_timeseries.graphql
@@ -1,7 +1,7 @@
 # fail: EntityDirectivesMissing
 type Stats {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Bytes!
   avg: BigDecimal! @aggregate(fn: "avg", arg: "price")
   sum: BigInt! @aggregate(fn: "sum", arg: "price")

--- a/graph/src/schema/test_schemas/ts_no_timestamp.graphql
+++ b/graph/src/schema/test_schemas/ts_no_timestamp.graphql
@@ -6,7 +6,7 @@ type Token @entity {
 
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   price: BigDecimal!
 }

--- a/graph/src/schema/test_schemas/ts_valid.graphql
+++ b/graph/src/schema/test_schemas/ts_valid.graphql
@@ -6,14 +6,14 @@ type Token @entity {
 
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   token: Token!
   max: BigDecimal! @aggregate(fn: "max", arg: "price")
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")

--- a/graph/src/schema/test_schemas/ts_valid_cumulative.graphql
+++ b/graph/src/schema/test_schemas/ts_valid_cumulative.graphql
@@ -1,12 +1,12 @@
 # valid: Minimal example
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price", cumulative: true)
 }

--- a/graph/src/schema/test_schemas/ts_wrong_interval.graphql
+++ b/graph/src/schema/test_schemas/ts_wrong_interval.graphql
@@ -1,12 +1,12 @@
 # fail: AggregationWrongIntervals
 type Data @entity(timeseries: true) {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   price: BigDecimal!
 }
 
 type Stats @aggregation(intervals: [60, 1440], source: "Data") {
   id: Int8!
-  timestamp: Int8!
+  timestamp: Timestamp!
   sum: BigDecimal! @aggregate(fn: "sum", arg: "price")
 }

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -1667,13 +1667,13 @@ async fn test_store_ts() {
     let schema = r#"
     type Data @entity(timeseries: true) {
         id: Int8!
-        timestamp: Int8!
+        timestamp: Timestamp!
         amount: BigDecimal!
     }
 
     type Stats @aggregation(intervals: ["hour"], source: "Data") {
         id: Int8!
-        timestamp: Int8!
+        timestamp: Timestamp!
         max: BigDecimal! @aggregate(fn: "max", arg:"amount")
     }"#;
 

--- a/store/postgres/src/relational/ddl_tests.rs
+++ b/store/postgres/src/relational/ddl_tests.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-// use pretty_assertions::assert_eq;
+use pretty_assertions::assert_eq;
 
 use super::*;
 
@@ -625,13 +625,13 @@ create index attr_0_1_thing_orientation
 const TS_GQL: &str = r#"
 type Data @entity(timeseries: true) {
     id: Int8!
-    timestamp: Int8!
+    timestamp: Timestamp!
     amount: BigDecimal!
 }
 
 type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
     id:        Int8!
-    timestamp: Int8!
+    timestamp: Timestamp!
     volume:    BigDecimal! @aggregate(fn: "sum", arg: "amount")
     maxPrice:  BigDecimal! @aggregate(fn: "max", arg: "amount")
 }
@@ -642,7 +642,7 @@ create table "sgd0815"."data" (
     vid                  bigserial primary key,
     block$                int not null,
     "id"                 int8 not null,
-    "timestamp"          int8 not null,
+    "timestamp"          timestamptz not null,
     "amount"             numeric not null,
     unique(id)
 );
@@ -657,7 +657,7 @@ create table "sgd0815"."stats_hour" (
     vid                  bigserial primary key,
     block$                int not null,
     "id"                 int8 not null,
-    "timestamp"          int8 not null,
+    "timestamp"          timestamptz not null,
     "volume"             numeric not null,
     "max_price"          numeric not null,
     unique(id)
@@ -675,7 +675,7 @@ create table "sgd0815"."stats_day" (
     vid                  bigserial primary key,
     block$               int not null,
     "id"                 int8 not null,
-    "timestamp"          int8 not null,
+    "timestamp"          timestamptz not null,
     "volume"             numeric not null,
     "max_price"          numeric not null,
     unique(id)
@@ -692,7 +692,7 @@ create index attr_2_2_stats_day_max_price
 const LIFETIME_GQL: &str = r#"
     type Data @entity(timeseries: true) {
         id: Int8!
-        timestamp: Int8!
+        timestamp: Timestamp!
         group1: Int!
         group2: Int!
         amount: BigDecimal!
@@ -700,20 +700,20 @@ const LIFETIME_GQL: &str = r#"
 
     type Stats1 @aggregation(intervals: ["hour", "day"], source: "Data") {
         id:        Int8!
-        timestamp: Int8!
+        timestamp: Timestamp!
         volume:    BigDecimal! @aggregate(fn: "sum", arg: "amount", cumulative: true)
     }
 
     type Stats2 @aggregation(intervals: ["hour", "day"], source: "Data") {
         id:        Int8!
-        timestamp: Int8!
+        timestamp: Timestamp!
         group1: Int!
         volume:    BigDecimal! @aggregate(fn: "sum", arg: "amount", cumulative: true)
     }
 
     type Stats3 @aggregation(intervals: ["hour", "day"], source: "Data") {
         id:        Int8!
-        timestamp: Int8!
+        timestamp: Timestamp!
         group2: Int!
         group1: Int!
         volume:    BigDecimal! @aggregate(fn: "sum", arg: "amount", cumulative: true)
@@ -721,7 +721,7 @@ const LIFETIME_GQL: &str = r#"
 
     type Stats2 @aggregation(intervals: ["hour", "day"], source: "Data") {
         id:        Int8!
-        timestamp: Int8!
+        timestamp: Timestamp!
         group1: Int!
         group2: Int!
         volume:    BigDecimal! @aggregate(fn: "sum", arg: "amount", cumulative: true)
@@ -733,7 +733,7 @@ create table "sgd0815"."data" (
     vid                  bigserial primary key,
     block$                int not null,
 "id"                 int8 not null,
-    "timestamp"          int8 not null,
+    "timestamp"          timestamptz not null,
     "group_1"            int4 not null,
     "group_2"            int4 not null,
     "amount"             numeric not null,
@@ -759,7 +759,7 @@ create table "sgd0815"."stats_1_hour" (
     vid                  bigserial primary key,
     block$                int not null,
 "id"                 int8 not null,
-    "timestamp"          int8 not null,
+    "timestamp"          timestamptz not null,
     "volume"             numeric not null,
     unique(id)
 );
@@ -775,7 +775,7 @@ create table "sgd0815"."stats_1_day" (
     vid                  bigserial primary key,
     block$                int not null,
 "id"                 int8 not null,
-    "timestamp"          int8 not null,
+    "timestamp"          timestamptz not null,
     "volume"             numeric not null,
     unique(id)
 );
@@ -791,7 +791,7 @@ create table "sgd0815"."stats_2_hour" (
     vid                  bigserial primary key,
     block$                int not null,
 "id"                 int8 not null,
-    "timestamp"          int8 not null,
+    "timestamp"          timestamptz not null,
     "group_1"            int4 not null,
     "volume"             numeric not null,
     unique(id)
@@ -810,7 +810,7 @@ create table "sgd0815"."stats_2_day" (
     vid                  bigserial primary key,
     block$                int not null,
 "id"                 int8 not null,
-    "timestamp"          int8 not null,
+    "timestamp"          timestamptz not null,
     "group_1"            int4 not null,
     "volume"             numeric not null,
     unique(id)
@@ -829,7 +829,7 @@ create table "sgd0815"."stats_3_hour" (
     vid                  bigserial primary key,
     block$                int not null,
 "id"                 int8 not null,
-    "timestamp"          int8 not null,
+    "timestamp"          timestamptz not null,
     "group_2"            int4 not null,
     "group_1"            int4 not null,
     "volume"             numeric not null,
@@ -851,7 +851,7 @@ create table "sgd0815"."stats_3_day" (
     vid                  bigserial primary key,
     block$                int not null,
 "id"                 int8 not null,
-    "timestamp"          int8 not null,
+    "timestamp"          timestamptz not null,
     "group_2"            int4 not null,
     "group_1"            int4 not null,
     "volume"             numeric not null,

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -836,6 +836,7 @@ impl Comparison {
                 Value::String(_)
                 | Value::Int(_)
                 | Value::Int8(_)
+                | Value::Timestamp(_)
                 | Value::BigDecimal(_)
                 | Value::BigInt(_)
                 | Value::Bytes(_),
@@ -846,7 +847,7 @@ impl Comparison {
                 | Comparison::LessOrEqual
                 | Comparison::GreaterOrEqual
                 | Comparison::Greater,
-                Value::Timestamp(_) | Value::Bool(_) | Value::List(_) | Value::Null,
+                Value::Bool(_) | Value::List(_) | Value::Null,
             )
             | (Comparison::Match, _) => {
                 return Err(StoreError::UnsupportedFilter(

--- a/store/test-store/tests/graphql/query.rs
+++ b/store/test-store/tests/graphql/query.rs
@@ -826,6 +826,44 @@ fn can_query_one_to_one_relationship() {
 }
 
 #[test]
+fn can_filter_by_timestamp() {
+    const QUERY1: &str = "
+    query {
+        musicians(first: 100, orderBy: id, where: { birthDate_gt: \"1710837304040955\" }) {
+            name
+        }
+    }
+    ";
+
+    const QUERY2: &str = "
+    query {
+        musicians(first: 100, orderBy: id, where: { birthDate_lt: \"1710837304040955\" }) {
+            name
+        }
+    }
+    ";
+
+    run_query(QUERY1, |result, _| {
+        let exp = object! {
+            musicians: vec![
+                object! { name: "John" },
+                object! { name: "Lisa" },
+                object! { name: "Tom" },
+                object! { name: "Valerie" }
+            ],
+        };
+        let data = extract_data!(result).unwrap();
+        assert_eq!(data, exp);
+    });
+
+    run_query(QUERY2, |result, _| {
+        let exp = object! { musicians: Vec::<r::Value>::new() };
+        let data = extract_data!(result).unwrap();
+        assert_eq!(data, exp);
+    })
+}
+
+#[test]
 fn can_query_one_to_many_relationships_in_both_directions() {
     const QUERY: &str = "
     query {


### PR DESCRIPTION
Timeseries and aggregations now use `Timestamp` as the type of the mandatory `timestamp` field