### PR TITLE
feat(starknet): firehose trigger filter

### DIFF
--- a/chain/starknet/src/adapter.rs
+++ b/chain/starknet/src/adapter.rs
@@ -1,3 +1,5 @@
+use std::collections::{hash_map::Entry, HashMap};
+
 use graph::{
     blockchain::{EmptyNodeCapabilities, TriggerFilter as TriggerFilterTrait},
     components::store::BlockNumber,
@@ -5,12 +7,21 @@ use graph::{
 
 use crate::{
     data_source::{DataSource, DataSourceTemplate},
+    felt::Felt,
     Chain,
 };
 
+type TopicWithRanges = HashMap<Felt, Vec<BlockRange>>;
+
 #[derive(Default, Clone)]
 pub struct TriggerFilter {
+    pub(crate) event: StarknetEventFilter,
     pub(crate) block: StarknetBlockFilter,
+}
+
+#[derive(Default, Clone)]
+pub struct StarknetEventFilter {
+    pub contract_addresses: HashMap<Felt, TopicWithRanges>,
 }
 
 #[derive(Default, Clone)]
@@ -28,6 +39,8 @@ impl TriggerFilterTrait<Chain> for TriggerFilter {
     fn extend_with_template(&mut self, _data_source: impl Iterator<Item = DataSourceTemplate>) {}
 
     fn extend<'a>(&mut self, data_sources: impl Iterator<Item = &'a DataSource> + Clone) {
+        self.event
+            .extend(StarknetEventFilter::from_data_sources(data_sources.clone()));
         self.block
             .extend(StarknetBlockFilter::from_data_sources(data_sources));
     }
@@ -38,6 +51,86 @@ impl TriggerFilterTrait<Chain> for TriggerFilter {
 
     fn to_firehose_filter(self) -> Vec<prost_types::Any> {
         todo!()
+    }
+}
+
+impl StarknetEventFilter {
+    pub fn from_data_sources<'a>(iter: impl IntoIterator<Item = &'a DataSource>) -> Self {
+        iter.into_iter()
+            // Using `filter_map` instead of `filter` to avoid having to unwrap source address in
+            // `fold` below.
+            .filter_map(|data_source| {
+                if data_source.mapping.event_handlers.is_empty() {
+                    None
+                } else {
+                    data_source
+                        .source
+                        .address
+                        .as_ref()
+                        .map(|source_address| (data_source, source_address.to_owned()))
+                }
+            })
+            .fold(
+                Self::default(),
+                |mut filter_opt, (data_source, source_address)| {
+                    filter_opt.extend(Self {
+                        contract_addresses: [(
+                            source_address,
+                            data_source
+                                .mapping
+                                .event_handlers
+                                .iter()
+                                .map(|event_handler| {
+                                    (
+                                        event_handler.event_selector.clone(),
+                                        vec![BlockRange {
+                                            start_block: data_source.source.start_block,
+                                            end_block: data_source.source.end_block,
+                                        }],
+                                    )
+                                })
+                                .collect(),
+                        )]
+                        .into_iter()
+                        .collect(),
+                    });
+                    filter_opt
+                },
+            )
+    }
+
+    pub fn extend(&mut self, other: StarknetEventFilter) {
+        if other.is_empty() {
+            return;
+        }
+
+        let StarknetEventFilter { contract_addresses } = other;
+
+        for (address, topic_with_ranges) in contract_addresses.into_iter() {
+            match self.contract_addresses.entry(address) {
+                Entry::Occupied(entry) => {
+                    let entry = entry.into_mut();
+                    for (topic, mut block_ranges) in topic_with_ranges.into_iter() {
+                        match entry.entry(topic) {
+                            Entry::Occupied(topic_entry) => {
+                                // TODO: merge overlapping block ranges
+                                topic_entry.into_mut().append(&mut block_ranges);
+                            }
+                            Entry::Vacant(topic_entry) => {
+                                topic_entry.insert(block_ranges);
+                            }
+                        }
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(topic_with_ranges);
+                }
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.contract_addresses.is_empty()
     }
 }
 

--- a/chain/starknet/src/adapter.rs
+++ b/chain/starknet/src/adapter.rs
@@ -1,4 +1,7 @@
-use graph::blockchain::{EmptyNodeCapabilities, TriggerFilter as TriggerFilterTrait};
+use graph::{
+    blockchain::{EmptyNodeCapabilities, TriggerFilter as TriggerFilterTrait},
+    components::store::BlockNumber,
+};
 
 use crate::{
     data_source::{DataSource, DataSourceTemplate},
@@ -6,22 +9,69 @@ use crate::{
 };
 
 #[derive(Default, Clone)]
-pub struct TriggerFilter;
+pub struct TriggerFilter {
+    pub(crate) block: StarknetBlockFilter,
+}
+
+#[derive(Default, Clone)]
+pub struct StarknetBlockFilter {
+    pub block_ranges: Vec<BlockRange>,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct BlockRange {
+    pub start_block: BlockNumber,
+    pub end_block: Option<BlockNumber>,
+}
 
 impl TriggerFilterTrait<Chain> for TriggerFilter {
-    #[allow(unused)]
-    fn extend_with_template(&mut self, data_source: impl Iterator<Item = DataSourceTemplate>) {
-        todo!()
+    fn extend_with_template(&mut self, _data_source: impl Iterator<Item = DataSourceTemplate>) {}
+
+    fn extend<'a>(&mut self, data_sources: impl Iterator<Item = &'a DataSource> + Clone) {
+        self.block
+            .extend(StarknetBlockFilter::from_data_sources(data_sources));
     }
 
-    #[allow(unused)]
-    fn extend<'a>(&mut self, data_sources: impl Iterator<Item = &'a DataSource> + Clone) {}
-
     fn node_capabilities(&self) -> EmptyNodeCapabilities<Chain> {
-        todo!()
+        Default::default()
     }
 
     fn to_firehose_filter(self) -> Vec<prost_types::Any> {
         todo!()
+    }
+}
+
+impl StarknetBlockFilter {
+    pub fn from_data_sources<'a>(iter: impl IntoIterator<Item = &'a DataSource>) -> Self {
+        iter.into_iter()
+            .filter(|data_source| data_source.mapping.block_handler.is_some())
+            .fold(Self::default(), |mut filter_opt, data_source| {
+                filter_opt.extend(Self {
+                    block_ranges: vec![BlockRange {
+                        start_block: data_source.source.start_block,
+                        end_block: data_source.source.end_block,
+                    }],
+                });
+                filter_opt
+            })
+    }
+
+    pub fn extend(&mut self, other: StarknetBlockFilter) {
+        if other.is_empty() {
+            return;
+        }
+
+        let StarknetBlockFilter { block_ranges } = other;
+
+        // TODO: merge overlapping block ranges
+        for new_range in block_ranges.into_iter() {
+            if !self.block_ranges.contains(&new_range) {
+                self.block_ranges.push(new_range);
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.block_ranges.is_empty()
     }
 }

--- a/chain/starknet/src/felt.rs
+++ b/chain/starknet/src/felt.rs
@@ -3,12 +3,12 @@ use std::{
     str::FromStr,
 };
 
-use graph::anyhow;
+use graph::anyhow::{self, anyhow};
 use serde::{de::Visitor, Deserialize};
 
 /// Represents the primitive `FieldElement` type used in Starknet. Each `FieldElement` is 252-bit
 /// in size.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Hash, Clone, PartialEq, Eq)]
 pub struct Felt([u8; 32]);
 
 struct FeltVisitor;
@@ -22,6 +22,21 @@ impl Debug for Felt {
 impl From<[u8; 32]> for Felt {
     fn from(value: [u8; 32]) -> Self {
         Self(value)
+    }
+}
+
+impl TryFrom<&[u8]> for Felt {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() > 32 {
+            Err(anyhow!("slice too long"))
+        } else {
+            let mut buffer = [0u8; 32];
+            buffer[(32 - value.len())..].copy_from_slice(value);
+
+            Ok(buffer.into())
+        }
     }
 }
 

--- a/chain/starknet/src/felt.rs
+++ b/chain/starknet/src/felt.rs
@@ -63,6 +63,12 @@ impl FromStr for Felt {
     }
 }
 
+impl From<&Felt> for Vec<u8> {
+    fn from(value: &Felt) -> Self {
+        value.0.to_vec()
+    }
+}
+
 impl<'de> Deserialize<'de> for Felt {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/graph/build.rs
+++ b/graph/build.rs
@@ -8,6 +8,7 @@ fn main() {
                 "proto/ethereum/transforms.proto",
                 "proto/near/transforms.proto",
                 "proto/cosmos/transforms.proto",
+                "proto/starknet/transforms.proto",
             ],
             &["proto"],
         )

--- a/graph/proto/starknet/transforms.proto
+++ b/graph/proto/starknet/transforms.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+package zklend.starknet.transform.v1;
+
+option go_package = "github.com/starknet-graph/firehose-starknet/types/pb/zklend/starknet/type/v1;pbtransform";
+
+// Stream block headers only. The `transactions` field is always empty.
+message BlockHeaderOnly {}
+
+// Stream every single block, but each block will only contain transactions that match with `event_filters`.
+// A TransactionEventFilter message with an empty `event_filters` is invalid. Do not send any filter instead
+// if you wish to receive full blocks.
+message TransactionEventFilter {
+  repeated ContractEventFilter event_filters = 1;
+}
+
+// Only include transactions which emit at least one event that *BOTH*
+// * is emitted by `contract_address`
+// * matches with at least one topic in `topics`
+message ContractEventFilter {
+  bytes contract_address = 1;
+  repeated TopicWithRanges topics = 2;
+}
+
+// Matches events whose `keys[0]` equals `topic`, *AND* in any of the `block_ranges`.
+message TopicWithRanges {
+  bytes topic = 1;
+  repeated BlockRange block_ranges = 2;
+}
+
+// A range of blocks. Both `start_block` and `end_block` are inclusive. When `end_block` is `0`, it means that any
+// block height >= `start_block` is matched.
+message BlockRange {
+  uint64 start_block = 1;
+  uint64 end_block = 2;
+}

--- a/graph/src/firehose/codec.rs
+++ b/graph/src/firehose/codec.rs
@@ -14,7 +14,12 @@ mod pbnear;
 #[path = "sf.cosmos.transform.v1.rs"]
 mod pbcosmos;
 
+#[rustfmt::skip]
+#[path = "zklend.starknet.transform.v1.rs"]
+mod pbstarknet;
+
 pub use pbcosmos::*;
 pub use pbethereum::*;
 pub use pbfirehose::*;
 pub use pbnear::*;
+pub use pbstarknet::*;

--- a/graph/src/firehose/zklend.starknet.transform.v1.rs
+++ b/graph/src/firehose/zklend.starknet.transform.v1.rs
@@ -1,0 +1,43 @@
+/// Stream block headers only. The `transactions` field is always empty.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BlockHeaderOnly {}
+/// Stream every single block, but each block will only contain transactions that match with `event_filters`.
+/// A TransactionEventFilter message with an empty `event_filters` is invalid. Do not send any filter instead
+/// if you wish to receive full blocks.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransactionEventFilter {
+    #[prost(message, repeated, tag = "1")]
+    pub event_filters: ::prost::alloc::vec::Vec<ContractEventFilter>,
+}
+/// Only include transactions which emit at least one event that *BOTH*
+/// * is emitted by `contract_address`
+/// * matches with at least one topic in `topics`
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ContractEventFilter {
+    #[prost(bytes = "vec", tag = "1")]
+    pub contract_address: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, repeated, tag = "2")]
+    pub topics: ::prost::alloc::vec::Vec<TopicWithRanges>,
+}
+/// Matches events whose `keys\[0\]` equals `topic`, *AND* in any of the `block_ranges`.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TopicWithRanges {
+    #[prost(bytes = "vec", tag = "1")]
+    pub topic: ::prost::alloc::vec::Vec<u8>,
+    #[prost(message, repeated, tag = "2")]
+    pub block_ranges: ::prost::alloc::vec::Vec<BlockRange>,
+}
+/// A range of blocks. Both `start_block` and `end_block` are inclusive. When `end_block` is `0`, it means that any
+/// block height >= `start_block` is matched.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BlockRange {
+    #[prost(uint64, tag = "1")]
+    pub start_block: u64,
+    #[prost(uint64, tag = "2")]
+    pub end_block: u64,
+}


### PR DESCRIPTION
Supersedes #5201.

This PR adds 2 trigger filters to Starknet:

- block trigger that specifies a list of ranges
- event trigger that's capable of filtering by contract address, event topic, _and_ block ranges

When used without turning on the `filters` feature on the Firehose provider, these filters only work on the `graph-node` side - meaning that full blocks are still always streamed to `graph-node`. Filters are applied _only to avoid excessive trigger parsing_. This part was what #5201 enabled.

What's new in this new PR is the additional implementation of Firhose triggers (i.e. `to_firehose_filter`), allowing `graph-node` to send a `transforms` field in its Firehose stream subscription requests when the `filters` feature is enabled for the provider. Note that all blocks are still always streamed - the filters only affects the list of transactions that are included.

`firehose-starknet` has already [implemented](https://github.com/starknet-graph/firehose-starknet/commit/ec0ae1e3df841635923ff15f99150c8f03fbb950) support for filters. This PR has been tested against that implementation and it works as expected - blocks without matching events have empty transactions, and those with matching ones only come with relevant transactions.