### PR TITLE
Derive macros for `CheapClone` and `CacheWeight`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,7 @@ name = "graph_derive"
 version = "0.34.0"
 dependencies = [
  "heck",
+ "proc-macro-utils",
  "proc-macro2",
  "quote",
  "syn 1.0.107",
@@ -3446,6 +3447,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c465d89134af1993ccbe4d4c859af29e73f049775f8174beb1de4789c7639a4a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,6 +1505,7 @@ dependencies = [
  "ethabi",
  "futures 0.1.31",
  "futures 0.3.16",
+ "graph_derive",
  "graphql-parser",
  "hex",
  "hex-literal 0.4.1",
@@ -1904,6 +1905,16 @@ dependencies = [
  "slog",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "graph_derive"
+version = "0.34.0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "substreams/*",
     "graph",
     "tests",
+    "graph/derive",
 ]
 
 [workspace.package]

--- a/chain/arweave/src/trigger.rs
+++ b/chain/arweave/src/trigger.rs
@@ -1,7 +1,7 @@
 use graph::blockchain::Block;
 use graph::blockchain::MappingTriggerTrait;
 use graph::blockchain::TriggerData;
-use graph::cheap_clone::CheapClone;
+use graph::derive::CheapClone;
 use graph::prelude::web3::types::H256;
 use graph::prelude::BlockNumber;
 use graph::runtime::asc_new;
@@ -47,19 +47,10 @@ impl ToAscPtr for ArweaveTrigger {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, CheapClone)]
 pub enum ArweaveTrigger {
     Block(Arc<codec::Block>),
     Transaction(Arc<TransactionWithBlockPtr>),
-}
-
-impl CheapClone for ArweaveTrigger {
-    fn cheap_clone(&self) -> ArweaveTrigger {
-        match self {
-            ArweaveTrigger::Block(block) => ArweaveTrigger::Block(block.cheap_clone()),
-            ArweaveTrigger::Transaction(tx) => ArweaveTrigger::Transaction(tx.cheap_clone()),
-        }
-    }
 }
 
 impl PartialEq for ArweaveTrigger {

--- a/chain/cosmos/src/data_source.rs
+++ b/chain/cosmos/src/data_source.rs
@@ -8,6 +8,7 @@ use graph::{
     blockchain::{self, Block, Blockchain, TriggerWithHandler},
     components::store::StoredDynamicDataSource,
     data::subgraph::DataSourceContext,
+    derive::CheapClone,
     prelude::{
         anyhow, async_trait, BlockNumber, CheapClone, Deserialize, Link, LinkResolver, Logger,
     },
@@ -517,7 +518,7 @@ pub struct Source {
     pub(crate) end_block: Option<BlockNumber>,
 }
 
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Deserialize)]
+#[derive(Clone, Copy, CheapClone, Debug, Hash, Eq, PartialEq, Deserialize)]
 pub enum EventOrigin {
     BeginBlock,
     DeliverTx,

--- a/chain/cosmos/src/trigger.rs
+++ b/chain/cosmos/src/trigger.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, sync::Arc};
 
 use graph::blockchain::{Block, BlockHash, MappingTriggerTrait, TriggerData};
-use graph::cheap_clone::CheapClone;
+use graph::derive::CheapClone;
 use graph::prelude::{BlockNumber, Error};
 use graph::runtime::HostExportError;
 use graph::runtime::{asc_new, gas::GasCounter, AscHeap, AscPtr};
@@ -59,7 +59,7 @@ impl ToAscPtr for CosmosTrigger {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, CheapClone)]
 pub enum CosmosTrigger {
     Block(Arc<codec::Block>),
     Event {
@@ -69,8 +69,6 @@ pub enum CosmosTrigger {
     Transaction(Arc<codec::TransactionData>),
     Message(Arc<codec::MessageData>),
 }
-
-impl CheapClone for CosmosTrigger {}
 
 impl PartialEq for CosmosTrigger {
     fn eq(&self, other: &Self) -> bool {

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -27,6 +27,7 @@ use tiny_keccak::{keccak256, Keccak};
 
 use graph::{
     blockchain::{self, Blockchain},
+    derive::CheapClone,
     prelude::{
         async_trait,
         ethabi::{Address, Contract, Event, Function, LogParam, ParamType, RawLog},
@@ -1576,13 +1577,11 @@ pub struct TemplateSource {
 /// The `address` and `arg` fields can be either `event.address` or
 /// `event.params.<name>`. Each entry under `calls` gets turned into a
 /// `CallDcl`
-#[derive(Clone, Debug, Default, Hash, Eq, PartialEq)]
+#[derive(Clone, CheapClone, Debug, Default, Hash, Eq, PartialEq)]
 pub struct CallDecls {
     pub decls: Arc<Vec<CallDecl>>,
     readonly: (),
 }
-
-impl CheapClone for CallDecls {}
 
 /// A single call declaration, like `myCall1:
 /// Contract[address].function(arg1, arg2, ...)`

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -8,6 +8,7 @@ use graph::data::store::ethereum::call;
 use graph::data::store::scalar;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::data::subgraph::API_VERSION_0_0_7;
+use graph::derive::CheapClone;
 use graph::prelude::ethabi::ParamType;
 use graph::prelude::ethabi::Token;
 use graph::prelude::futures03::future::try_join_all;
@@ -63,7 +64,7 @@ use crate::{
     TriggerFilter, ENV_VARS,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, CheapClone)]
 pub struct EthereumAdapter {
     logger: Logger,
     provider: String,
@@ -71,19 +72,6 @@ pub struct EthereumAdapter {
     metrics: Arc<ProviderEthRpcMetrics>,
     supports_eip_1898: bool,
     call_only: bool,
-}
-
-impl CheapClone for EthereumAdapter {
-    fn cheap_clone(&self) -> Self {
-        Self {
-            logger: self.logger.clone(),
-            provider: self.provider.clone(),
-            web3: self.web3.cheap_clone(),
-            metrics: self.metrics.cheap_clone(),
-            supports_eip_1898: self.supports_eip_1898,
-            call_only: self.call_only,
-        }
-    }
 }
 
 impl EthereumAdapter {

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -8,7 +8,6 @@ use graph::data::store::ethereum::call;
 use graph::data::store::scalar;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::data::subgraph::API_VERSION_0_0_7;
-use graph::derive::CheapClone;
 use graph::prelude::ethabi::ParamType;
 use graph::prelude::ethabi::Token;
 use graph::prelude::futures03::future::try_join_all;
@@ -64,7 +63,7 @@ use crate::{
     TriggerFilter, ENV_VARS,
 };
 
-#[derive(Debug, Clone, CheapClone)]
+#[derive(Debug, Clone)]
 pub struct EthereumAdapter {
     logger: Logger,
     provider: String,
@@ -72,6 +71,19 @@ pub struct EthereumAdapter {
     metrics: Arc<ProviderEthRpcMetrics>,
     supports_eip_1898: bool,
     call_only: bool,
+}
+
+impl CheapClone for EthereumAdapter {
+    fn cheap_clone(&self) -> Self {
+        Self {
+            logger: self.logger.clone(),
+            provider: self.provider.clone(),
+            web3: self.web3.cheap_clone(),
+            metrics: self.metrics.cheap_clone(),
+            supports_eip_1898: self.supports_eip_1898,
+            call_only: self.call_only,
+        }
+    }
 }
 
 impl EthereumAdapter {

--- a/chain/near/src/trigger.rs
+++ b/chain/near/src/trigger.rs
@@ -1,7 +1,7 @@
 use graph::blockchain::Block;
 use graph::blockchain::MappingTriggerTrait;
 use graph::blockchain::TriggerData;
-use graph::cheap_clone::CheapClone;
+use graph::derive::CheapClone;
 use graph::prelude::hex;
 use graph::prelude::web3::types::H256;
 use graph::prelude::BlockNumber;
@@ -50,19 +50,10 @@ impl ToAscPtr for NearTrigger {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, CheapClone)]
 pub enum NearTrigger {
     Block(Arc<codec::Block>),
     Receipt(Arc<ReceiptWithOutcome>),
-}
-
-impl CheapClone for NearTrigger {
-    fn cheap_clone(&self) -> NearTrigger {
-        match self {
-            NearTrigger::Block(block) => NearTrigger::Block(block.cheap_clone()),
-            NearTrigger::Receipt(receipt) => NearTrigger::Receipt(receipt.cheap_clone()),
-        }
-    }
 }
 
 impl PartialEq for NearTrigger {

--- a/core/src/polling_monitor/arweave_service.rs
+++ b/core/src/polling_monitor/arweave_service.rs
@@ -13,13 +13,11 @@ pub type ArweaveService = Buffer<Base64, BoxFuture<'static, Result<Option<Bytes>
 
 pub fn arweave_service(
     client: Arc<ArweaveClient>,
-    timeout: Duration,
     rate_limit: u16,
     max_file_size: FileSizeLimit,
 ) -> ArweaveService {
     let arweave = ArweaveServiceInner {
         client,
-        timeout,
         max_file_size,
     };
 
@@ -36,7 +34,6 @@ pub fn arweave_service(
 #[derive(Clone)]
 struct ArweaveServiceInner {
     client: Arc<ArweaveClient>,
-    timeout: Duration,
     max_file_size: FileSizeLimit,
 }
 
@@ -44,7 +41,6 @@ impl CheapClone for ArweaveServiceInner {
     fn cheap_clone(&self) -> Self {
         Self {
             client: self.client.cheap_clone(),
-            timeout: self.timeout,
             max_file_size: self.max_file_size.cheap_clone(),
         }
     }

--- a/core/src/polling_monitor/arweave_service.rs
+++ b/core/src/polling_monitor/arweave_service.rs
@@ -4,6 +4,7 @@ use futures::future::BoxFuture;
 use graph::{
     components::link_resolver::{ArweaveClient, ArweaveResolver, FileSizeLimit},
     data_source::offchain::Base64,
+    derive::CheapClone,
     prelude::CheapClone,
 };
 use std::{sync::Arc, time::Duration};
@@ -31,19 +32,10 @@ pub fn arweave_service(
     Buffer::new(svc, u32::MAX as usize)
 }
 
-#[derive(Clone)]
+#[derive(Clone, CheapClone)]
 struct ArweaveServiceInner {
     client: Arc<ArweaveClient>,
     max_file_size: FileSizeLimit,
-}
-
-impl CheapClone for ArweaveServiceInner {
-    fn cheap_clone(&self) -> Self {
-        Self {
-            client: self.client.cheap_clone(),
-            max_file_size: self.max_file_size.cheap_clone(),
-        }
-    }
 }
 
 impl ArweaveServiceInner {

--- a/core/src/polling_monitor/ipfs_service.rs
+++ b/core/src/polling_monitor/ipfs_service.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Error};
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use graph::{
+    derive::CheapClone,
     ipfs_client::{CidFile, IpfsClient},
     prelude::CheapClone,
 };
@@ -35,21 +36,11 @@ pub fn ipfs_service(
     Buffer::new(svc, u32::MAX as usize)
 }
 
-#[derive(Clone)]
+#[derive(Clone, CheapClone)]
 struct IpfsServiceInner {
     client: IpfsClient,
     max_file_size: usize,
     timeout: Duration,
-}
-
-impl CheapClone for IpfsServiceInner {
-    fn cheap_clone(&self) -> Self {
-        Self {
-            client: self.client.cheap_clone(),
-            max_file_size: self.max_file_size,
-            timeout: self.timeout,
-        }
-    }
 }
 
 impl IpfsServiceInner {

--- a/core/src/subgraph/context/mod.rs
+++ b/core/src/subgraph/context/mod.rs
@@ -17,6 +17,7 @@ use graph::{
         offchain::{self, Base64},
         CausalityRegion, DataSource, DataSourceTemplate,
     },
+    derive::CheapClone,
     ipfs_client::CidFile,
     prelude::{
         BlockNumber, BlockPtr, BlockState, CancelGuard, CheapClone, DeploymentHash,
@@ -33,13 +34,11 @@ use self::instance::SubgraphInstance;
 
 use super::Decoder;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, CheapClone, Debug)]
 pub struct SubgraphKeepAlive {
     alive_map: Arc<RwLock<HashMap<DeploymentId, CancelGuard>>>,
     sg_metrics: Arc<SubgraphCountMetric>,
 }
-
-impl CheapClone for SubgraphKeepAlive {}
 
 impl SubgraphKeepAlive {
     pub fn new(sg_metrics: Arc<SubgraphCountMetric>) -> Self {

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -14,6 +14,7 @@ atomic_refcell = "0.1.13"
 old_bigdecimal = { version = "=0.1.2", features = ["serde"], package = "bigdecimal" }
 bytes = "1.0.1"
 cid = "0.11.0"
+graph_derive = { path = "./derive" }
 diesel = { workspace = true }
 diesel_derives = { workspace = true }
 chrono = "0.4.31"

--- a/graph/derive/Cargo.toml
+++ b/graph/derive/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "graph_derive"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "1.0.98", features = ["full"] }
+quote = "1.0"
+proc-macro2 = "1.0.73"
+heck = "0.4"

--- a/graph/derive/Cargo.toml
+++ b/graph/derive/Cargo.toml
@@ -16,3 +16,6 @@ syn = { version = "1.0.98", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0.73"
 heck = "0.4"
+
+[dev-dependencies]
+proc-macro-utils = "0.9.1"

--- a/graph/derive/src/lib.rs
+++ b/graph/derive/src/lib.rs
@@ -1,30 +1,131 @@
+#![recursion_limit = "256"]
+
 use proc_macro::TokenStream;
-use proc_macro2::Span;
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, Ident, Index};
+use syn::{parse_macro_input, Data, DeriveInput, Fields, Generics, Ident, Index, TypeParamBound};
 
 #[proc_macro_derive(CheapClone)]
 pub fn derive_cheap_clone(input: TokenStream) -> TokenStream {
-    // Parse the input tokens into a syntax tree
-    let input = parse_macro_input!(input as DeriveInput);
-    let crate_name = std::env::var("CARGO_PKG_NAME").unwrap();
+    impl_cheap_clone(input.into()).into()
+}
 
-    let cheap_clone = if crate_name == "graph" {
-        quote! { crate::cheap_clone::CheapClone }
-    } else {
-        quote! { graph::cheap_clone::CheapClone }
+fn impl_cheap_clone(input: TokenStream2) -> TokenStream2 {
+    fn constrain_generics(generics: &Generics, bound: &TypeParamBound) -> Generics {
+        let mut generics = generics.clone();
+        for ty in generics.type_params_mut() {
+            ty.bounds.push(bound.clone());
+        }
+        generics
+    }
+
+    fn cheap_clone_path() -> TokenStream2 {
+        let crate_name = std::env::var("CARGO_PKG_NAME").unwrap();
+        if crate_name == "graph" {
+            quote! { crate::cheap_clone::CheapClone }
+        } else {
+            quote! { graph::cheap_clone::CheapClone }
+        }
+    }
+
+    fn cheap_clone_body(data: Data) -> TokenStream2 {
+        match data {
+            Data::Struct(st) => match &st.fields {
+                Fields::Unit => return quote! { Self  },
+                Fields::Unnamed(fields) => {
+                    let mut field_clones = Vec::new();
+                    for (num, _) in fields.unnamed.iter().enumerate() {
+                        let idx = Index::from(num);
+                        field_clones.push(quote! { self.#idx.cheap_clone() });
+                    }
+                    quote! { Self(#(#field_clones,)*) }
+                }
+                Fields::Named(fields) => {
+                    let mut field_clones = Vec::new();
+                    for field in fields.named.iter() {
+                        let ident = field.ident.as_ref().unwrap();
+                        field_clones.push(quote! { #ident: self.#ident.cheap_clone() });
+                    }
+                    quote! {
+                        Self {
+                            #(#field_clones,)*
+                        }
+                    }
+                }
+            },
+            Data::Enum(en) => {
+                let mut arms = Vec::new();
+                for variant in en.variants {
+                    let ident = variant.ident;
+                    match variant.fields {
+                        Fields::Named(fields) => {
+                            let mut idents = Vec::new();
+                            let mut clones = Vec::new();
+                            for field in fields.named {
+                                let ident = field.ident.unwrap();
+                                idents.push(ident.clone());
+                                clones.push(quote! { #ident: #ident.cheap_clone() });
+                            }
+                            arms.push(quote! {
+                                Self::#ident{#(#idents,)*} => Self::#ident{#(#clones,)*}
+                            });
+                        }
+                        Fields::Unnamed(fields) => {
+                            let num_fields = fields.unnamed.len();
+                            let idents = (0..num_fields)
+                                .map(|i| Ident::new(&format!("v{}", i), Span::call_site()))
+                                .collect::<Vec<_>>();
+                            let mut cloned = Vec::new();
+                            for ident in &idents {
+                                cloned.push(quote! { #ident.cheap_clone() });
+                            }
+                            arms.push(quote! {
+                                Self::#ident(#(#idents,)*) => Self::#ident(#(#cloned,)*)
+                            });
+                        }
+                        Fields::Unit => {
+                            arms.push(quote! { Self::#ident => Self::#ident });
+                        }
+                    }
+                }
+                quote! {
+                    match self {
+                        #(#arms,)*
+                    }
+                }
+            }
+            Data::Union(_) => {
+                panic!("Deriving CheapClone for unions is currently not supported.")
+            }
+        }
+    }
+
+    let input = match syn::parse2::<DeriveInput>(input) {
+        Ok(input) => input,
+        Err(e) => {
+            return e.to_compile_error().into();
+        }
     };
+    let DeriveInput {
+        ident: name,
+        generics,
+        data,
+        ..
+    } = input;
 
-    let name = input.ident;
-    let generics = input.generics;
-    // Build the output, possibly using the input
+    let cheap_clone = cheap_clone_path();
+    let constrained = constrain_generics(&generics, &syn::parse_quote!(#cheap_clone));
+    let body = cheap_clone_body(data);
+
     let expanded = quote! {
-        // The generated impl
-        impl #generics #cheap_clone for #name #generics { }
+        impl #constrained #cheap_clone for #name #generics {
+            fn cheap_clone(&self) -> Self {
+                #body
+            }
+        }
     };
 
-    // Hand the output tokens back to the compiler
-    TokenStream::from(expanded)
+    expanded
 }
 
 #[proc_macro_derive(CacheWeight)]
@@ -116,7 +217,9 @@ pub fn derive_cache_weight(input: TokenStream) -> TokenStream {
                 #total
             }
         }
-        syn::Data::Union(_) => todo!(),
+        syn::Data::Union(_) => {
+            panic!("Deriving CacheWeight for unions is currently not supported.")
+        }
     };
     // Build the output, possibly using the input
     let expanded = quote! {
@@ -130,4 +233,81 @@ pub fn derive_cache_weight(input: TokenStream) -> TokenStream {
 
     // Hand the output tokens back to the compiler
     TokenStream::from(expanded)
+}
+
+#[cfg(test)]
+mod tests {
+    use proc_macro_utils::assert_expansion;
+
+    use super::impl_cheap_clone;
+
+    #[test]
+    fn cheap_clone() {
+        assert_expansion!(
+            #[derive(impl_cheap_clone)]
+            struct Empty;,
+            {
+                impl graph::cheap_clone::CheapClone for Empty {
+                    fn cheap_clone(&self) -> Self {
+                        Self
+                    }
+                }
+            }
+        );
+
+        assert_expansion!(
+            #[derive(impl_cheap_clone)]
+            struct Foo<T> {
+                a: T,
+                b: u32,
+            },
+            {
+                impl<T: graph::cheap_clone::CheapClone> graph::cheap_clone::CheapClone for Foo<T> {
+                    fn cheap_clone(&self) -> Self {
+                        Self {
+                            a: self.a.cheap_clone(),
+                            b: self.b.cheap_clone(),
+                        }
+                    }
+                }
+            }
+        );
+
+        #[rustfmt::skip]
+        assert_expansion!(
+            #[derive(impl_cheap_clone)]
+            struct Bar(u32, u32);,
+            {
+                impl graph::cheap_clone::CheapClone for Bar {
+                    fn cheap_clone(&self) -> Self {
+                        Self(self.0.cheap_clone(), self.1.cheap_clone(),)
+                    }
+                }
+            }
+        );
+
+        #[rustfmt::skip]
+        assert_expansion!(
+            #[derive(impl_cheap_clone)]
+            enum Bar {
+                A,
+                B(u32),
+                C { a: u32, b: u32 },
+            },
+            {
+                impl graph::cheap_clone::CheapClone for Bar {
+                    fn cheap_clone(&self) -> Self {
+                        match self {
+                            Self::A => Self::A,
+                            Self::B(v0,) => Self::B(v0.cheap_clone(),),
+                            Self::C { a, b, } => Self::C {
+                                a: a.cheap_clone(),
+                                b: b.cheap_clone(),
+                            },
+                        }
+                    }
+                }
+            }
+        );
+    }
 }

--- a/graph/derive/src/lib.rs
+++ b/graph/derive/src/lib.rs
@@ -1,6 +1,7 @@
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{parse_macro_input, DeriveInput, Ident, Index};
 
 #[proc_macro_derive(CheapClone)]
 pub fn derive_cheap_clone(input: TokenStream) -> TokenStream {
@@ -20,6 +21,111 @@ pub fn derive_cheap_clone(input: TokenStream) -> TokenStream {
     let expanded = quote! {
         // The generated impl
         impl #generics #cheap_clone for #name #generics { }
+    };
+
+    // Hand the output tokens back to the compiler
+    TokenStream::from(expanded)
+}
+
+#[proc_macro_derive(CacheWeight)]
+pub fn derive_cache_weight(input: TokenStream) -> TokenStream {
+    // Parse the input tokens into a syntax tree
+    let DeriveInput {
+        ident,
+        generics,
+        data,
+        ..
+    } = parse_macro_input!(input as DeriveInput);
+
+    let crate_name = std::env::var("CARGO_PKG_NAME").unwrap();
+    let cache_weight = if crate_name == "graph" {
+        quote! { crate::util::cache_weight::CacheWeight }
+    } else {
+        quote! { graph::util::cache_weight::CacheWeight }
+    };
+
+    let total = Ident::new("__total_cache_weight", Span::call_site());
+    let body = match data {
+        syn::Data::Struct(st) => {
+            let mut incrs: Vec<proc_macro2::TokenStream> = Vec::new();
+            for (num, field) in st.fields.iter().enumerate() {
+                let incr = match &field.ident {
+                    Some(ident) => quote! {
+                        #total += self.#ident.indirect_weight();
+                    },
+                    None => {
+                        let idx = Index::from(num);
+                        quote! {
+                            #total += self.#idx.indirect_weight();
+                        }
+                    }
+                };
+                incrs.push(incr);
+            }
+            quote! {
+                let mut #total = 0;
+                #(#incrs)*
+                #total
+            }
+        }
+        syn::Data::Enum(en) => {
+            let mut match_arms = Vec::new();
+            for variant in en.variants.into_iter() {
+                let ident = variant.ident;
+                match variant.fields {
+                    syn::Fields::Named(fields) => {
+                        let idents: Vec<_> =
+                            fields.named.into_iter().map(|f| f.ident.unwrap()).collect();
+
+                        let mut incrs = Vec::new();
+                        for ident in &idents {
+                            incrs.push(quote! { #total += #ident.indirect_weight(); });
+                        }
+                        match_arms.push(quote! {
+                            Self::#ident{#(#idents,)*} => {
+                                #(#incrs)*
+                            }
+                        });
+                    }
+                    syn::Fields::Unnamed(fields) => {
+                        let num_fields = fields.unnamed.len();
+
+                        let idents = (0..num_fields)
+                            .map(|i| {
+                                syn::Ident::new(&format!("v{}", i), proc_macro2::Span::call_site())
+                            })
+                            .collect::<Vec<_>>();
+                        let mut incrs = Vec::new();
+                        for ident in &idents {
+                            incrs.push(quote! { #total += #ident.indirect_weight(); });
+                        }
+                        match_arms.push(quote! {
+                            Self::#ident(#(#idents,)*) => {
+                                #(#incrs)*
+                            }
+                        });
+                    }
+                    syn::Fields::Unit => {
+                        match_arms.push(quote! { Self::#ident => { /* nothing to do */ }})
+                    }
+                };
+            }
+            quote! {
+                let mut #total = 0;
+                match &self { #(#match_arms)* };
+                #total
+            }
+        }
+        syn::Data::Union(_) => todo!(),
+    };
+    // Build the output, possibly using the input
+    let expanded = quote! {
+        // The generated impl
+        impl #generics #cache_weight for #ident #generics {
+            fn indirect_weight(&self) -> usize {
+              #body
+            }
+         }
     };
 
     // Hand the output tokens back to the compiler

--- a/graph/derive/src/lib.rs
+++ b/graph/derive/src/lib.rs
@@ -1,0 +1,27 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(CheapClone)]
+pub fn derive_cheap_clone(input: TokenStream) -> TokenStream {
+    // Parse the input tokens into a syntax tree
+    let input = parse_macro_input!(input as DeriveInput);
+    let crate_name = std::env::var("CARGO_PKG_NAME").unwrap();
+
+    let cheap_clone = if crate_name == "graph" {
+        quote! { crate::cheap_clone::CheapClone }
+    } else {
+        quote! { graph::cheap_clone::CheapClone }
+    };
+
+    let name = input.ident;
+    let generics = input.generics;
+    // Build the output, possibly using the input
+    let expanded = quote! {
+        // The generated impl
+        impl #generics #cheap_clone for #name #generics { }
+    };
+
+    // Hand the output tokens back to the compiler
+    TokenStream::from(expanded)
+}

--- a/graph/src/blockchain/mod.rs
+++ b/graph/src/blockchain/mod.rs
@@ -34,6 +34,7 @@ use crate::{
 };
 use anyhow::{anyhow, Context, Error};
 use async_trait::async_trait;
+use graph_derive::CheapClone;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use slog::Logger;
@@ -414,19 +415,10 @@ pub struct HostFnCtx<'a> {
 
 /// Host fn that receives one u32 argument and returns an u32.
 /// The name for an AS fuction is in the format `<namespace>.<function>`.
-#[derive(Clone)]
+#[derive(Clone, CheapClone)]
 pub struct HostFn {
     pub name: &'static str,
     pub func: Arc<dyn Send + Sync + Fn(HostFnCtx, u32) -> Result<u32, HostExportError>>,
-}
-
-impl CheapClone for HostFn {
-    fn cheap_clone(&self) -> Self {
-        HostFn {
-            name: self.name,
-            func: self.func.cheap_clone(),
-        }
-    }
 }
 
 pub trait RuntimeAdapter<C: Blockchain>: Send + Sync {

--- a/graph/src/blockchain/types.rs
+++ b/graph/src/blockchain/types.rs
@@ -10,15 +10,15 @@ use std::time::Duration;
 use std::{fmt, str::FromStr};
 use web3::types::{Block, H256};
 
+use crate::components::store::BlockNumber;
 use crate::data::graphql::IntoValue;
 use crate::data::store::scalar::Timestamp;
+use crate::derive::CheapClone;
 use crate::object;
 use crate::prelude::{r, BigInt, TryFromValue, Value, ValueMap};
 use crate::util::stable_hash_glue::{impl_stable_hash, AsBytes};
-use crate::{cheap_clone::CheapClone, components::store::BlockNumber};
-
 /// A simple marker for byte arrays that are really block hashes
-#[derive(Clone, Default, PartialEq, Eq, Hash, FromSqlRow, AsExpression)]
+#[derive(Clone, CheapClone, Default, PartialEq, Eq, Hash, FromSqlRow, AsExpression)]
 #[diesel(sql_type = Bytea)]
 pub struct BlockHash(pub Box<[u8]>);
 
@@ -59,8 +59,6 @@ impl fmt::LowerHex for BlockHash {
         f.write_str(&hex::encode(&self.0))
     }
 }
-
-impl CheapClone for BlockHash {}
 
 impl From<H256> for BlockHash {
     fn from(hash: H256) -> Self {
@@ -125,13 +123,11 @@ impl ToSql<Bytea, Pg> for BlockHash {
 /// A block hash and block number from a specific Ethereum block.
 ///
 /// Block numbers are signed 32 bit integers
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, CheapClone, PartialEq, Eq, Hash)]
 pub struct BlockPtr {
     pub hash: BlockHash,
     pub number: BlockNumber,
 }
-
-impl CheapClone for BlockPtr {}
 
 impl_stable_hash!(BlockPtr { hash, number });
 

--- a/graph/src/blockchain/types.rs
+++ b/graph/src/blockchain/types.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use std::{fmt, str::FromStr};
 use web3::types::{Block, H256};
 
+use crate::cheap_clone::CheapClone;
 use crate::components::store::BlockNumber;
 use crate::data::graphql::IntoValue;
 use crate::data::store::scalar::Timestamp;
@@ -17,8 +18,9 @@ use crate::derive::CheapClone;
 use crate::object;
 use crate::prelude::{r, BigInt, TryFromValue, Value, ValueMap};
 use crate::util::stable_hash_glue::{impl_stable_hash, AsBytes};
+
 /// A simple marker for byte arrays that are really block hashes
-#[derive(Clone, CheapClone, Default, PartialEq, Eq, Hash, FromSqlRow, AsExpression)]
+#[derive(Clone, Default, PartialEq, Eq, Hash, FromSqlRow, AsExpression)]
 #[diesel(sql_type = Bytea)]
 pub struct BlockHash(pub Box<[u8]>);
 
@@ -39,6 +41,12 @@ impl BlockHash {
 
     pub fn zero() -> Self {
         Self::from(H256::zero())
+    }
+}
+
+impl CheapClone for BlockHash {
+    fn cheap_clone(&self) -> Self {
+        Self(self.0.clone())
     }
 }
 

--- a/graph/src/cheap_clone.rs
+++ b/graph/src/cheap_clone.rs
@@ -38,3 +38,29 @@ impl<M: diesel::r2d2::ManageConnection> CheapClone for diesel::r2d2::Pool<M> {}
 impl<F: Future> CheapClone for futures03::future::Shared<F> {}
 
 impl CheapClone for Channel {}
+
+macro_rules! cheap_clone_is_copy {
+    ($($t:ty),*) => {
+        $(
+            impl CheapClone for $t {
+                #[inline]
+                fn cheap_clone(&self) -> Self {
+                    *self
+                }
+            }
+        )*
+    };
+}
+
+cheap_clone_is_copy!(
+    (),
+    bool,
+    u16,
+    u32,
+    i32,
+    u64,
+    usize,
+    &'static str,
+    std::time::Duration
+);
+cheap_clone_is_copy!(ethabi::Address);

--- a/graph/src/cheap_clone.rs
+++ b/graph/src/cheap_clone.rs
@@ -1,43 +1,93 @@
-use slog::Logger;
 use std::future::Future;
 use std::rc::Rc;
 use std::sync::Arc;
 use tonic::transport::Channel;
 
-/// Things that are fast to clone in the context of an application such as Graph Node
+/// Things that are fast to clone in the context of an application such as
+/// Graph Node
 ///
-/// The purpose of this API is to reduce the number of calls to .clone() which need to
-/// be audited for performance.
+/// The purpose of this API is to reduce the number of calls to .clone()
+/// which need to be audited for performance.
 ///
-/// As a rule of thumb, only constant-time Clone impls should also implement CheapClone.
+/// In general, the derive macro `graph::Derive::CheapClone` should be used
+/// to implement this trait. A manual implementation should only be used if
+/// the derive macro cannot be used, and should mention all fields that need
+/// to be cloned.
+///
+/// As a rule of thumb, only constant-time Clone impls should also implement
+/// CheapClone.
 /// Eg:
 ///    ✔ Arc<T>
 ///    ✗ Vec<T>
 ///    ✔ u128
 ///    ✗ String
 pub trait CheapClone: Clone {
+    fn cheap_clone(&self) -> Self;
+}
+
+impl<T: ?Sized> CheapClone for Rc<T> {
     #[inline]
     fn cheap_clone(&self) -> Self {
         self.clone()
     }
 }
 
-impl<T: ?Sized> CheapClone for Rc<T> {}
-impl<T: ?Sized> CheapClone for Arc<T> {}
-impl<T: ?Sized + CheapClone> CheapClone for Box<T> {}
-impl<T: ?Sized + CheapClone> CheapClone for std::pin::Pin<T> {}
-impl<T: CheapClone> CheapClone for Option<T> {}
-impl CheapClone for Logger {}
-// reqwest::Client uses Arc internally, so it is CheapClone.
-impl CheapClone for reqwest::Client {}
+impl<T: ?Sized> CheapClone for Arc<T> {
+    #[inline]
+    fn cheap_clone(&self) -> Self {
+        self.clone()
+    }
+}
+
+impl<T: ?Sized + CheapClone> CheapClone for Box<T> {
+    #[inline]
+    fn cheap_clone(&self) -> Self {
+        self.clone()
+    }
+}
+
+impl<T: ?Sized + CheapClone> CheapClone for std::pin::Pin<T> {
+    #[inline]
+    fn cheap_clone(&self) -> Self {
+        self.clone()
+    }
+}
+
+impl<T: CheapClone> CheapClone for Option<T> {
+    #[inline]
+    fn cheap_clone(&self) -> Self {
+        self.clone()
+    }
+}
 
 // Pool is implemented as a newtype over Arc,
 // So it is CheapClone.
-impl<M: diesel::r2d2::ManageConnection> CheapClone for diesel::r2d2::Pool<M> {}
+impl<M: diesel::r2d2::ManageConnection> CheapClone for diesel::r2d2::Pool<M> {
+    #[inline]
+    fn cheap_clone(&self) -> Self {
+        self.clone()
+    }
+}
 
-impl<F: Future> CheapClone for futures03::future::Shared<F> {}
+impl<F: Future> CheapClone for futures03::future::Shared<F> {
+    #[inline]
+    fn cheap_clone(&self) -> Self {
+        self.clone()
+    }
+}
 
-impl CheapClone for Channel {}
+macro_rules! cheap_clone_is_clone {
+    ($($t:ty),*) => {
+        $(
+            impl CheapClone for $t {
+                #[inline]
+                fn cheap_clone(&self) -> Self {
+                    self.clone()
+                }
+            }
+        )*
+    };
+}
 
 macro_rules! cheap_clone_is_copy {
     ($($t:ty),*) => {
@@ -51,6 +101,11 @@ macro_rules! cheap_clone_is_copy {
         )*
     };
 }
+
+cheap_clone_is_clone!(Channel);
+// reqwest::Client uses Arc internally, so it is CheapClone.
+cheap_clone_is_clone!(reqwest::Client);
+cheap_clone_is_clone!(slog::Logger);
 
 cheap_clone_is_copy!(
     (),

--- a/graph/src/components/link_resolver/arweave.rs
+++ b/graph/src/components/link_resolver/arweave.rs
@@ -7,8 +7,8 @@ use serde_json::Value;
 use slog::{debug, Logger};
 use thiserror::Error;
 
-use crate::cheap_clone::CheapClone;
 use crate::data_source::offchain::Base64;
+use crate::derive::CheapClone;
 use crate::prelude::Error;
 use std::fmt::Debug;
 
@@ -30,13 +30,11 @@ pub struct ArweaveClient {
     logger: Logger,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, CheapClone)]
 pub enum FileSizeLimit {
     Unlimited,
     MaxBytes(u64),
 }
-
-impl CheapClone for FileSizeLimit {}
 
 impl Default for ArweaveClient {
     fn default() -> Self {

--- a/graph/src/components/link_resolver/ipfs.rs
+++ b/graph/src/components/link_resolver/ipfs.rs
@@ -14,6 +14,7 @@ use lru_time_cache::LruCache;
 use serde_json::Value;
 
 use crate::{
+    cheap_clone::CheapClone,
     derive::CheapClone,
     ipfs_client::IpfsClient,
     prelude::{LinkResolver as LinkResolverTrait, *},

--- a/graph/src/components/link_resolver/ipfs.rs
+++ b/graph/src/components/link_resolver/ipfs.rs
@@ -14,6 +14,7 @@ use lru_time_cache::LruCache;
 use serde_json::Value;
 
 use crate::{
+    derive::CheapClone,
     ipfs_client::IpfsClient,
     prelude::{LinkResolver as LinkResolverTrait, *},
 };
@@ -94,7 +95,7 @@ async fn select_fastest_client(
     }))
 }
 
-#[derive(Clone)]
+#[derive(Clone, CheapClone)]
 pub struct IpfsResolver {
     clients: Arc<Vec<IpfsClient>>,
     cache: Arc<Mutex<LruCache<String, Vec<u8>>>>,
@@ -124,12 +125,6 @@ impl Debug for IpfsResolver {
             .field("retry", &self.retry)
             .field("env_vars", &self.env_vars)
             .finish()
-    }
-}
-
-impl CheapClone for IpfsResolver {
-    fn cheap_clone(&self) -> Self {
-        self.clone()
     }
 }
 

--- a/graph/src/components/metrics/gas.rs
+++ b/graph/src/components/metrics/gas.rs
@@ -1,5 +1,5 @@
 use super::MetricsRegistry;
-use crate::prelude::DeploymentHash;
+use crate::{cheap_clone::CheapClone, prelude::DeploymentHash};
 use prometheus::CounterVec;
 use std::sync::Arc;
 
@@ -7,6 +7,15 @@ use std::sync::Arc;
 pub struct GasMetrics {
     pub gas_counter: CounterVec,
     pub op_counter: CounterVec,
+}
+
+impl CheapClone for GasMetrics {
+    fn cheap_clone(&self) -> Self {
+        Self {
+            gas_counter: self.gas_counter.clone(),
+            op_counter: self.op_counter.clone(),
+        }
+    }
 }
 
 impl GasMetrics {

--- a/graph/src/components/metrics/stopwatch.rs
+++ b/graph/src/components/metrics/stopwatch.rs
@@ -1,6 +1,8 @@
-use crate::prelude::*;
 use std::sync::{atomic::AtomicBool, atomic::Ordering, Mutex};
 use std::time::Instant;
+
+use crate::derive::CheapClone;
+use crate::prelude::*;
 
 /// This is a "section guard", that closes the section on drop.
 pub struct Section {
@@ -32,13 +34,11 @@ impl Drop for Section {
 /// // do stuff...
 /// // At the end of the scope `_main_section` is dropped, which is equivalent to calling
 /// // `_main_section.end()`.
-#[derive(Clone)]
+#[derive(Clone, CheapClone)]
 pub struct StopwatchMetrics {
     disabled: Arc<AtomicBool>,
     inner: Arc<Mutex<StopwatchInner>>,
 }
-
-impl CheapClone for StopwatchMetrics {}
 
 impl StopwatchMetrics {
     pub fn new(

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -33,6 +33,7 @@ use crate::data::store::scalar::Bytes;
 use crate::data::store::{Id, IdList, Value};
 use crate::data::value::Word;
 use crate::data_source::CausalityRegion;
+use crate::derive::CheapClone;
 use crate::env::ENV_VARS;
 use crate::prelude::{s, Attribute, DeploymentHash, SubscriptionFilter, ValueType};
 use crate::schema::{ast as sast, EntityKey, EntityType, InputSchema};
@@ -872,13 +873,11 @@ impl DeploymentId {
 /// identifier (`hash`) and its unique internal identifier (`id`) which
 /// ensures we are talking about a unique location for the deployment's data
 /// in the store
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Clone, CheapClone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct DeploymentLocator {
     pub id: DeploymentId,
     pub hash: DeploymentHash,
 }
-
-impl CheapClone for DeploymentLocator {}
 
 impl slog::Value for DeploymentLocator {
     fn serialize(

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -854,7 +854,7 @@ pub struct StoredDynamicDataSource {
 /// identifier only has meaning in the context of a specific instance of
 /// graph-node. Only store code should ever construct or consume it; all
 /// other code passes it around as an opaque token.
-#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, CheapClone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub struct DeploymentId(pub i32);
 
 impl Display for DeploymentId {

--- a/graph/src/data/query/cache_status.rs
+++ b/graph/src/data/query/cache_status.rs
@@ -3,8 +3,10 @@ use std::slice::Iter;
 
 use serde::Serialize;
 
+use crate::derive::CacheWeight;
+
 /// Used for checking if a response hit the cache.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, CacheWeight, Debug, PartialEq, Eq, Hash)]
 pub enum CacheStatus {
     /// Hit is a hit in the generational cache.
     Hit,

--- a/graph/src/data/query/result.rs
+++ b/graph/src/data/query/result.rs
@@ -3,6 +3,7 @@ use super::trace::{HttpTrace, TRACE_NONE};
 use crate::cheap_clone::CheapClone;
 use crate::components::server::query::ServerResponse;
 use crate::data::value::Object;
+use crate::derive::CacheWeight;
 use crate::prelude::{r, CacheWeight, DeploymentHash};
 use http_body_util::Full;
 use hyper::header::{
@@ -218,7 +219,7 @@ impl QueryResults {
 }
 
 /// The result of running a query, if successful.
-#[derive(Debug, Default, Serialize)]
+#[derive(Debug, CacheWeight, Default, Serialize)]
 pub struct QueryResult {
     #[serde(
         skip_serializing_if = "Option::is_none",
@@ -365,12 +366,6 @@ impl<V: Into<QueryResult>, E: Into<QueryResult>> From<Result<V, E>> for QueryRes
             Ok(v) => v.into(),
             Err(e) => e.into(),
         }
-    }
-}
-
-impl CacheWeight for QueryResult {
-    fn indirect_weight(&self) -> usize {
-        self.data.indirect_weight() + self.errors.indirect_weight()
     }
 }
 

--- a/graph/src/data/query/trace.rs
+++ b/graph/src/data/query/trace.rs
@@ -4,6 +4,7 @@ use serde::{ser::SerializeMap, Serialize};
 
 use crate::{
     components::store::{BlockNumber, QueryPermit},
+    derive::CacheWeight,
     prelude::{lazy_static, CheapClone},
 };
 
@@ -13,7 +14,7 @@ lazy_static! {
     pub static ref TRACE_NONE: Arc<Trace> = Arc::new(Trace::None);
 }
 
-#[derive(Debug)]
+#[derive(Debug, CacheWeight)]
 pub struct TraceWithCacheStatus {
     pub trace: Arc<Trace>,
     pub cache_status: CacheStatus,
@@ -34,7 +35,7 @@ impl HttpTrace {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, CacheWeight)]
 pub enum Trace {
     None,
     Root {

--- a/graph/src/data/store/ethereum.rs
+++ b/graph/src/data/store/ethereum.rs
@@ -1,4 +1,5 @@
 use super::scalar;
+use crate::derive::CheapClone;
 use crate::prelude::*;
 use web3::types::{Address, Bytes, H2048, H256, H64, U64};
 
@@ -101,7 +102,7 @@ pub mod call {
     /// For equality and hashing, we only consider the address and the
     /// encoded call as the index is set by the caller and has no influence
     /// on the call's return value
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, CheapClone)]
     pub struct Request {
         pub address: ethabi::Address,
         pub encoded_call: Arc<Bytes>,
@@ -109,8 +110,6 @@ pub mod call {
         /// request in related data structures that the caller might have
         pub index: u32,
     }
-
-    impl CheapClone for Request {}
 
     impl Request {
         pub fn new(address: ethabi::Address, encoded_call: Vec<u8>, index: u32) -> Self {

--- a/graph/src/data/store/id.rs
+++ b/graph/src/data/store/id.rs
@@ -22,7 +22,8 @@ use crate::{
     components::store::StoreError,
     constraint_violation,
     data::value::Word,
-    prelude::{CacheWeight, QueryExecutionError},
+    derive::CacheWeight,
+    prelude::QueryExecutionError,
     runtime::gas::{Gas, GasSizeOf},
 };
 
@@ -137,7 +138,7 @@ impl std::fmt::Display for IdType {
 }
 
 /// Values for the ids of entities
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, CacheWeight, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Id {
     String(Word),
     Bytes(scalar::Bytes),
@@ -214,16 +215,6 @@ impl std::fmt::Display for Id {
             Id::String(s) => write!(f, "{}", s),
             Id::Bytes(b) => write!(f, "{}", b),
             Id::Int8(i) => write!(f, "{}", i),
-        }
-    }
-}
-
-impl CacheWeight for Id {
-    fn indirect_weight(&self) -> usize {
-        match self {
-            Id::String(s) => s.indirect_weight(),
-            Id::Bytes(b) => b.indirect_weight(),
-            Id::Int8(_) => 0,
         }
     }
 }

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     components::store::DeploymentLocator,
+    derive::CacheWeight,
     prelude::{lazy_static, q, r, s, CacheWeight, QueryExecutionError},
     runtime::gas::{Gas, GasSizeOf},
     schema::{EntityKey, EntityType},
@@ -737,7 +738,7 @@ lazy_static! {
 }
 
 /// An entity is represented as a map of attribute names to values.
-#[derive(Clone, PartialEq, Eq, Serialize)]
+#[derive(Clone, CacheWeight, PartialEq, Eq, Serialize)]
 pub struct Entity(Object<Value>);
 
 impl<'a> IntoIterator for &'a Entity {
@@ -1056,12 +1057,6 @@ impl Entity {
 impl<'a> From<&'a Entity> for Cow<'a, Entity> {
     fn from(entity: &'a Entity) -> Self {
         Cow::Borrowed(entity)
-    }
-}
-
-impl CacheWeight for Entity {
-    fn indirect_weight(&self) -> usize {
-        self.0.indirect_weight()
     }
 }
 

--- a/graph/src/data/store/scalar/bytes.rs
+++ b/graph/src/data/store/scalar/bytes.rs
@@ -8,10 +8,11 @@ use std::ops::Deref;
 use std::str::FromStr;
 
 use crate::blockchain::BlockHash;
+use crate::derive::CacheWeight;
 use crate::util::stable_hash_glue::{impl_stable_hash, AsBytes};
 
 /// A byte array that's serialized as a hex string prefixed by `0x`.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, CacheWeight, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Bytes(Box<[u8]>);
 
 impl Deref for Bytes {

--- a/graph/src/data/store/scalar/timestamp.rs
+++ b/graph/src/data/store/scalar/timestamp.rs
@@ -6,9 +6,12 @@ use stable_hash::StableHash;
 use std::fmt::{self, Display, Formatter};
 use std::num::ParseIntError;
 
+use crate::derive::CacheWeight;
 use crate::runtime::gas::{Gas, GasSizeOf, SaturatingInto};
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(
+    Clone, Copy, CacheWeight, Debug, Deserialize, Serialize, PartialEq, Eq, Hash, PartialOrd, Ord,
+)]
 pub struct Timestamp(pub DateTime<Utc>);
 
 #[derive(thiserror::Error, Debug)]

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -10,7 +10,7 @@ pub mod status;
 
 pub use features::{SubgraphFeature, SubgraphFeatureValidationError};
 
-use crate::{components::store::BLOCK_NUMBER_MAX, object};
+use crate::{cheap_clone::CheapClone, components::store::BLOCK_NUMBER_MAX, object};
 use anyhow::{anyhow, Context, Error};
 use futures03::{future::try_join, stream::FuturesOrdered, TryStreamExt as _};
 use itertools::Itertools;
@@ -46,7 +46,7 @@ use crate::{
         offchain::OFFCHAIN_KINDS, DataSource, DataSourceTemplate, UnresolvedDataSource,
         UnresolvedDataSourceTemplate,
     },
-    derive::{CacheWeight, CheapClone},
+    derive::CacheWeight,
     ensure,
     prelude::{r, Value, ENV_VARS},
     schema::{InputSchema, SchemaValidationError},
@@ -77,8 +77,14 @@ where
 
 /// The IPFS hash used to identifiy a deployment externally, i.e., the
 /// `Qm..` string that `graph-cli` prints when deploying to a subgraph
-#[derive(Clone, CheapClone, CacheWeight, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
+#[derive(Clone, CacheWeight, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
 pub struct DeploymentHash(String);
+
+impl CheapClone for DeploymentHash {
+    fn cheap_clone(&self) -> Self {
+        self.clone()
+    }
+}
 
 impl stable_hash_legacy::StableHash for DeploymentHash {
     #[inline]

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -46,7 +46,7 @@ use crate::{
         offchain::OFFCHAIN_KINDS, DataSource, DataSourceTemplate, UnresolvedDataSource,
         UnresolvedDataSourceTemplate,
     },
-    derive::CheapClone,
+    derive::{CacheWeight, CheapClone},
     ensure,
     prelude::{r, Value, ENV_VARS},
     schema::{InputSchema, SchemaValidationError},
@@ -77,7 +77,7 @@ where
 
 /// The IPFS hash used to identifiy a deployment externally, i.e., the
 /// `Qm..` string that `graph-cli` prints when deploying to a subgraph
-#[derive(Clone, CheapClone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
+#[derive(Clone, CheapClone, CacheWeight, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
 pub struct DeploymentHash(String);
 
 impl stable_hash_legacy::StableHash for DeploymentHash {

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -46,8 +46,9 @@ use crate::{
         offchain::OFFCHAIN_KINDS, DataSource, DataSourceTemplate, UnresolvedDataSource,
         UnresolvedDataSourceTemplate,
     },
+    derive::CheapClone,
     ensure,
-    prelude::{r, CheapClone, Value, ENV_VARS},
+    prelude::{r, Value, ENV_VARS},
     schema::{InputSchema, SchemaValidationError},
 };
 
@@ -76,7 +77,7 @@ where
 
 /// The IPFS hash used to identifiy a deployment externally, i.e., the
 /// `Qm..` string that `graph-cli` prints when deploying to a subgraph
-#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
+#[derive(Clone, CheapClone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
 pub struct DeploymentHash(String);
 
 impl stable_hash_legacy::StableHash for DeploymentHash {
@@ -99,9 +100,6 @@ impl StableHash for DeploymentHash {
 }
 
 impl_slog_value!(DeploymentHash);
-
-/// `DeploymentHash` is fixed-length so cheap to clone.
-impl CheapClone for DeploymentHash {}
 
 impl DeploymentHash {
     /// Check that `s` is a valid `SubgraphDeploymentId` and create a new one.

--- a/graph/src/data_source/causality_region.rs
+++ b/graph/src/data_source/causality_region.rs
@@ -7,6 +7,7 @@ use diesel::{
 use std::fmt;
 
 use crate::components::subgraph::Entity;
+use crate::derive::CacheWeight;
 
 /// The causality region of a data source. All onchain data sources share the same causality region,
 /// but each offchain data source is assigned its own. This isolates offchain data sources from
@@ -19,7 +20,7 @@ use crate::components::subgraph::Entity;
 /// This necessary for determinism because offchain data sources don't have a deterministic order of
 /// execution, for example an IPFS file may become available at any point in time. The isolation
 /// rules make the indexing result reproducible, given a set of available files.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, FromSqlRow, Hash, PartialOrd, Ord)]
+#[derive(Debug, CacheWeight, Copy, Clone, PartialEq, Eq, FromSqlRow, Hash, PartialOrd, Ord)]
 pub struct CausalityRegion(i32);
 
 impl fmt::Display for CausalityRegion {

--- a/graph/src/ipfs_client.rs
+++ b/graph/src/ipfs_client.rs
@@ -1,4 +1,3 @@
-use crate::prelude::CheapClone;
 use anyhow::anyhow;
 use anyhow::Error;
 use bytes::Bytes;
@@ -13,6 +12,8 @@ use serde::Deserialize;
 use std::fmt::Display;
 use std::time::Duration;
 use std::{str::FromStr, sync::Arc};
+
+use crate::derive::CheapClone;
 
 #[derive(Debug, thiserror::Error)]
 pub enum IpfsError {
@@ -114,21 +115,12 @@ pub struct AddResponse {
 }
 
 /// Reference type, clones will share the connection pool.
-#[derive(Clone)]
+#[derive(Clone, CheapClone)]
 pub struct IpfsClient {
     base: Arc<Uri>,
     // reqwest::Client doesn't need to be `Arc` because it has one internally
     // already.
     client: reqwest::Client,
-}
-
-impl CheapClone for IpfsClient {
-    fn cheap_clone(&self) -> Self {
-        IpfsClient {
-            base: self.base.cheap_clone(),
-            client: self.client.cheap_clone(),
-        }
-    }
 }
 
 impl IpfsClient {

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -45,6 +45,7 @@ pub use task_spawn::{
 
 pub use anyhow;
 pub use bytes;
+pub use graph_derive as derive;
 pub use http;
 pub use http_body_util;
 pub use hyper;

--- a/graph/src/runtime/gas/mod.rs
+++ b/graph/src/runtime/gas/mod.rs
@@ -4,7 +4,8 @@ mod ops;
 mod saturating;
 mod size_of;
 use crate::components::metrics::gas::GasMetrics;
-use crate::prelude::{CheapClone, ENV_VARS};
+use crate::derive::CheapClone;
+use crate::prelude::ENV_VARS;
 use crate::runtime::DeterministicHostError;
 pub use combinators::*;
 pub use costs::DEFAULT_BASE_COST;
@@ -76,13 +77,11 @@ impl Display for Gas {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, CheapClone)]
 pub struct GasCounter {
     counter: Arc<AtomicU64>,
     metrics: GasMetrics,
 }
-
-impl CheapClone for GasCounter {}
 
 impl GasCounter {
     pub fn new(metrics: GasMetrics) -> Self {

--- a/graph/src/schema/api.rs
+++ b/graph/src/schema/api.rs
@@ -16,6 +16,7 @@ use crate::schema::{ast, META_FIELD_NAME, META_FIELD_TYPE, SCHEMA_TYPE_NAME};
 use crate::data::graphql::ext::{
     camel_cased_names, DefinitionExt, DirectiveExt, DocumentExt, ValueExt,
 };
+use crate::derive::CheapClone;
 use crate::prelude::{q, r, s, DeploymentHash};
 
 use super::{Aggregation, Field, InputSchema, Schema, TypeKind};
@@ -39,7 +40,7 @@ const BLOCK_HEIGHT: &str = "Block_height";
 const CHANGE_BLOCK_FILTER_NAME: &str = "BlockChangedFilter";
 const ERROR_POLICY_TYPE: &str = "_SubgraphErrorPolicy_";
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, CheapClone)]
 pub enum ErrorPolicy {
     Allow,
     Deny,

--- a/graph/src/schema/ast.rs
+++ b/graph/src/schema/ast.rs
@@ -4,9 +4,9 @@ use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use crate::cheap_clone::CheapClone;
 use crate::data::graphql::ext::DirectiveFinder;
 use crate::data::graphql::{DirectiveExt, DocumentExt, ObjectOrInterface};
+use crate::derive::CheapClone;
 use crate::prelude::anyhow::anyhow;
 use crate::prelude::{s, Error, ValueType};
 
@@ -83,7 +83,7 @@ pub fn parse_field_as_filter(key: &str) -> (String, FilterOp) {
 }
 
 /// An `ObjectType` with `Hash` and `Eq` derived from the name.
-#[derive(Clone, Debug)]
+#[derive(Clone, CheapClone, Debug)]
 pub struct ObjectType(Arc<s::ObjectType>);
 
 impl Ord for ObjectType {
@@ -131,8 +131,6 @@ impl Deref for ObjectType {
         &self.0
     }
 }
-
-impl CheapClone for ObjectType {}
 
 impl AsEntityTypeName for &ObjectType {
     fn name(&self) -> &str {

--- a/graph/src/schema/entity_key.rs
+++ b/graph/src/schema/entity_key.rs
@@ -3,12 +3,13 @@ use std::fmt;
 use crate::components::store::StoreError;
 use crate::data::store::{Id, Value};
 use crate::data_source::CausalityRegion;
+use crate::derive::CacheWeight;
 use crate::schema::EntityType;
 use crate::util::intern;
 
 /// Key by which an individual entity in the store can be accessed. Stores
 /// only the entity type and id. The deployment must be known from context.
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, CacheWeight, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EntityKey {
     /// Name of the entity type.
     pub entity_type: EntityType,

--- a/graph/src/schema/entity_type.rs
+++ b/graph/src/schema/entity_type.rs
@@ -13,6 +13,8 @@ use crate::{
 
 use super::{EntityKey, Field, InputSchema, InterfaceType, ObjectType, POI_OBJECT};
 
+use graph_derive::CheapClone;
+
 /// A reference to a type in the input schema. It should mostly be the
 /// reference to a concrete entity type, either one declared with `@entity`
 /// in the input schema, or the object type that stores aggregations for a
@@ -23,7 +25,7 @@ use super::{EntityKey, Field, InputSchema, InterfaceType, ObjectType, POI_OBJECT
 /// Even though it is not implemented as a string type, it behaves as if it
 /// were the string name of the type for all external purposes like
 /// comparison, ordering, and serialization
-#[derive(Clone)]
+#[derive(Clone, CheapClone)]
 pub struct EntityType {
     schema: InputSchema,
     pub(in crate::schema) atom: Atom,
@@ -161,8 +163,6 @@ impl Borrow<str> for EntityType {
         self.as_str()
     }
 }
-
-impl CheapClone for EntityType {}
 
 impl std::fmt::Debug for EntityType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/graph/src/schema/input/mod.rs
+++ b/graph/src/schema/input/mod.rs
@@ -298,10 +298,23 @@ impl Field {
     }
 }
 
-#[derive(Copy, Clone, CheapClone)]
+#[derive(Copy, Clone)]
 pub enum ObjectOrInterface<'a> {
     Object(&'a InputSchema, &'a ObjectType),
     Interface(&'a InputSchema, &'a InterfaceType),
+}
+
+impl<'a> CheapClone for ObjectOrInterface<'a> {
+    fn cheap_clone(&self) -> Self {
+        match self {
+            ObjectOrInterface::Object(schema, object) => {
+                ObjectOrInterface::Object(*schema, *object)
+            }
+            ObjectOrInterface::Interface(schema, interface) => {
+                ObjectOrInterface::Interface(*schema, *interface)
+            }
+        }
+    }
 }
 
 impl<'a> ObjectOrInterface<'a> {

--- a/graph/src/schema/input/mod.rs
+++ b/graph/src/schema/input/mod.rs
@@ -18,6 +18,7 @@ use crate::data::store::{
     self, EntityValidationError, IdType, IntoEntityIterator, TryIntoEntityIterator, ValueType, ID,
 };
 use crate::data::value::Word;
+use crate::derive::CheapClone;
 use crate::prelude::q::Value;
 use crate::prelude::{s, DeploymentHash};
 use crate::schema::api::api_schema;
@@ -58,7 +59,7 @@ pub mod kw {
 ///
 /// There's no need to put this into an `Arc`, since `InputSchema` already
 /// does that internally and is `CheapClone`
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, CheapClone, Debug, PartialEq)]
 pub struct InputSchema {
     inner: Arc<Inner>,
 }
@@ -297,7 +298,7 @@ impl Field {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, CheapClone)]
 pub enum ObjectOrInterface<'a> {
     Object(&'a InputSchema, &'a ObjectType),
     Interface(&'a InputSchema, &'a InterfaceType),
@@ -378,8 +379,6 @@ impl<'a> ObjectOrInterface<'a> {
         }
     }
 }
-
-impl CheapClone for ObjectOrInterface<'_> {}
 
 impl std::fmt::Debug for ObjectOrInterface<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -942,14 +941,6 @@ pub struct Inner {
     pool: Arc<AtomPool>,
     /// A list of all timeseries types by interval
     agg_mappings: Box<[AggregationMapping]>,
-}
-
-impl CheapClone for InputSchema {
-    fn cheap_clone(&self) -> Self {
-        InputSchema {
-            inner: self.inner.cheap_clone(),
-        }
-    }
 }
 
 impl InputSchema {

--- a/graph/src/util/cache_weight.rs
+++ b/graph/src/util/cache_weight.rs
@@ -46,6 +46,12 @@ impl CacheWeight for bool {
     }
 }
 
+impl<T1: CacheWeight, T2: CacheWeight> CacheWeight for (T1, T2) {
+    fn indirect_weight(&self) -> usize {
+        self.0.indirect_weight() + self.1.indirect_weight()
+    }
+}
+
 impl<T: CacheWeight> CacheWeight for Option<T> {
     fn indirect_weight(&self) -> usize {
         match self {

--- a/graph/src/util/herd_cache.rs
+++ b/graph/src/util/herd_cache.rs
@@ -10,6 +10,7 @@ use stable_hash_legacy::crypto::SetHasher;
 use stable_hash_legacy::prelude::*;
 
 use crate::cheap_clone::CheapClone;
+use crate::derive::CheapClone;
 
 use super::timed_rw_lock::TimedMutex;
 
@@ -25,12 +26,10 @@ type PinFut<R> = Pin<Box<dyn Future<Output = R> + 'static + Send>>;
 /// but more specialized. The name alludes to the fact that this data
 /// structure stops a thundering herd from causing the same work to be done
 /// repeatedly.
-#[derive(Clone)]
+#[derive(Clone, CheapClone)]
 pub struct HerdCache<R> {
     cache: Arc<TimedMutex<HashMap<Hash, Shared<PinFut<R>>>>>,
 }
-
-impl<R: Clone> CheapClone for HerdCache<R> {}
 
 impl<R: CheapClone> HerdCache<R> {
     pub fn new(id: impl Into<String>) -> Self {

--- a/graph/src/util/intern.rs
+++ b/graph/src/util/intern.rs
@@ -14,6 +14,7 @@ use serde::Serialize;
 
 use crate::cheap_clone::CheapClone;
 use crate::data::value::Word;
+use crate::derive::CheapClone;
 use crate::runtime::gas::{Gas, GasSizeOf};
 
 use super::cache_weight::CacheWeight;
@@ -27,7 +28,7 @@ type AtomInt = u16;
 ///
 /// The ordering for atoms is based on their integer value, and has no
 /// connection to how the strings they represent would be ordered
-#[derive(Eq, Hash, PartialEq, PartialOrd, Ord, Clone, Copy, Debug)]
+#[derive(Eq, Hash, PartialEq, PartialOrd, Ord, Clone, Copy, CheapClone, Debug)]
 pub struct Atom(AtomInt);
 
 /// An atom and the underlying pool. A `FatAtom` can be used in place of a

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -8,6 +8,7 @@ use graph::data::graphql::load_manager::LoadManager;
 use graph::data::graphql::{object, ObjectOrInterface};
 use graph::data::query::{CacheStatus, QueryResults, Trace};
 use graph::data::value::{Object, Word};
+use graph::derive::CheapClone;
 use graph::prelude::*;
 use graph::schema::{
     ast as sast, ApiSchema, INTROSPECTION_SCHEMA_FIELD_NAME, INTROSPECTION_TYPE_FIELD_NAME,
@@ -22,7 +23,7 @@ use crate::query::ext::BlockConstraint;
 use crate::store::query::collect_entities_from_query_field;
 
 /// A resolver that fetches entities from a `Store`.
-#[derive(Clone)]
+#[derive(Clone, CheapClone)]
 pub struct StoreResolver {
     #[allow(dead_code)]
     logger: Logger,
@@ -35,8 +36,6 @@ pub struct StoreResolver {
     graphql_metrics: Arc<GraphQLMetrics>,
     load_manager: Arc<LoadManager>,
 }
-
-impl CheapClone for StoreResolver {}
 
 impl StoreResolver {
     /// Create a resolver that looks up entities at whatever block is the

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -253,7 +253,6 @@ async fn main() {
 
     let arweave_service = arweave_service(
         arweave_resolver.cheap_clone(),
-        env_vars.mappings.ipfs_timeout,
         env_vars.mappings.ipfs_request_limit,
         match env_vars.mappings.max_ipfs_file_bytes {
             0 => FileSizeLimit::Unlimited,

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -83,7 +83,6 @@ pub async fn run(
     ));
     let arweave_service = arweave_service(
         arweave_resolver.cheap_clone(),
-        env_vars.mappings.ipfs_timeout,
         env_vars.mappings.ipfs_request_limit,
         match env_vars.mappings.max_ipfs_file_bytes {
             0 => FileSizeLimit::Unlimited,

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -4,6 +4,7 @@ use diesel::r2d2::{ConnectionManager, PooledConnection};
 use diesel::sql_types::Text;
 use diesel::{insert_into, update};
 use graph::data::store::ethereum::call;
+use graph::derive::CheapClone;
 use graph::env::ENV_VARS;
 use graph::parking_lot::RwLock;
 use graph::prelude::MetricsRegistry;
@@ -1603,10 +1604,8 @@ impl ChainStoreMetrics {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, CheapClone)]
 struct BlocksLookupResult(Arc<Result<Vec<JsonBlock>, StoreError>>);
-
-impl CheapClone for BlocksLookupResult {}
 
 pub struct ChainStore {
     logger: Logger,

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -16,6 +16,7 @@ use graph::data::query::Trace;
 use graph::data::store::{Id, IdList};
 use graph::data::subgraph::{status, SPEC_VERSION_0_0_6};
 use graph::data_source::CausalityRegion;
+use graph::derive::CheapClone;
 use graph::prelude::futures03::FutureExt;
 use graph::prelude::{
     ApiVersion, CancelHandle, CancelToken, CancelableError, EntityOperation, PoolWaitStats,
@@ -118,10 +119,8 @@ pub struct StoreInner {
 
 /// Storage of the data for individual deployments. Each `DeploymentStore`
 /// corresponds to one of the database shards that `SubgraphStore` manages.
-#[derive(Clone)]
+#[derive(Clone, CheapClone)]
 pub struct DeploymentStore(Arc<StoreInner>);
-
-impl CheapClone for DeploymentStore {}
 
 impl Deref for DeploymentStore {
     type Target = StoreInner;

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -471,7 +471,6 @@ pub async fn setup<C: Blockchain>(
     let arweave_resolver = Arc::new(ArweaveClient::default());
     let arweave_service = arweave_service(
         arweave_resolver.cheap_clone(),
-        env_vars.mappings.ipfs_timeout,
         env_vars.mappings.ipfs_request_limit,
         match env_vars.mappings.max_ipfs_file_bytes {
             0 => FileSizeLimit::Unlimited,


### PR DESCRIPTION
This PR adds derive macros. The one for `CheapClone` is more of a nice-to-have, but the one for `CacheWeight` should help avoid inaccurate `CacheWeight` implementations.

The PR also adds a few tests for the cache weight of various objects; in the course of doing that, I realized that our cache weight calculation for `graph::data::value::Object` was wrong. That is a `Box<[Entry]>` and the existing calculation only took the indirect weight of the `Entry` into account, but not the size of the actual `[Entry]`. An `Entry` is 48 bytes, which means we might have been ignoring a significant amount of the memory that a query result takes up.

The tests in particular should be reviewed carefully to make sure that the sizes they check for are accurate. This PR will likely have an effect on query caching and should be watched carefully when deployed.