### PR TITLE
store: Fix check for deterministic error

### DIFF
--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -705,9 +705,8 @@ pub fn state(conn: &mut PgConnection, id: DeploymentHash) -> Result<DeploymentSt
                 e::table
                     .filter(e::subgraph_id.eq(id.as_str()))
                     .filter(e::deterministic)
-                    .select(sql::<Integer>("min(lower(block_range))"))
-                    .first::<i32>(conn)
-                    .optional()?
+                    .select(sql::<Nullable<Integer>>("min(lower(block_range))"))
+                    .first::<Option<i32>>(conn)?
             } else {
                 None
             };


### PR DESCRIPTION
The check for a deterministic error in deployment::state was wrong in that it claimed that it contained a `sql::<Integer>` but a query using `min` will return null when there are no rows. The query needs to say `sql::<Nullable<Integer>>`

