### PR TITLE
Remove provider checks at startup

### DIFF
--- a/chain/arweave/src/trigger.rs
+++ b/chain/arweave/src/trigger.rs
@@ -17,6 +17,7 @@ use crate::codec;
 // Logging the block is too verbose, so this strips the block from the trigger for Debug.
 impl std::fmt::Debug for ArweaveTrigger {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[allow(unused)]
         #[derive(Debug)]
         pub enum MappingTriggerWithoutBlock {
             Block,

--- a/chain/cosmos/src/trigger.rs
+++ b/chain/cosmos/src/trigger.rs
@@ -13,6 +13,7 @@ use crate::data_source::EventOrigin;
 // Logging the block is too verbose, so this strips the block from the trigger for Debug.
 impl std::fmt::Debug for CosmosTrigger {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[allow(unused)]
         #[derive(Debug)]
         pub enum MappingTriggerWithoutBlock<'e> {
             Block,

--- a/chain/ethereum/examples/firehose.rs
+++ b/chain/ethereum/examples/firehose.rs
@@ -2,10 +2,9 @@ use anyhow::Error;
 use graph::{
     endpoint::EndpointMetrics,
     env::env_var,
-    firehose::SubgraphLimit,
+    firehose::{self, FirehoseEndpoint, NoopGenesisDecoder, SubgraphLimit},
     log::logger,
     prelude::{prost, tokio, tonic, MetricsRegistry},
-    {firehose, firehose::FirehoseEndpoint},
 };
 use graph_chain_ethereum::codec;
 use hex::ToHex;
@@ -39,6 +38,7 @@ async fn main() -> Result<(), Error> {
         false,
         SubgraphLimit::Unlimited,
         metrics,
+        NoopGenesisDecoder::boxed(),
     ));
 
     loop {

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1905,7 +1905,8 @@ pub(crate) async fn get_calls(
             } else {
                 client
                     .rpc()?
-                    .cheapest_with(capabilities)?
+                    .cheapest_with(capabilities)
+                    .await?
                     .calls_in_block(
                         &logger,
                         subgraph_metrics.clone(),

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -32,7 +32,6 @@ pub use crate::adapter::{
     ProviderEthRpcMetrics, SubgraphEthRpcMetrics, TriggerFilter,
 };
 pub use crate::chain::Chain;
-pub use crate::network::EthereumNetworks;
 pub use graph::blockchain::BlockIngestor;
 
 #[cfg(test)]

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -111,7 +111,7 @@ impl blockchain::RuntimeAdapter<Chain> for RuntimeAdapter {
         let ethereum_get_balance = HostFn {
             name: "ethereum.getBalance",
             func: Arc::new(move |ctx, wasm_ptr| {
-                let eth_adapter = eth_adapters.cheapest_with(&NodeCapabilities {
+                let eth_adapter = eth_adapters.unverified_cheapest_with(&NodeCapabilities {
                     archive,
                     traces: false,
                 })?;
@@ -123,7 +123,7 @@ impl blockchain::RuntimeAdapter<Chain> for RuntimeAdapter {
         let ethereum_get_code = HostFn {
             name: "ethereum.hasCode",
             func: Arc::new(move |ctx, wasm_ptr| {
-                let eth_adapter = eth_adapters.cheapest_with(&NodeCapabilities {
+                let eth_adapter = eth_adapters.unverified_cheapest_with(&NodeCapabilities {
                     archive,
                     traces: false,
                 })?;

--- a/chain/ethereum/src/transport.rs
+++ b/chain/ethereum/src/transport.rs
@@ -1,4 +1,5 @@
-use graph::endpoint::{EndpointMetrics, Provider, RequestLabels};
+use graph::components::adapter::ProviderName;
+use graph::endpoint::{EndpointMetrics, RequestLabels};
 use jsonrpc_core::types::Call;
 use jsonrpc_core::Value;
 
@@ -15,7 +16,7 @@ pub enum Transport {
     RPC {
         client: http::Http,
         metrics: Arc<EndpointMetrics>,
-        provider: Provider,
+        provider: ProviderName,
     },
     IPC(ipc::Ipc),
     WS(ws::WebSocket),

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -7,6 +7,7 @@ use graph::blockchain::{
     NoopRuntimeAdapter,
 };
 use graph::cheap_clone::CheapClone;
+use graph::components::adapter::ChainId;
 use graph::components::store::DeploymentCursorTracker;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::env::EnvVars;
@@ -160,7 +161,7 @@ impl BlockStreamBuilder<Chain> for NearStreamBuilder {
 
 pub struct Chain {
     logger_factory: LoggerFactory,
-    name: String,
+    name: ChainId,
     client: Arc<ChainClient<Self>>,
     chain_store: Arc<dyn ChainStore>,
     metrics_registry: Arc<MetricsRegistry>,
@@ -174,8 +175,9 @@ impl std::fmt::Debug for Chain {
     }
 }
 
+#[async_trait]
 impl BlockchainBuilder<Chain> for BasicBlockchainBuilder {
-    fn build(self, config: &Arc<EnvVars>) -> Chain {
+    async fn build(self, config: &Arc<EnvVars>) -> Chain {
         Chain {
             logger_factory: self.logger_factory,
             name: self.name,
@@ -279,7 +281,7 @@ impl Blockchain for Chain {
         logger: &Logger,
         number: BlockNumber,
     ) -> Result<BlockPtr, IngestorError> {
-        let firehose_endpoint = self.client.firehose_endpoint()?;
+        let firehose_endpoint = self.client.firehose_endpoint().await?;
 
         firehose_endpoint
             .block_ptr_for_number::<codec::HeaderOnlyBlock>(logger, number)
@@ -287,15 +289,15 @@ impl Blockchain for Chain {
             .await
     }
 
-    fn runtime(&self) -> (Arc<dyn RuntimeAdapterTrait<Self>>, Self::DecoderHook) {
-        (Arc::new(NoopRuntimeAdapter::default()), NoopDecoderHook)
+    fn runtime(&self) -> anyhow::Result<(Arc<dyn RuntimeAdapterTrait<Self>>, Self::DecoderHook)> {
+        Ok((Arc::new(NoopRuntimeAdapter::default()), NoopDecoderHook))
     }
 
     fn chain_client(&self) -> Arc<ChainClient<Self>> {
         self.client.clone()
     }
 
-    fn block_ingestor(&self) -> anyhow::Result<Box<dyn BlockIngestor>> {
+    async fn block_ingestor(&self) -> anyhow::Result<Box<dyn BlockIngestor>> {
         let ingestor = FirehoseBlockIngestor::<crate::HeaderOnlyBlock, Self>::new(
             self.chain_store.cheap_clone(),
             self.chain_client(),

--- a/chain/near/src/trigger.rs
+++ b/chain/near/src/trigger.rs
@@ -15,6 +15,7 @@ use crate::codec;
 // Logging the block is too verbose, so this strips the block from the trigger for Debug.
 impl std::fmt::Debug for NearTrigger {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[allow(unused)]
         #[derive(Debug)]
         pub enum MappingTriggerWithoutBlock<'a> {
             Block,

--- a/chain/substreams/examples/substreams.rs
+++ b/chain/substreams/examples/substreams.rs
@@ -3,7 +3,7 @@ use graph::blockchain::block_stream::{BlockStreamEvent, FirehoseCursor};
 use graph::blockchain::client::ChainClient;
 use graph::blockchain::substreams_block_stream::SubstreamsBlockStream;
 use graph::endpoint::EndpointMetrics;
-use graph::firehose::{FirehoseEndpoints, SubgraphLimit};
+use graph::firehose::{FirehoseEndpoints, NoopGenesisDecoder, SubgraphLimit};
 use graph::prelude::{info, tokio, DeploymentHash, MetricsRegistry, Registry};
 use graph::tokio_stream::StreamExt;
 use graph::{env::env_var, firehose::FirehoseEndpoint, log::logger, substreams};
@@ -57,11 +57,12 @@ async fn main() -> Result<(), Error> {
         false,
         SubgraphLimit::Unlimited,
         Arc::new(endpoint_metrics),
+        NoopGenesisDecoder::boxed(),
     ));
 
-    let client = Arc::new(ChainClient::new_firehose(FirehoseEndpoints::from(vec![
-        firehose,
-    ])));
+    let client = Arc::new(ChainClient::new_firehose(FirehoseEndpoints::for_testing(
+        vec![firehose],
+    )));
 
     let mut stream: SubstreamsBlockStream<graph_chain_substreams::Chain> =
         SubstreamsBlockStream::new(

--- a/chain/substreams/src/block_ingestor.rs
+++ b/chain/substreams/src/block_ingestor.rs
@@ -3,9 +3,11 @@ use std::{sync::Arc, time::Duration};
 use crate::mapper::Mapper;
 use anyhow::{Context, Error};
 use graph::blockchain::block_stream::{BlockStreamError, FirehoseCursor};
+use graph::blockchain::BlockchainKind;
 use graph::blockchain::{
     client::ChainClient, substreams_block_stream::SubstreamsBlockStream, BlockIngestor,
 };
+use graph::components::adapter::ChainId;
 use graph::prelude::MetricsRegistry;
 use graph::slog::trace;
 use graph::substreams::Package;
@@ -27,7 +29,7 @@ pub struct SubstreamsBlockIngestor {
     chain_store: Arc<dyn ChainStore>,
     client: Arc<ChainClient<super::Chain>>,
     logger: Logger,
-    chain_name: String,
+    chain_name: ChainId,
     metrics: Arc<MetricsRegistry>,
 }
 
@@ -36,7 +38,7 @@ impl SubstreamsBlockIngestor {
         chain_store: Arc<dyn ChainStore>,
         client: Arc<ChainClient<super::Chain>>,
         logger: Logger,
-        chain_name: String,
+        chain_name: ChainId,
         metrics: Arc<MetricsRegistry>,
     ) -> SubstreamsBlockIngestor {
         SubstreamsBlockIngestor {
@@ -192,7 +194,10 @@ impl BlockIngestor for SubstreamsBlockIngestor {
         }
     }
 
-    fn network_name(&self) -> String {
+    fn network_name(&self) -> ChainId {
         self.chain_name.clone()
+    }
+    fn kind(&self) -> BlockchainKind {
+        BlockchainKind::Substreams
     }
 }

--- a/core/src/subgraph/instance_manager.rs
+++ b/core/src/subgraph/instance_manager.rs
@@ -11,6 +11,7 @@ use graph::blockchain::{Blockchain, BlockchainKind, DataSource, NodeCapabilities
 use graph::components::metrics::gas::GasMetrics;
 use graph::components::subgraph::ProofOfIndexingVersion;
 use graph::data::subgraph::{UnresolvedSubgraphManifest, SPEC_VERSION_0_0_6};
+use graph::data::value::Word;
 use graph::data_source::causality_region::CausalityRegionSeq;
 use graph::env::EnvVars;
 use graph::prelude::{SubgraphInstanceManager as SubgraphInstanceManagerTrait, *};
@@ -307,7 +308,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
             .collect::<Vec<_>>();
 
         let required_capabilities = C::NodeCapabilities::from_data_sources(&onchain_data_sources);
-        let network = manifest.network_name();
+        let network: Word = manifest.network_name().into();
 
         let chain = self
             .chains
@@ -390,7 +391,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
         let deployment_head = store.block_ptr().map(|ptr| ptr.number).unwrap_or(0) as f64;
         block_stream_metrics.deployment_head.set(deployment_head);
 
-        let (runtime_adapter, decoder_hook) = chain.runtime();
+        let (runtime_adapter, decoder_hook) = chain.runtime()?;
         let host_builder = graph_runtime_wasm::RuntimeHostBuilder::new(
             runtime_adapter,
             self.link_resolver.cheap_clone(),
@@ -426,7 +427,7 @@ impl<S: SubgraphStore> SubgraphInstanceManager<S> {
             unified_api_version,
             static_filters: self.static_filters,
             poi_version,
-            network,
+            network: network.to_string(),
             instrument,
         };
 

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -9,6 +9,7 @@ use graph::components::store::{DeploymentId, DeploymentLocator, SubscriptionMana
 use graph::components::subgraph::Settings;
 use graph::data::subgraph::schema::DeploymentCreate;
 use graph::data::subgraph::Graft;
+use graph::data::value::Word;
 use graph::futures01;
 use graph::futures01::future;
 use graph::futures01::stream;
@@ -643,7 +644,7 @@ async fn create_subgraph_version<C: Blockchain, S: SubgraphStore>(
         .await
         .map_err(SubgraphRegistrarError::ManifestValidationError)?;
 
-    let network_name = manifest.network_name();
+    let network_name: Word = manifest.network_name().into();
 
     let chain = chains
         .get::<C>(network_name.clone())
@@ -726,7 +727,7 @@ async fn create_subgraph_version<C: Blockchain, S: SubgraphStore>(
             &manifest.schema,
             deployment,
             node_id,
-            network_name,
+            network_name.into(),
             version_switching_mode,
         )
         .map_err(SubgraphRegistrarError::SubgraphDeploymentError)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     volumes:
       - ./data/ipfs:/data/ipfs:Z
   postgres:
-    image: postgres:14
+    image: postgres
     ports:
       - '5432:5432'
     command:

--- a/graph/src/blockchain/builder.rs
+++ b/graph/src/blockchain/builder.rs
@@ -1,6 +1,8 @@
+use tonic::async_trait;
+
 use super::Blockchain;
 use crate::{
-    components::store::ChainStore, env::EnvVars, firehose::FirehoseEndpoints,
+    components::store::ChainStore, data::value::Word, env::EnvVars, firehose::FirehoseEndpoints,
     prelude::LoggerFactory, prelude::MetricsRegistry,
 };
 use std::sync::Arc;
@@ -9,16 +11,17 @@ use std::sync::Arc;
 /// particularly fancy builder logic.
 pub struct BasicBlockchainBuilder {
     pub logger_factory: LoggerFactory,
-    pub name: String,
+    pub name: Word,
     pub chain_store: Arc<dyn ChainStore>,
     pub firehose_endpoints: FirehoseEndpoints,
     pub metrics_registry: Arc<MetricsRegistry>,
 }
 
 /// Something that can build a [`Blockchain`].
+#[async_trait]
 pub trait BlockchainBuilder<C>
 where
     C: Blockchain,
 {
-    fn build(self, config: &Arc<EnvVars>) -> C;
+    async fn build(self, config: &Arc<EnvVars>) -> C;
 }

--- a/graph/src/blockchain/firehose_block_ingestor.rs
+++ b/graph/src/blockchain/firehose_block_ingestor.rs
@@ -2,7 +2,7 @@ use std::{marker::PhantomData, sync::Arc, time::Duration};
 
 use crate::{
     blockchain::Block as BlockchainBlock,
-    components::store::ChainStore,
+    components::{adapter::ChainId, store::ChainStore},
     firehose::{self, decode_firehose_block, HeaderOnly},
     prelude::{error, info, Logger},
     util::backoff::ExponentialBackoff,
@@ -15,7 +15,7 @@ use prost_types::Any;
 use slog::{o, trace};
 use tonic::Streaming;
 
-use super::{client::ChainClient, BlockIngestor, Blockchain};
+use super::{client::ChainClient, BlockIngestor, Blockchain, BlockchainKind};
 
 const TRANSFORM_ETHEREUM_HEADER_ONLY: &str =
     "type.googleapis.com/sf.ethereum.transform.v1.HeaderOnly";
@@ -43,7 +43,7 @@ where
     client: Arc<ChainClient<C>>,
     logger: Logger,
     default_transforms: Vec<Transforms>,
-    chain_name: String,
+    chain_name: ChainId,
 
     phantom: PhantomData<M>,
 }
@@ -56,7 +56,7 @@ where
         chain_store: Arc<dyn ChainStore>,
         client: Arc<ChainClient<C>>,
         logger: Logger,
-        chain_name: String,
+        chain_name: ChainId,
     ) -> FirehoseBlockIngestor<M, C> {
         FirehoseBlockIngestor {
             chain_store,
@@ -169,7 +169,7 @@ where
             ExponentialBackoff::new(Duration::from_millis(250), Duration::from_secs(30));
 
         loop {
-            let endpoint = match self.client.firehose_endpoint() {
+            let endpoint = match self.client.firehose_endpoint().await {
                 Ok(endpoint) => endpoint,
                 Err(err) => {
                     error!(
@@ -182,7 +182,7 @@ where
             };
 
             let logger = self.logger.new(
-                o!("provider" => endpoint.provider.to_string(), "network_name"=> self.network_name()),
+                o!("provider" => endpoint.provider.to_string(), "network_name"=> self.network_name().to_string()),
             );
 
             info!(
@@ -226,7 +226,11 @@ where
         }
     }
 
-    fn network_name(&self) -> String {
+    fn network_name(&self) -> ChainId {
         self.chain_name.clone()
+    }
+
+    fn kind(&self) -> BlockchainKind {
+        C::KIND
     }
 }

--- a/graph/src/blockchain/firehose_block_stream.rs
+++ b/graph/src/blockchain/firehose_block_stream.rs
@@ -214,7 +214,7 @@ fn stream_blocks<C: Blockchain, F: FirehoseMapper<C>>(
 
     try_stream! {
         loop {
-            let endpoint = client.firehose_endpoint()?;
+            let endpoint = client.firehose_endpoint().await?;
             let logger = logger.new(o!("deployment" => deployment.clone(), "provider" => endpoint.provider.to_string()));
 
             info!(

--- a/graph/src/blockchain/mock.rs
+++ b/graph/src/blockchain/mock.rs
@@ -1,4 +1,5 @@
 use crate::{
+    bail,
     components::{
         link_resolver::LinkResolver,
         store::{BlockNumber, DeploymentCursorTracker, DeploymentLocator},
@@ -372,15 +373,17 @@ impl Blockchain for MockBlockchain {
         todo!()
     }
 
-    fn runtime(&self) -> (std::sync::Arc<dyn RuntimeAdapter<Self>>, Self::DecoderHook) {
-        todo!()
+    fn runtime(
+        &self,
+    ) -> anyhow::Result<(std::sync::Arc<dyn RuntimeAdapter<Self>>, Self::DecoderHook)> {
+        bail!("mock has no runtime adapter")
     }
 
     fn chain_client(&self) -> Arc<ChainClient<MockBlockchain>> {
         todo!()
     }
 
-    fn block_ingestor(&self) -> anyhow::Result<Box<dyn BlockIngestor>> {
+    async fn block_ingestor(&self) -> anyhow::Result<Box<dyn BlockIngestor>> {
         todo!()
     }
 }

--- a/graph/src/blockchain/substreams_block_stream.rs
+++ b/graph/src/blockchain/substreams_block_stream.rs
@@ -194,7 +194,7 @@ fn stream_blocks<C: Blockchain, F: BlockStreamMapper<C>>(
                 )))?;
             }
 
-            let endpoint = client.firehose_endpoint()?;
+            let endpoint = client.firehose_endpoint().await?;
             let mut logger = logger.new(o!("deployment" => deployment.clone(), "provider" => endpoint.provider.to_string()));
 
         loop {

--- a/graph/src/blockchain/types.rs
+++ b/graph/src/blockchain/types.rs
@@ -333,6 +333,21 @@ pub struct ChainIdentifier {
     pub genesis_block_hash: BlockHash,
 }
 
+impl ChainIdentifier {
+    pub fn is_default(&self) -> bool {
+        ChainIdentifier::default().eq(self)
+    }
+}
+
+impl Default for ChainIdentifier {
+    fn default() -> Self {
+        Self {
+            net_version: String::default(),
+            genesis_block_hash: BlockHash::from(H256::zero()),
+        }
+    }
+}
+
 impl fmt::Display for ChainIdentifier {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(

--- a/graph/src/components/adapter.rs
+++ b/graph/src/components/adapter.rs
@@ -1,0 +1,886 @@
+use std::{
+    collections::HashMap,
+    ops::{Add, Deref},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Duration, Utc};
+
+use itertools::Itertools;
+use slog::{o, warn, Discard, Logger};
+use thiserror::Error;
+
+use crate::{
+    blockchain::{BlockHash, ChainIdentifier},
+    cheap_clone::CheapClone,
+    data::value::Word,
+    prelude::error,
+    tokio::sync::RwLock,
+};
+
+use crate::components::store::{BlockStore as BlockStoreTrait, ChainStore as ChainStoreTrait};
+
+const VALIDATION_ATTEMPT_TTL: Duration = Duration::minutes(5);
+
+#[derive(Debug, Error)]
+pub enum ProviderManagerError {
+    #[error("unknown error {0}")]
+    Unknown(#[from] anyhow::Error),
+    #[error("provider {provider} on chain {chain_id} failed verification, expected ident {expected}, got {actual}")]
+    ProviderFailedValidation {
+        chain_id: ChainId,
+        provider: ProviderName,
+        expected: ChainIdentifier,
+        actual: ChainIdentifier,
+    },
+    #[error("no providers available for chain {0}")]
+    NoProvidersAvailable(ChainId),
+    #[error("all providers for chain_id {0} have failed")]
+    AllProvidersFailed(ChainId),
+}
+
+#[async_trait]
+pub trait NetIdentifiable: Sync + Send {
+    async fn net_identifiers(&self) -> Result<ChainIdentifier, anyhow::Error>;
+    fn provider_name(&self) -> ProviderName;
+}
+
+#[async_trait]
+impl<T: NetIdentifiable> NetIdentifiable for Arc<T> {
+    async fn net_identifiers(&self) -> Result<ChainIdentifier, anyhow::Error> {
+        self.as_ref().net_identifiers().await
+    }
+    fn provider_name(&self) -> ProviderName {
+        self.as_ref().provider_name()
+    }
+}
+
+pub type ProviderName = Word;
+pub type ChainId = Word;
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
+struct Ident {
+    provider: ProviderName,
+    chain_id: ChainId,
+}
+
+#[derive(Error, Debug, Clone)]
+pub enum IdentValidatorError {
+    #[error("database error: {0}")]
+    UnknownError(String),
+    #[error("Store ident wasn't set")]
+    UnsetIdent,
+    #[error("the net version for chain {chain_id} has changed from {store_net_version} to {chain_net_version} since the last time we ran")]
+    ChangedNetVersion {
+        chain_id: ChainId,
+        store_net_version: String,
+        chain_net_version: String,
+    },
+    #[error("the genesis block hash for chain {chain_id} has changed from {store_hash} to {chain_hash} since the last time we ran")]
+    ChangedHash {
+        chain_id: ChainId,
+        store_hash: BlockHash,
+        chain_hash: BlockHash,
+    },
+    #[error("unable to get store for chain {0}")]
+    UnavailableStore(ChainId),
+}
+
+impl From<anyhow::Error> for IdentValidatorError {
+    fn from(value: anyhow::Error) -> Self {
+        IdentValidatorError::UnknownError(value.to_string())
+    }
+}
+
+#[async_trait]
+/// IdentValidator validates that the provided chain ident matches the expected value for a certain
+/// chain_id. This is probably only going to matter for the ChainStore but this allows us to decouple
+/// the all the trait bounds and database integration from the ProviderManager and tests.
+pub trait IdentValidator: Sync + Send {
+    fn check_ident(
+        &self,
+        chain_id: &ChainId,
+        ident: &ChainIdentifier,
+    ) -> Result<(), IdentValidatorError>;
+
+    fn update_ident(
+        &self,
+        chain_id: &ChainId,
+        ident: &ChainIdentifier,
+    ) -> Result<(), anyhow::Error>;
+}
+
+impl<T: ChainStoreTrait, B: BlockStoreTrait<ChainStore = T>> IdentValidator for B {
+    fn check_ident(
+        &self,
+        chain_id: &ChainId,
+        ident: &ChainIdentifier,
+    ) -> Result<(), IdentValidatorError> {
+        let network_chain = self
+            .chain_store(&chain_id)
+            .ok_or_else(|| IdentValidatorError::UnavailableStore(chain_id.clone()))?;
+        let store_ident = network_chain
+            .chain_identifier()
+            .map_err(IdentValidatorError::from)?;
+
+        if store_ident == ChainIdentifier::default() {
+            return Err(IdentValidatorError::UnsetIdent);
+        }
+
+        if store_ident.net_version != ident.net_version {
+            // This behavior is preserved from the previous implementation, firehose does not provide
+            // a net_version so switching to and from firehose will cause this value to be different.
+            // we prioritise rpc when creating the chain but it's possible that it is created by firehose
+            // firehose always return 0 on net_version so we need to allow switching between the two.
+            if store_ident.net_version != "0" && ident.net_version != "0" {
+                return Err(IdentValidatorError::ChangedNetVersion {
+                    chain_id: chain_id.clone(),
+                    store_net_version: store_ident.net_version.clone(),
+                    chain_net_version: ident.net_version.clone(),
+                });
+            }
+        }
+
+        let store_hash = &store_ident.genesis_block_hash;
+        let chain_hash = &ident.genesis_block_hash;
+        if store_hash != chain_hash {
+            return Err(IdentValidatorError::ChangedHash {
+                chain_id: chain_id.clone(),
+                store_hash: store_hash.clone(),
+                chain_hash: chain_hash.clone(),
+            });
+        }
+
+        return Ok(());
+    }
+
+    fn update_ident(
+        &self,
+        chain_id: &ChainId,
+        ident: &ChainIdentifier,
+    ) -> Result<(), anyhow::Error> {
+        let network_chain = self
+            .chain_store(&chain_id)
+            .ok_or_else(|| IdentValidatorError::UnavailableStore(chain_id.clone()))?;
+
+        network_chain.set_chain_identifier(ident)?;
+
+        Ok(())
+    }
+}
+
+pub struct MockIdentValidator;
+
+impl IdentValidator for MockIdentValidator {
+    fn check_ident(
+        &self,
+        _chain_id: &ChainId,
+        _ident: &ChainIdentifier,
+    ) -> Result<(), IdentValidatorError> {
+        Ok(())
+    }
+
+    fn update_ident(
+        &self,
+        _chain_id: &ChainId,
+        _ident: &ChainIdentifier,
+    ) -> Result<(), anyhow::Error> {
+        Ok(())
+    }
+}
+
+/// ProviderCorrectness will maintain a list of providers which have had their
+/// ChainIdentifiers checked. The first identifier is considered correct, if a later
+/// provider for the same chain offers a different ChainIdentifier, this will be considered a
+/// failed validation and it will be disabled.
+#[derive(Clone, Debug)]
+pub struct ProviderManager<T: NetIdentifiable + Clone + 'static> {
+    inner: Arc<Inner<T>>,
+}
+
+impl<T: NetIdentifiable + Clone> CheapClone for ProviderManager<T> {
+    fn cheap_clone(&self) -> Self {
+        Self {
+            inner: self.inner.cheap_clone(),
+        }
+    }
+}
+
+impl<T: NetIdentifiable + Clone> Default for ProviderManager<T> {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                logger: Logger::root(Discard, o!()),
+                adapters: HashMap::default(),
+                status: vec![],
+                validator: Arc::new(MockIdentValidator {}),
+            }),
+        }
+    }
+}
+
+impl<T: NetIdentifiable + Clone + 'static> ProviderManager<T> {
+    pub fn new(
+        logger: Logger,
+        adapters: impl Iterator<Item = (ChainId, Vec<T>)>,
+        validator: Arc<dyn IdentValidator>,
+    ) -> Self {
+        let mut status: Vec<(Ident, RwLock<GenesisCheckStatus>)> = Vec::new();
+
+        let adapters = HashMap::from_iter(adapters.map(|(chain_id, adapters)| {
+            let adapters = adapters
+                .into_iter()
+                .map(|adapter| {
+                    let name = adapter.provider_name();
+
+                    // Get status index or add new status.
+                    let index = match status
+                        .iter()
+                        .find_position(|(ident, _)| ident.provider.eq(&name))
+                    {
+                        Some((index, _)) => index,
+                        None => {
+                            status.push((
+                                Ident {
+                                    provider: name,
+                                    chain_id: chain_id.clone(),
+                                },
+                                RwLock::new(GenesisCheckStatus::NotChecked),
+                            ));
+                            status.len() - 1
+                        }
+                    };
+                    (index, adapter)
+                })
+                .collect_vec();
+
+            (chain_id, adapters)
+        }));
+
+        Self {
+            inner: Arc::new(Inner {
+                logger,
+                adapters,
+                status,
+                validator,
+            }),
+        }
+    }
+
+    pub fn len(&self, chain_id: &ChainId) -> usize {
+        self.inner
+            .adapters
+            .get(chain_id)
+            .map(|a| a.len())
+            .unwrap_or_default()
+    }
+
+    #[cfg(debug_assertions)]
+    pub async fn mark_all_valid(&self) {
+        for (_, status) in self.inner.status.iter() {
+            let mut s = status.write().await;
+            *s = GenesisCheckStatus::Valid;
+        }
+    }
+
+    async fn verify(&self, adapters: &Vec<(usize, T)>) -> Result<(), ProviderManagerError> {
+        let mut tasks = vec![];
+
+        for (index, adapter) in adapters.into_iter() {
+            let inner = self.inner.cheap_clone();
+            let adapter = adapter.clone();
+            let index = *index;
+            tasks.push(inner.verify_provider(index, adapter));
+        }
+
+        crate::futures03::future::join_all(tasks)
+            .await
+            .into_iter()
+            .collect::<Result<Vec<()>, ProviderManagerError>>()?;
+
+        Ok(())
+    }
+
+    /// get_all_unverified it's an escape hatch for places where checking the adapter status is
+    /// undesirable or just can't be done because async can't be used. This function just returns
+    /// the stored adapters and doesn't try to perform any verification. It will also return
+    /// adapters that failed verification. For the most part this should be fine since ideally
+    /// get_all would have been used before. Nevertheless, it is possible that a misconfigured
+    /// adapter is returned from this list even after validation.
+    pub fn get_all_unverified(&self, chain_id: &ChainId) -> Result<Vec<&T>, ProviderManagerError> {
+        Ok(self
+            .inner
+            .adapters
+            .get(chain_id)
+            .map(|v| v.iter().map(|v| &v.1).collect())
+            .unwrap_or_default())
+    }
+
+    /// get_all will trigger the verification of the endpoints for the provided chain_id, hence the
+    /// async. If this is undesirable, check `get_all_unverified` as an alternatives that does not
+    /// cause the validation but also doesn't not guaratee any adapters have been validated.
+    pub async fn get_all(&self, chain_id: &ChainId) -> Result<Vec<&T>, ProviderManagerError> {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async move {
+            let adapters = match self.inner.adapters.get(chain_id) {
+                Some(adapters) if !adapters.is_empty() => adapters,
+                _ => return Ok(vec![]),
+            };
+
+            // Optimistic check
+            if self.inner.is_all_verified(&adapters).await {
+                return Ok(adapters.iter().map(|v| &v.1).collect());
+            }
+
+            match self.verify(adapters).await {
+                Ok(_) => {}
+                Err(error) => error!(
+                    self.inner.logger,
+                    "unable to verify genesis for adapter: {}",
+                    error.to_string()
+                ),
+            }
+
+            self.inner.get_verified_for_chain(&chain_id).await
+        })
+        .await
+        .map_err(|_| crate::anyhow::anyhow!("timed out, validation took too long"))?
+    }
+}
+
+struct Inner<T: NetIdentifiable> {
+    logger: Logger,
+    // Most operations start by getting the value so we keep track of the index to minimize the
+    // locked surface.
+    adapters: HashMap<ChainId, Vec<(usize, T)>>,
+    // Status per (ChainId, ProviderName) pair. The RwLock here helps prevent multiple concurrent
+    // checks for the same provider, when one provider is being checked, all other uses will wait,
+    // this is correct because no provider should be used until they have been validated.
+    // There shouldn't be many values here so Vec is fine even if less ergonomic, because we track
+    // the index alongside the adapter it should be O(1) after initialization.
+    status: Vec<(Ident, RwLock<GenesisCheckStatus>)>,
+    // Validator used to compare the existing identifier to the one returned by an adapter.
+    validator: Arc<dyn IdentValidator + 'static>,
+}
+
+impl<T: NetIdentifiable + 'static> std::fmt::Debug for Inner<T> {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
+    }
+}
+
+impl<T: NetIdentifiable + 'static> Inner<T> {
+    async fn is_all_verified(&self, adapters: &Vec<(usize, T)>) -> bool {
+        for (index, _) in adapters.iter() {
+            let status = self.status.get(*index).unwrap().1.read().await;
+            if *status != GenesisCheckStatus::Valid {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    /// Returns any adapters that have been validated, empty if none are defined or an error if
+    /// all adapters have failed or are unavailable, returns different errors for these use cases
+    /// so that that caller can handle the different situations, as one is permanent and the other
+    /// is retryable.
+    async fn get_verified_for_chain(
+        &self,
+        chain_id: &ChainId,
+    ) -> Result<Vec<&T>, ProviderManagerError> {
+        let mut out = vec![];
+        let adapters = match self.adapters.get(chain_id) {
+            Some(adapters) if !adapters.is_empty() => adapters,
+            _ => return Ok(vec![]),
+        };
+
+        let mut failed = 0;
+        for (index, adapter) in adapters.iter() {
+            let status = self.status.get(*index).unwrap().1.read().await;
+            match status.deref() {
+                GenesisCheckStatus::Valid => {}
+                GenesisCheckStatus::Failed => {
+                    failed += 1;
+                    continue;
+                }
+                GenesisCheckStatus::NotChecked | GenesisCheckStatus::TemporaryFailure { .. } => {
+                    continue
+                }
+            }
+            out.push(adapter);
+        }
+
+        if out.is_empty() {
+            if failed == adapters.len() {
+                return Err(ProviderManagerError::AllProvidersFailed(chain_id.clone()));
+            }
+
+            return Err(ProviderManagerError::NoProvidersAvailable(chain_id.clone()));
+        }
+
+        Ok(out)
+    }
+
+    async fn get_ident_status(&self, index: usize) -> (Ident, GenesisCheckStatus) {
+        match self.status.get(index) {
+            Some(status) => (status.0.clone(), status.1.read().await.clone()),
+            None => (Ident::default(), GenesisCheckStatus::Failed),
+        }
+    }
+
+    fn ttl_has_elapsed(checked_at: &DateTime<Utc>) -> bool {
+        checked_at.add(VALIDATION_ATTEMPT_TTL) < Utc::now()
+    }
+
+    fn should_verify(status: &GenesisCheckStatus) -> bool {
+        match status {
+            GenesisCheckStatus::TemporaryFailure { checked_at }
+                if Self::ttl_has_elapsed(checked_at) =>
+            {
+                true
+            }
+            // Let check the provider
+            GenesisCheckStatus::NotChecked => true,
+            _ => false,
+        }
+    }
+
+    async fn verify_provider(
+        self: Arc<Inner<T>>,
+        index: usize,
+        adapter: T,
+    ) -> Result<(), ProviderManagerError> {
+        let (ident, status) = self.get_ident_status(index).await;
+        if !Self::should_verify(&status) {
+            return Ok(());
+        }
+
+        let mut status = self.status.get(index).unwrap().1.write().await;
+        // double check nothing has changed.
+        if !Self::should_verify(&status) {
+            return Ok(());
+        }
+
+        let chain_ident = match adapter.net_identifiers().await {
+            Ok(ident) => ident,
+            Err(err) => {
+                error!(
+                    &self.logger,
+                    "failed to get net identifiers: {}",
+                    err.to_string()
+                );
+                *status = GenesisCheckStatus::TemporaryFailure {
+                    checked_at: Utc::now(),
+                };
+
+                return Err(err.into());
+            }
+        };
+
+        match self.validator.check_ident(&ident.chain_id, &chain_ident) {
+            Ok(_) => {
+                *status = GenesisCheckStatus::Valid;
+            }
+            Err(err) => match err {
+                IdentValidatorError::UnsetIdent => {
+                    self.validator
+                        .update_ident(&ident.chain_id, &chain_ident)
+                        .map_err(ProviderManagerError::from)?;
+                    *status = GenesisCheckStatus::Valid;
+                }
+                IdentValidatorError::ChangedNetVersion {
+                    chain_id,
+                    store_net_version,
+                    chain_net_version,
+                } if store_net_version == "0" => {
+                    warn!(self.logger,
+                            "the net version for chain {} has changed from 0 to {} since the last time we ran, ignoring difference because 0 means UNSET and firehose does not provide it",
+                            chain_id,
+                            chain_net_version,
+                            );
+                    *status = GenesisCheckStatus::Valid;
+                }
+                IdentValidatorError::ChangedNetVersion {
+                    store_net_version,
+                    chain_net_version,
+                    ..
+                } => {
+                    *status = GenesisCheckStatus::Failed;
+                    return Err(ProviderManagerError::ProviderFailedValidation {
+                        provider: ident.provider,
+                        expected: ChainIdentifier {
+                            net_version: store_net_version,
+                            genesis_block_hash: chain_ident.genesis_block_hash.clone(),
+                        },
+                        actual: ChainIdentifier {
+                            net_version: chain_net_version,
+                            genesis_block_hash: chain_ident.genesis_block_hash,
+                        },
+                        chain_id: ident.chain_id.clone(),
+                    });
+                }
+                IdentValidatorError::ChangedHash {
+                    store_hash,
+                    chain_hash,
+                    ..
+                } => {
+                    *status = GenesisCheckStatus::Failed;
+                    return Err(ProviderManagerError::ProviderFailedValidation {
+                        provider: ident.provider,
+                        expected: ChainIdentifier {
+                            net_version: chain_ident.net_version.clone(),
+                            genesis_block_hash: store_hash,
+                        },
+                        actual: ChainIdentifier {
+                            net_version: chain_ident.net_version,
+                            genesis_block_hash: chain_hash,
+                        },
+                        chain_id: ident.chain_id.clone(),
+                    });
+                }
+                e @ IdentValidatorError::UnavailableStore(_)
+                | e @ IdentValidatorError::UnknownError(_) => {
+                    *status = GenesisCheckStatus::TemporaryFailure {
+                        checked_at: Utc::now(),
+                    };
+
+                    return Err(ProviderManagerError::Unknown(crate::anyhow::anyhow!(
+                        e.to_string()
+                    )));
+                }
+            },
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GenesisCheckStatus {
+    NotChecked,
+    TemporaryFailure { checked_at: DateTime<Utc> },
+    Valid,
+    Failed,
+}
+
+#[cfg(test)]
+mod test {
+    use std::{
+        ops::Sub,
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+    };
+
+    use crate::{
+        bail,
+        blockchain::BlockHash,
+        components::adapter::{ChainId, GenesisCheckStatus, MockIdentValidator},
+        data::value::Word,
+        prelude::lazy_static,
+    };
+    use async_trait::async_trait;
+    use chrono::{Duration, Utc};
+    use ethabi::ethereum_types::H256;
+    use slog::{o, Discard, Logger};
+
+    use crate::{blockchain::ChainIdentifier, components::adapter::ProviderManagerError};
+
+    use super::{
+        IdentValidator, IdentValidatorError, NetIdentifiable, ProviderManager, ProviderName,
+        VALIDATION_ATTEMPT_TTL,
+    };
+
+    const TEST_CHAIN_ID: &str = "valid";
+
+    lazy_static! {
+        static ref UNTESTABLE_ADAPTER: MockAdapter =
+                    MockAdapter{
+                provider: "untestable".into(),
+                status: GenesisCheckStatus::TemporaryFailure { checked_at: Utc::now()},
+            };
+
+                        // way past TTL, ready to check again
+        static ref TESTABLE_ADAPTER: MockAdapter =
+            MockAdapter{
+                provider: "testable".into(),
+                status: GenesisCheckStatus::TemporaryFailure { checked_at: Utc::now().sub(Duration::seconds(10000000)) },
+            };
+        static ref VALID_ADAPTER: MockAdapter = MockAdapter {provider: "valid".into(), status: GenesisCheckStatus::Valid,};
+        static ref FAILED_ADAPTER: MockAdapter = MockAdapter {provider: "FAILED".into(), status: GenesisCheckStatus::Failed,};
+        static ref NEW_CHAIN_IDENT: ChainIdentifier =ChainIdentifier { net_version: "123".to_string(), genesis_block_hash:  BlockHash::from( H256::repeat_byte(1))};
+    }
+
+    struct TestValidator {
+        check_result: Result<(), IdentValidatorError>,
+        expected_new_ident: Option<ChainIdentifier>,
+    }
+
+    impl IdentValidator for TestValidator {
+        fn check_ident(
+            &self,
+            _chain_id: &ChainId,
+            _ident: &ChainIdentifier,
+        ) -> Result<(), IdentValidatorError> {
+            self.check_result.clone()
+        }
+
+        fn update_ident(
+            &self,
+            _chain_id: &ChainId,
+            ident: &ChainIdentifier,
+        ) -> Result<(), anyhow::Error> {
+            match self.expected_new_ident.as_ref() {
+                None => unreachable!("unexpected call to update_ident"),
+                Some(ident_expected) if ident_expected.eq(ident) => Ok(()),
+                Some(_) => bail!("update_ident called with unexpected value"),
+            }
+        }
+    }
+
+    #[derive(Clone, PartialEq, Eq, Debug)]
+    struct MockAdapter {
+        provider: Word,
+        status: GenesisCheckStatus,
+    }
+
+    #[async_trait]
+    impl NetIdentifiable for MockAdapter {
+        async fn net_identifiers(&self) -> Result<ChainIdentifier, anyhow::Error> {
+            match self.status {
+                GenesisCheckStatus::TemporaryFailure { checked_at }
+                    if checked_at > Utc::now().sub(VALIDATION_ATTEMPT_TTL) =>
+                {
+                    unreachable!("should never check if ttl has not elapsed");
+                }
+                _ => Ok(NEW_CHAIN_IDENT.clone()),
+            }
+        }
+
+        fn provider_name(&self) -> ProviderName {
+            self.provider.clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_provider_manager() {
+        struct Case<'a> {
+            name: &'a str,
+            chain_id: &'a str,
+            adapters: Vec<(ChainId, Vec<MockAdapter>)>,
+            validator: Option<TestValidator>,
+            expected: Result<Vec<&'a MockAdapter>, ProviderManagerError>,
+        }
+
+        let cases = vec![
+            Case {
+                name: "no adapters",
+                chain_id: TEST_CHAIN_ID,
+                adapters: vec![],
+                validator: None,
+                expected: Ok(vec![]),
+            },
+            Case {
+                name: "no adapters",
+                chain_id: TEST_CHAIN_ID,
+                adapters: vec![(TEST_CHAIN_ID.into(), vec![TESTABLE_ADAPTER.clone()])],
+                validator: Some(TestValidator {
+                    check_result: Err(IdentValidatorError::UnsetIdent),
+                    expected_new_ident: Some(NEW_CHAIN_IDENT.clone()),
+                }),
+                expected: Ok(vec![&TESTABLE_ADAPTER]),
+            },
+            Case {
+                name: "adapter temporary failure with Ident unset",
+                chain_id: TEST_CHAIN_ID,
+                // UNTESTABLE_ADAPTER has failed ident, will be valid cause idents has None value
+                adapters: vec![(TEST_CHAIN_ID.into(), vec![UNTESTABLE_ADAPTER.clone()])],
+                validator: None,
+                expected: Err(ProviderManagerError::NoProvidersAvailable(
+                    TEST_CHAIN_ID.into(),
+                )),
+            },
+            Case {
+                name: "adapter temporary failure",
+                chain_id: TEST_CHAIN_ID,
+                adapters: vec![(TEST_CHAIN_ID.into(), vec![UNTESTABLE_ADAPTER.clone()])],
+                validator: None,
+                expected: Err(ProviderManagerError::NoProvidersAvailable(
+                    TEST_CHAIN_ID.into(),
+                )),
+            },
+            Case {
+                name: "wrong chain ident",
+                chain_id: TEST_CHAIN_ID,
+                adapters: vec![(TEST_CHAIN_ID.into(), vec![FAILED_ADAPTER.clone()])],
+                validator: Some(TestValidator {
+                    check_result: Err(IdentValidatorError::ChangedNetVersion {
+                        chain_id: TEST_CHAIN_ID.into(),
+                        store_net_version: "".to_string(),
+                        chain_net_version: "".to_string(),
+                    }),
+                    expected_new_ident: None,
+                }),
+                expected: Err(ProviderManagerError::AllProvidersFailed(
+                    TEST_CHAIN_ID.into(),
+                )),
+            },
+            Case {
+                name: "all adapters ok or not checkable yet",
+                chain_id: TEST_CHAIN_ID,
+                adapters: vec![(
+                    TEST_CHAIN_ID.into(),
+                    vec![VALID_ADAPTER.clone(), FAILED_ADAPTER.clone()],
+                )],
+                // if a check is performed (which it shouldn't) the test will fail
+                validator: Some(TestValidator {
+                    check_result: Err(IdentValidatorError::ChangedNetVersion {
+                        chain_id: TEST_CHAIN_ID.into(),
+                        store_net_version: "".to_string(),
+                        chain_net_version: "".to_string(),
+                    }),
+                    expected_new_ident: None,
+                }),
+                expected: Ok(vec![&VALID_ADAPTER]),
+            },
+            Case {
+                name: "all adapters ok or checkable",
+                chain_id: TEST_CHAIN_ID,
+                adapters: vec![(
+                    TEST_CHAIN_ID.into(),
+                    vec![VALID_ADAPTER.clone(), TESTABLE_ADAPTER.clone()],
+                )],
+                validator: None,
+                expected: Ok(vec![&VALID_ADAPTER, &TESTABLE_ADAPTER]),
+            },
+        ];
+
+        for case in cases.into_iter() {
+            let Case {
+                name,
+                chain_id,
+                adapters,
+                validator,
+                expected,
+            } = case;
+
+            let logger = Logger::root(Discard, o!());
+            let chain_id = chain_id.into();
+
+            let validator: Arc<dyn IdentValidator> = match validator {
+                None => Arc::new(MockIdentValidator {}),
+                Some(validator) => Arc::new(validator),
+            };
+
+            let manager = ProviderManager::new(logger, adapters.clone().into_iter(), validator);
+
+            for (_, adapters) in adapters.iter() {
+                for adapter in adapters.iter() {
+                    let provider = adapter.provider.clone();
+                    let slot = manager
+                        .inner
+                        .status
+                        .iter()
+                        .find(|(ident, _)| ident.provider.eq(&provider))
+                        .expect(&format!(
+                            "case: {} - there should be a status for provider \"{}\"",
+                            name, provider
+                        ));
+                    let mut s = slot.1.write().await;
+                    *s = adapter.status.clone();
+                }
+            }
+
+            let result = manager.get_all(&chain_id).await;
+            match (expected, result) {
+                (Ok(expected), Ok(result)) => assert_eq!(
+                    expected, result,
+                    "case {} failed. Result: {:?}",
+                    name, result
+                ),
+                (Err(expected), Err(result)) => assert_eq!(
+                    expected.to_string(),
+                    result.to_string(),
+                    "case {} failed. Result: {:?}",
+                    name,
+                    result
+                ),
+                (Ok(expected), Err(result)) => panic!(
+                    "case {} failed. Result: {}, Expected: {:?}",
+                    name, result, expected
+                ),
+                (Err(expected), Ok(result)) => panic!(
+                    "case {} failed. Result: {:?}, Expected: {}",
+                    name, result, expected
+                ),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_provider_manager_updates_on_unset() {
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        struct MockAdapter {}
+
+        #[async_trait]
+        impl NetIdentifiable for MockAdapter {
+            async fn net_identifiers(&self) -> Result<ChainIdentifier, anyhow::Error> {
+                Ok(NEW_CHAIN_IDENT.clone())
+            }
+            fn provider_name(&self) -> ProviderName {
+                TEST_CHAIN_ID.into()
+            }
+        }
+
+        struct TestValidator {
+            called: AtomicBool,
+            err: IdentValidatorError,
+        }
+
+        impl IdentValidator for TestValidator {
+            fn check_ident(
+                &self,
+                _chain_id: &ChainId,
+                _ident: &ChainIdentifier,
+            ) -> Result<(), IdentValidatorError> {
+                Err(self.err.clone())
+            }
+
+            fn update_ident(
+                &self,
+                _chain_id: &ChainId,
+                ident: &ChainIdentifier,
+            ) -> Result<(), anyhow::Error> {
+                if NEW_CHAIN_IDENT.eq(ident) {
+                    self.called.store(true, Ordering::SeqCst);
+                    return Ok(());
+                }
+
+                unreachable!("unexpected call to update_ident ot unexpected ident passed");
+            }
+        }
+
+        let logger = Logger::root(Discard, o!());
+        let chain_id = TEST_CHAIN_ID.into();
+
+        // Ensure the provider updates the chain ident when it wasn't set yet.
+        let validator = Arc::new(TestValidator {
+            called: AtomicBool::default(),
+            err: IdentValidatorError::UnsetIdent,
+        });
+        let adapter = MockAdapter {};
+
+        let manager = ProviderManager::new(
+            logger,
+            vec![(TEST_CHAIN_ID.into(), vec![adapter.clone()])].into_iter(),
+            validator.clone(),
+        );
+
+        let mut result = manager.get_all(&chain_id).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(&adapter, result.pop().unwrap());
+        assert_eq!(validator.called.load(Ordering::SeqCst), true);
+    }
+}

--- a/graph/src/components/mod.rs
+++ b/graph/src/components/mod.rs
@@ -60,6 +60,8 @@ pub mod metrics;
 /// Components dealing with versioning
 pub mod versions;
 
+pub mod adapter;
+
 /// A component that receives events of type `T`.
 pub trait EventConsumer<E> {
     /// Get the event sink.

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -410,6 +410,11 @@ pub trait QueryStoreManager: Send + Sync + 'static {
 pub trait BlockStore: Send + Sync + 'static {
     type ChainStore: ChainStore;
 
+    fn create_chain_store(
+        &self,
+        network: &str,
+        ident: ChainIdentifier,
+    ) -> anyhow::Result<Arc<Self::ChainStore>>;
     fn chain_store(&self, network: &str) -> Option<Arc<Self::ChainStore>>;
 }
 
@@ -536,7 +541,10 @@ pub trait ChainStore: Send + Sync + 'static {
     async fn clear_call_cache(&self, from: BlockNumber, to: BlockNumber) -> Result<(), Error>;
 
     /// Return the chain identifier for this store.
-    fn chain_identifier(&self) -> &ChainIdentifier;
+    fn chain_identifier(&self) -> Result<ChainIdentifier, Error>;
+
+    /// Update the chain identifier for this store.
+    fn set_chain_identifier(&self, ident: &ChainIdentifier) -> Result<(), Error>;
 }
 
 pub trait EthereumCallCache: Send + Sync + 'static {

--- a/graph/src/firehose/endpoints.rs
+++ b/graph/src/firehose/endpoints.rs
@@ -1,29 +1,34 @@
 use crate::{
-    blockchain::block_stream::FirehoseCursor,
-    blockchain::Block as BlockchainBlock,
-    blockchain::BlockPtr,
+    bail,
+    blockchain::{
+        block_stream::FirehoseCursor, Block as BlockchainBlock, BlockHash, BlockPtr,
+        ChainIdentifier,
+    },
     cheap_clone::CheapClone,
-    components::store::BlockNumber,
+    components::{
+        adapter::{ChainId, NetIdentifiable, ProviderManager, ProviderName},
+        store::BlockNumber,
+    },
     data::value::Word,
-    endpoint::{ConnectionType, EndpointMetrics, Provider, RequestLabels},
+    endpoint::{ConnectionType, EndpointMetrics, RequestLabels},
     env::ENV_VARS,
     firehose::decode_firehose_block,
     prelude::{anyhow, debug, info, DeploymentHash},
-    substreams_rpc,
+    substreams::Package,
+    substreams_rpc::{self, response, BlockScopedData, Response},
 };
 
 use crate::firehose::fetch_client::FetchClient;
 use crate::firehose::interceptors::AuthInterceptor;
+use async_trait::async_trait;
 use futures03::StreamExt;
 use http::uri::{Scheme, Uri};
 use itertools::Itertools;
+use prost::Message;
 use slog::Logger;
 use std::{
-    collections::{BTreeMap, HashMap},
-    fmt::Display,
-    ops::ControlFlow,
-    sync::Arc,
-    time::Duration,
+    collections::HashMap, fmt::Display, marker::PhantomData, ops::ControlFlow, str::FromStr,
+    sync::Arc, time::Duration,
 };
 use tonic::codegen::InterceptedService;
 use tonic::{
@@ -40,23 +45,182 @@ use super::{codec as firehose, interceptors::MetricsInterceptor, stream_client::
 /// For more details see: https://github.com/graphprotocol/graph-node/issues/3879
 pub const SUBGRAPHS_PER_CONN: usize = 100;
 
+/// Substreams does not provide a simpler way to get the chain identity so we use this package
+/// to obtain the genesis hash.
+const SUBSTREAMS_HEAD_TRACKER_BYTES: &[u8; 89935] = include_bytes!(
+    "../../../substreams/substreams-head-tracker/substreams-head-tracker-v1.0.0.spkg"
+);
+
 const LOW_VALUE_THRESHOLD: usize = 10;
 const LOW_VALUE_USED_PERCENTAGE: usize = 50;
 const HIGH_VALUE_USED_PERCENTAGE: usize = 80;
 
+/// Firehose endpoints do not currently provide a chain agnostic way of getting the genesis block.
+/// In order to get the genesis hash the block needs to be decoded and the graph crate has no
+/// knowledge of specific chains so this abstracts the chain details from the FirehoseEndpoint.
+#[async_trait]
+pub trait GenesisDecoder: std::fmt::Debug + Sync + Send {
+    async fn get_genesis_block_ptr(
+        &self,
+        endpoint: &Arc<FirehoseEndpoint>,
+    ) -> Result<BlockPtr, anyhow::Error>;
+    fn box_clone(&self) -> Box<dyn GenesisDecoder>;
+}
+
+#[derive(Debug, Clone)]
+pub struct FirehoseGenesisDecoder<M: prost::Message + BlockchainBlock + Default + 'static> {
+    pub logger: Logger,
+    phantom: PhantomData<M>,
+}
+
+impl<M: prost::Message + BlockchainBlock + Default + 'static> FirehoseGenesisDecoder<M> {
+    pub fn new(logger: Logger) -> Box<dyn GenesisDecoder> {
+        Box::new(Self {
+            logger,
+            phantom: PhantomData,
+        })
+    }
+}
+
+#[async_trait]
+impl<M: prost::Message + BlockchainBlock + Default + 'static> GenesisDecoder
+    for FirehoseGenesisDecoder<M>
+{
+    async fn get_genesis_block_ptr(
+        &self,
+        endpoint: &Arc<FirehoseEndpoint>,
+    ) -> Result<BlockPtr, anyhow::Error> {
+        endpoint.genesis_block_ptr::<M>(&self.logger).await
+    }
+
+    fn box_clone(&self) -> Box<dyn GenesisDecoder> {
+        Box::new(Self {
+            logger: self.logger.cheap_clone(),
+            phantom: PhantomData,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SubstreamsGenesisDecoder {}
+
+#[async_trait]
+impl GenesisDecoder for SubstreamsGenesisDecoder {
+    async fn get_genesis_block_ptr(
+        &self,
+        endpoint: &Arc<FirehoseEndpoint>,
+    ) -> Result<BlockPtr, anyhow::Error> {
+        let package = Package::decode(SUBSTREAMS_HEAD_TRACKER_BYTES.to_vec().as_ref()).unwrap();
+        let headers = ConnectionHeaders::new();
+        let endpoint = endpoint.cheap_clone();
+
+        let mut stream = endpoint
+            .substreams(
+                substreams_rpc::Request {
+                    start_block_num: 0,
+                    start_cursor: "".to_string(),
+                    stop_block_num: 1,
+                    final_blocks_only: true,
+                    production_mode: false,
+                    output_module: "map_blocks".to_string(),
+                    modules: package.modules,
+                    debug_initial_store_snapshot_for_modules: vec![],
+                },
+                &headers,
+            )
+            .await?;
+
+        tokio::time::timeout(Duration::from_secs(30), async move {
+            loop {
+                let rsp = stream.next().await;
+
+                match rsp {
+                    Some(Ok(Response { message })) => match message {
+                        Some(response::Message::BlockScopedData(BlockScopedData {
+                            clock, ..
+                        })) if clock.is_some() => {
+                            // unwrap: the match guard ensures this is safe.
+                            let clock = clock.unwrap();
+                            return Ok(BlockPtr {
+                                number: clock.number.try_into()?,
+                                hash: BlockHash::from_str(&clock.id)?,
+                            });
+                        }
+                        // most other messages are related to the protocol itself or debugging which are
+                        // not relevant for this use case.
+                        Some(_) => continue,
+                        // No idea when this would happen
+                        None => continue,
+                    },
+                    Some(Err(status)) => bail!("unable to get genesis block, status: {}", status),
+                    None => bail!("unable to get genesis block, stream ended"),
+                }
+            }
+        })
+        .await
+        .map_err(|_| anyhow!("unable to get genesis block, timed out."))?
+    }
+
+    fn box_clone(&self) -> Box<dyn GenesisDecoder> {
+        Box::new(Self {})
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct NoopGenesisDecoder;
+
+impl NoopGenesisDecoder {
+    pub fn boxed() -> Box<Self> {
+        Box::new(Self {})
+    }
+}
+
+#[async_trait]
+impl GenesisDecoder for NoopGenesisDecoder {
+    async fn get_genesis_block_ptr(
+        &self,
+        _endpoint: &Arc<FirehoseEndpoint>,
+    ) -> Result<BlockPtr, anyhow::Error> {
+        Ok(BlockPtr {
+            hash: BlockHash::zero(),
+            number: 0,
+        })
+    }
+
+    fn box_clone(&self) -> Box<dyn GenesisDecoder> {
+        Box::new(Self {})
+    }
+}
+
 #[derive(Debug)]
 pub struct FirehoseEndpoint {
-    pub provider: Provider,
+    pub provider: ProviderName,
     pub auth: AuthInterceptor,
     pub filters_enabled: bool,
     pub compression_enabled: bool,
     pub subgraph_limit: SubgraphLimit,
+    genesis_decoder: Box<dyn GenesisDecoder>,
     endpoint_metrics: Arc<EndpointMetrics>,
     channel: Channel,
 }
 
 #[derive(Debug)]
 pub struct ConnectionHeaders(HashMap<MetadataKey<Ascii>, MetadataValue<Ascii>>);
+
+#[async_trait]
+impl NetIdentifiable for Arc<FirehoseEndpoint> {
+    async fn net_identifiers(&self) -> Result<ChainIdentifier, anyhow::Error> {
+        let ptr: BlockPtr = self.genesis_decoder.get_genesis_block_ptr(self).await?;
+
+        Ok(ChainIdentifier {
+            net_version: "0".to_string(),
+            genesis_block_hash: ptr.hash,
+        })
+    }
+    fn provider_name(&self) -> ProviderName {
+        self.provider.clone()
+    }
+}
 
 impl ConnectionHeaders {
     pub fn new() -> Self {
@@ -149,6 +313,7 @@ impl FirehoseEndpoint {
         compression_enabled: bool,
         subgraph_limit: SubgraphLimit,
         endpoint_metrics: Arc<EndpointMetrics>,
+        genesis_decoder: Box<dyn GenesisDecoder>,
     ) -> Self {
         let uri = url
             .as_ref()
@@ -211,6 +376,7 @@ impl FirehoseEndpoint {
             compression_enabled,
             subgraph_limit,
             endpoint_metrics,
+            genesis_decoder,
         }
     }
 
@@ -273,7 +439,6 @@ impl FirehoseEndpoint {
         if self.compression_enabled {
             client = client.send_compressed(CompressionEncoding::Gzip);
         }
-
         client = client
             .max_decoding_message_size(1024 * 1024 * ENV_VARS.firehose_grpc_max_decode_size_mb);
 
@@ -462,25 +627,46 @@ impl FirehoseEndpoint {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct FirehoseEndpoints(Vec<Arc<FirehoseEndpoint>>);
+#[derive(Clone, Debug, Default)]
+pub struct FirehoseEndpoints(ChainId, ProviderManager<Arc<FirehoseEndpoint>>);
 
 impl FirehoseEndpoints {
-    pub fn new() -> Self {
-        Self(vec![])
+    pub fn for_testing(adapters: Vec<Arc<FirehoseEndpoint>>) -> Self {
+        use slog::{o, Discard};
+
+        use crate::components::adapter::MockIdentValidator;
+        let chain_id: Word = "testing".into();
+
+        Self(
+            chain_id.clone(),
+            ProviderManager::new(
+                Logger::root(Discard, o!()),
+                vec![(chain_id, adapters)].into_iter(),
+                Arc::new(MockIdentValidator),
+            ),
+        )
+    }
+
+    pub fn new(
+        chain_id: ChainId,
+        provider_manager: ProviderManager<Arc<FirehoseEndpoint>>,
+    ) -> Self {
+        Self(chain_id, provider_manager)
     }
 
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.1.len(&self.0)
     }
 
     /// This function will attempt to grab an endpoint based on the Lowest error count
     //  with high capacity available. If an adapter cannot be found `endpoint` will
     // return an error.
-    pub fn endpoint(&self) -> anyhow::Result<Arc<FirehoseEndpoint>> {
+    pub async fn endpoint(&self) -> anyhow::Result<Arc<FirehoseEndpoint>> {
         let endpoint = self
-            .0
-            .iter()
+            .1
+            .get_all(&self.0)
+            .await?
+            .into_iter()
             .sorted_by_key(|x| x.current_error_count())
             .try_fold(None, |acc, adapter| {
                 match adapter.get_capacity() {
@@ -502,66 +688,6 @@ impl FirehoseEndpoints {
             adapter.cloned().ok_or(anyhow!("unable to get a connection, increase the firehose conn_pool_size or limit for the node"))
         }
     }
-
-    pub fn remove(&mut self, provider: &str) {
-        self.0
-            .retain(|network_endpoint| network_endpoint.provider.as_str() != provider);
-    }
-}
-
-impl From<Vec<Arc<FirehoseEndpoint>>> for FirehoseEndpoints {
-    fn from(val: Vec<Arc<FirehoseEndpoint>>) -> Self {
-        FirehoseEndpoints(val)
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct FirehoseNetworks {
-    /// networks contains a map from chain id (`near-mainnet`, `near-testnet`, `solana-mainnet`, etc.)
-    /// to a list of FirehoseEndpoint (type wrapper around `Arc<Vec<FirehoseEndpoint>>`).
-    pub networks: BTreeMap<String, FirehoseEndpoints>,
-}
-
-impl FirehoseNetworks {
-    pub fn new() -> FirehoseNetworks {
-        FirehoseNetworks {
-            networks: BTreeMap::new(),
-        }
-    }
-
-    pub fn insert(&mut self, chain_id: String, endpoint: Arc<FirehoseEndpoint>) {
-        let endpoints = self
-            .networks
-            .entry(chain_id)
-            .or_insert_with(FirehoseEndpoints::new);
-
-        endpoints.0.push(endpoint);
-    }
-
-    pub fn remove(&mut self, chain_id: &str, provider: &str) {
-        if let Some(endpoints) = self.networks.get_mut(chain_id) {
-            endpoints.remove(provider);
-        }
-    }
-
-    /// Returns a `HashMap` where the key is the chain's id and the key is an endpoint for this chain.
-    /// There can be multiple keys with the same chain id but with different
-    /// endpoint where multiple providers exist for a single chain id. Providers with the same
-    /// label do not need to be tested individually, if one is working, every other endpoint in the
-    /// pool should also work.
-    pub fn flatten(&self) -> HashMap<(String, Word), Arc<FirehoseEndpoint>> {
-        self.networks
-            .iter()
-            .flat_map(|(chain_id, firehose_endpoints)| {
-                firehose_endpoints.0.iter().map(move |endpoint| {
-                    (
-                        (chain_id.clone(), endpoint.provider.clone()),
-                        endpoint.clone(),
-                    )
-                })
-            })
-            .collect()
-    }
 }
 
 #[cfg(test)]
@@ -571,7 +697,9 @@ mod test {
     use slog::{o, Discard, Logger};
 
     use crate::{
-        components::metrics::MetricsRegistry, endpoint::EndpointMetrics, firehose::SubgraphLimit,
+        components::{adapter::NetIdentifiable, metrics::MetricsRegistry},
+        endpoint::EndpointMetrics,
+        firehose::{NoopGenesisDecoder, SubgraphLimit},
     };
 
     use super::{AvailableCapacity, FirehoseEndpoint, FirehoseEndpoints, SUBGRAPHS_PER_CONN};
@@ -587,25 +715,25 @@ mod test {
             false,
             SubgraphLimit::Unlimited,
             Arc::new(EndpointMetrics::mock()),
+            NoopGenesisDecoder::boxed(),
         ))];
 
-        let mut endpoints = FirehoseEndpoints::from(endpoint);
+        let endpoints = FirehoseEndpoints::for_testing(endpoint);
 
         let mut keep = vec![];
         for _i in 0..SUBGRAPHS_PER_CONN {
-            keep.push(endpoints.endpoint().unwrap());
+            keep.push(endpoints.endpoint().await.unwrap());
         }
 
-        let err = endpoints.endpoint().unwrap_err();
+        let err = endpoints.endpoint().await.unwrap_err();
         assert!(err.to_string().contains("conn_pool_size"));
 
         mem::drop(keep);
-        endpoints.endpoint().unwrap();
+        endpoints.endpoint().await.unwrap();
 
-        // Fails when empty too
-        endpoints.remove("");
+        let endpoints = FirehoseEndpoints::for_testing(vec![]);
 
-        let err = endpoints.endpoint().unwrap_err();
+        let err = endpoints.endpoint().await.unwrap_err();
         assert!(err.to_string().contains("unable to get a connection"));
     }
 
@@ -620,26 +748,21 @@ mod test {
             false,
             SubgraphLimit::Limit(2),
             Arc::new(EndpointMetrics::mock()),
+            NoopGenesisDecoder::boxed(),
         ))];
 
-        let mut endpoints = FirehoseEndpoints::from(endpoint);
+        let endpoints = FirehoseEndpoints::for_testing(endpoint);
 
         let mut keep = vec![];
         for _ in 0..2 {
-            keep.push(endpoints.endpoint().unwrap());
+            keep.push(endpoints.endpoint().await.unwrap());
         }
 
-        let err = endpoints.endpoint().unwrap_err();
+        let err = endpoints.endpoint().await.unwrap_err();
         assert!(err.to_string().contains("conn_pool_size"));
 
         mem::drop(keep);
-        endpoints.endpoint().unwrap();
-
-        // Fails when empty too
-        endpoints.remove("");
-
-        let err = endpoints.endpoint().unwrap_err();
-        assert!(err.to_string().contains("unable to get a connection"));
+        endpoints.endpoint().await.unwrap();
     }
 
     #[tokio::test]
@@ -653,18 +776,13 @@ mod test {
             false,
             SubgraphLimit::Disabled,
             Arc::new(EndpointMetrics::mock()),
+            NoopGenesisDecoder::boxed(),
         ))];
 
-        let mut endpoints = FirehoseEndpoints::from(endpoint);
+        let endpoints = FirehoseEndpoints::for_testing(endpoint);
 
-        let err = endpoints.endpoint().unwrap_err();
+        let err = endpoints.endpoint().await.unwrap_err();
         assert!(err.to_string().contains("conn_pool_size"));
-
-        // Fails when empty too
-        endpoints.remove("");
-
-        let err = endpoints.endpoint().unwrap_err();
-        assert!(err.to_string().contains("unable to get a connection"));
     }
 
     #[tokio::test]
@@ -685,6 +803,7 @@ mod test {
             false,
             SubgraphLimit::Unlimited,
             endpoint_metrics.clone(),
+            NoopGenesisDecoder::boxed(),
         ));
         let high_error_adapter2 = Arc::new(FirehoseEndpoint::new(
             "high_error".to_string(),
@@ -695,6 +814,7 @@ mod test {
             false,
             SubgraphLimit::Unlimited,
             endpoint_metrics.clone(),
+            NoopGenesisDecoder::boxed(),
         ));
         let low_availability = Arc::new(FirehoseEndpoint::new(
             "low availability".to_string(),
@@ -705,6 +825,7 @@ mod test {
             false,
             SubgraphLimit::Limit(2),
             endpoint_metrics.clone(),
+            NoopGenesisDecoder::boxed(),
         ));
         let high_availability = Arc::new(FirehoseEndpoint::new(
             "high availability".to_string(),
@@ -715,29 +836,41 @@ mod test {
             false,
             SubgraphLimit::Unlimited,
             endpoint_metrics.clone(),
+            NoopGenesisDecoder::boxed(),
         ));
 
         endpoint_metrics.report_for_test(&high_error_adapter1.provider, false);
 
-        let mut endpoints = FirehoseEndpoints::from(vec![
+        let endpoints = FirehoseEndpoints::for_testing(vec![
             high_error_adapter1.clone(),
-            high_error_adapter2,
+            high_error_adapter2.clone(),
             low_availability.clone(),
             high_availability.clone(),
         ]);
 
-        let res = endpoints.endpoint().unwrap();
+        let res = endpoints.endpoint().await.unwrap();
         assert_eq!(res.provider, high_availability.provider);
+        mem::drop(endpoints);
 
         // Removing high availability without errors should fallback to low availability
-        endpoints.remove(&high_availability.provider);
+        let endpoints = FirehoseEndpoints::for_testing(
+            vec![
+                high_error_adapter1.clone(),
+                high_error_adapter2,
+                low_availability.clone(),
+                high_availability.clone(),
+            ]
+            .into_iter()
+            .filter(|a| a.provider_name() != high_availability.provider)
+            .collect(),
+        );
 
         // Ensure we're in a low capacity situation
         assert_eq!(low_availability.get_capacity(), AvailableCapacity::Low);
 
         // In the scenario where the only high level adapter has errors we keep trying that
         // because the others will be low or unavailable
-        let res = endpoints.endpoint().unwrap();
+        let res = endpoints.endpoint().await.unwrap();
         // This will match both high error adapters
         assert_eq!(res.provider, high_error_adapter1.provider);
     }

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -112,6 +112,7 @@ pub mod prelude {
 
     pub use crate::blockchain::{BlockHash, BlockPtr};
 
+    pub use crate::components::adapter;
     pub use crate::components::ethereum::{
         EthereumBlock, EthereumBlockWithCalls, EthereumCall, LightEthereumBlock,
         LightEthereumBlockExt,

--- a/graph/src/task_spawn.rs
+++ b/graph/src/task_spawn.rs
@@ -51,6 +51,7 @@ pub fn spawn_blocking_allow_panic<R: 'static + Send>(
 }
 
 /// Runs the future on the current thread. Panics if not within a tokio runtime.
+#[track_caller]
 pub fn block_on<T>(f: impl Future03<Output = T>) -> T {
     tokio::runtime::Handle::current().block_on(f)
 }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -7,6 +7,7 @@ extern crate diesel;
 
 pub mod chain;
 pub mod config;
+pub mod network_setup;
 pub mod opt;
 pub mod store_builder;
 

--- a/node/src/manager/commands/chain.rs
+++ b/node/src/manager/commands/chain.rs
@@ -174,9 +174,9 @@ pub fn change_block_cache_shard(
         .chain_store(&chain_name)
         .ok_or_else(|| anyhow!("unknown chain: {}", &chain_name))?;
     let new_name = format!("{}-old", &chain_name);
+    let ident = chain_store.chain_identifier()?;
 
     conn.transaction(|conn| -> Result<(), StoreError> {
-        let ident = chain_store.chain_identifier.clone();
         let shard = Shard::new(shard.to_string())?;
 
         let chain = BlockStore::allocate_chain(conn, &chain_name, &shard, &ident)?;
@@ -194,7 +194,7 @@ pub fn change_block_cache_shard(
 
 
         // Create a new chain with the name in the destination shard
-        let _=  add_chain(conn, &chain_name, &ident, &shard)?;
+        let _ = add_chain(conn, &chain_name, &shard, ident)?;
 
         // Re-add the foreign key constraint
         sql_query(

--- a/node/src/network_setup.rs
+++ b/node/src/network_setup.rs
@@ -1,0 +1,412 @@
+use ethereum::{
+    network::{EthereumNetworkAdapter, EthereumNetworkAdapters},
+    BlockIngestor,
+};
+use graph::{
+    anyhow::{self, bail},
+    blockchain::{Blockchain, BlockchainKind, BlockchainMap, ChainIdentifier},
+    cheap_clone::CheapClone,
+    components::{
+        adapter::{ChainId, IdentValidator, MockIdentValidator, NetIdentifiable, ProviderManager},
+        metrics::MetricsRegistry,
+    },
+    endpoint::EndpointMetrics,
+    env::EnvVars,
+    firehose::{FirehoseEndpoint, FirehoseEndpoints},
+    futures03::future::TryFutureExt,
+    itertools::Itertools,
+    log::factory::LoggerFactory,
+    prelude::{
+        anyhow::{anyhow, Result},
+        info, Logger, NodeId,
+    },
+    slog::{o, warn, Discard},
+};
+use graph_chain_ethereum as ethereum;
+use graph_store_postgres::{BlockStore, ChainHeadUpdateListener};
+
+use std::{any::Any, cmp::Ordering, sync::Arc, time::Duration};
+
+use crate::chain::{
+    create_all_ethereum_networks, create_firehose_networks, create_substreams_networks,
+    networks_as_chains,
+};
+
+#[derive(Debug, Clone)]
+pub struct EthAdapterConfig {
+    pub chain_id: ChainId,
+    pub adapters: Vec<EthereumNetworkAdapter>,
+    pub call_only: Vec<EthereumNetworkAdapter>,
+    // polling interval is set per chain so if set all adapter configuration will have
+    // the same value.
+    pub polling_interval: Option<Duration>,
+}
+
+#[derive(Debug, Clone)]
+pub struct FirehoseAdapterConfig {
+    pub chain_id: ChainId,
+    pub kind: BlockchainKind,
+    pub adapters: Vec<Arc<FirehoseEndpoint>>,
+}
+
+#[derive(Debug, Clone)]
+pub enum AdapterConfiguration {
+    Rpc(EthAdapterConfig),
+    Firehose(FirehoseAdapterConfig),
+    Substreams(FirehoseAdapterConfig),
+}
+
+impl AdapterConfiguration {
+    pub fn kind(&self) -> &BlockchainKind {
+        match self {
+            AdapterConfiguration::Rpc(_) => &BlockchainKind::Ethereum,
+            AdapterConfiguration::Firehose(fh) | AdapterConfiguration::Substreams(fh) => &fh.kind,
+        }
+    }
+    pub fn chain_id(&self) -> &ChainId {
+        match self {
+            AdapterConfiguration::Rpc(EthAdapterConfig { chain_id, .. })
+            | AdapterConfiguration::Firehose(FirehoseAdapterConfig { chain_id, .. })
+            | AdapterConfiguration::Substreams(FirehoseAdapterConfig { chain_id, .. }) => chain_id,
+        }
+    }
+
+    pub fn as_rpc(&self) -> Option<&EthAdapterConfig> {
+        match self {
+            AdapterConfiguration::Rpc(rpc) => Some(rpc),
+            _ => None,
+        }
+    }
+
+    pub fn as_firehose(&self) -> Option<&FirehoseAdapterConfig> {
+        match self {
+            AdapterConfiguration::Firehose(fh) => Some(fh),
+            _ => None,
+        }
+    }
+
+    pub fn as_substreams(&self) -> Option<&FirehoseAdapterConfig> {
+        match self {
+            AdapterConfiguration::Substreams(fh) => Some(fh),
+            _ => None,
+        }
+    }
+}
+
+pub struct Networks {
+    pub adapters: Vec<AdapterConfiguration>,
+    rpc_provider_manager: ProviderManager<EthereumNetworkAdapter>,
+    firehose_provider_manager: ProviderManager<Arc<FirehoseEndpoint>>,
+    substreams_provider_manager: ProviderManager<Arc<FirehoseEndpoint>>,
+}
+
+impl Networks {
+    // noop is important for query_nodes as it shortcuts a lot of the process.
+    fn noop() -> Self {
+        Self {
+            adapters: vec![],
+            rpc_provider_manager: ProviderManager::new(
+                Logger::root(Discard, o!()),
+                vec![].into_iter(),
+                Arc::new(MockIdentValidator),
+            ),
+            firehose_provider_manager: ProviderManager::new(
+                Logger::root(Discard, o!()),
+                vec![].into_iter(),
+                Arc::new(MockIdentValidator),
+            ),
+            substreams_provider_manager: ProviderManager::new(
+                Logger::root(Discard, o!()),
+                vec![].into_iter(),
+                Arc::new(MockIdentValidator),
+            ),
+        }
+    }
+
+    pub async fn chain_identifier(
+        &self,
+        logger: &Logger,
+        chain_id: &ChainId,
+    ) -> Result<ChainIdentifier> {
+        async fn get_identifier<T: NetIdentifiable + Clone>(
+            pm: ProviderManager<T>,
+            logger: &Logger,
+            chain_id: &ChainId,
+            provider_type: &str,
+        ) -> Result<ChainIdentifier> {
+            for adapter in pm.get_all_unverified(chain_id).unwrap_or_default() {
+                match adapter.net_identifiers().await {
+                    Ok(ident) => return Ok(ident),
+                    Err(err) => {
+                        warn!(
+                        logger,
+                        "unable to get chain identification from {} provider {} for chain {}, err: {}",
+                        provider_type,
+                        adapter.provider_name(),
+                        chain_id,
+                        err.to_string(),
+                    );
+                    }
+                }
+            }
+
+            bail!("no working adapters for chain {}", chain_id);
+        }
+
+        get_identifier(
+            self.rpc_provider_manager.cheap_clone(),
+            logger,
+            chain_id,
+            "rpc",
+        )
+        .or_else(|_| {
+            get_identifier(
+                self.firehose_provider_manager.cheap_clone(),
+                logger,
+                chain_id,
+                "firehose",
+            )
+        })
+        .or_else(|_| {
+            get_identifier(
+                self.substreams_provider_manager.cheap_clone(),
+                logger,
+                chain_id,
+                "substreams",
+            )
+        })
+        .await
+    }
+
+    pub async fn from_config(
+        logger: Logger,
+        config: &crate::config::Config,
+        registry: Arc<MetricsRegistry>,
+        endpoint_metrics: Arc<EndpointMetrics>,
+        store: Arc<dyn IdentValidator>,
+    ) -> Result<Networks> {
+        if config.query_only(&config.node) {
+            return Ok(Networks::noop());
+        }
+
+        let eth = create_all_ethereum_networks(
+            logger.cheap_clone(),
+            registry,
+            &config,
+            endpoint_metrics.cheap_clone(),
+        )
+        .await?;
+        let firehose = create_firehose_networks(
+            logger.cheap_clone(),
+            &config,
+            endpoint_metrics.cheap_clone(),
+        );
+        let substreams =
+            create_substreams_networks(logger.cheap_clone(), &config, endpoint_metrics);
+        let adapters: Vec<_> = eth
+            .into_iter()
+            .chain(firehose.into_iter())
+            .chain(substreams.into_iter())
+            .collect();
+
+        Ok(Networks::new(&logger, adapters, store))
+    }
+
+    fn new(
+        logger: &Logger,
+        adapters: Vec<AdapterConfiguration>,
+        validator: Arc<dyn IdentValidator>,
+    ) -> Self {
+        let adapters2 = adapters.clone();
+        let eth_adapters = adapters.iter().flat_map(|a| a.as_rpc()).cloned().map(
+            |EthAdapterConfig {
+                 chain_id,
+                 mut adapters,
+                 call_only: _,
+                 polling_interval: _,
+             }| {
+                adapters.sort_by(|a, b| {
+                    a.capabilities
+                        .partial_cmp(&b.capabilities)
+                        .unwrap_or(Ordering::Equal)
+                });
+
+                (chain_id, adapters)
+            },
+        );
+
+        let firehose_adapters = adapters
+            .iter()
+            .flat_map(|a| a.as_firehose())
+            .cloned()
+            .map(
+                |FirehoseAdapterConfig {
+                     chain_id,
+                     kind: _,
+                     adapters,
+                 }| { (chain_id, adapters) },
+            )
+            .collect_vec();
+
+        let substreams_adapters = adapters
+            .iter()
+            .flat_map(|a| a.as_substreams())
+            .cloned()
+            .map(
+                |FirehoseAdapterConfig {
+                     chain_id,
+                     kind: _,
+                     adapters,
+                 }| { (chain_id, adapters) },
+            )
+            .collect_vec();
+
+        Self {
+            adapters: adapters2,
+            rpc_provider_manager: ProviderManager::new(
+                logger.clone(),
+                eth_adapters,
+                validator.cheap_clone(),
+            ),
+            firehose_provider_manager: ProviderManager::new(
+                logger.clone(),
+                firehose_adapters
+                    .into_iter()
+                    .map(|(chain_id, endpoints)| (chain_id, endpoints)),
+                validator.cheap_clone(),
+            ),
+            substreams_provider_manager: ProviderManager::new(
+                logger.clone(),
+                substreams_adapters
+                    .into_iter()
+                    .map(|(chain_id, endpoints)| (chain_id, endpoints)),
+                validator.cheap_clone(),
+            ),
+        }
+    }
+
+    pub async fn block_ingestors(
+        logger: &Logger,
+        blockchain_map: &Arc<BlockchainMap>,
+    ) -> anyhow::Result<Vec<Box<dyn BlockIngestor>>> {
+        async fn block_ingestor<C: Blockchain>(
+            logger: &Logger,
+            chain_id: &ChainId,
+            chain: &Arc<dyn Any + Send + Sync>,
+            ingestors: &mut Vec<Box<dyn BlockIngestor>>,
+        ) -> anyhow::Result<()> {
+            let chain: Arc<C> = chain.cheap_clone().downcast().map_err(|_| {
+                anyhow!("unable to downcast, wrong type for blockchain {}", C::KIND)
+            })?;
+
+            let logger = logger.new(o!("network_name" => chain_id.to_string()));
+
+            match chain.block_ingestor().await {
+                Ok(ingestor) => {
+                    info!(&logger, "Creating block ingestor");
+                    ingestors.push(ingestor)
+                }
+                Err(err) => graph::slog::error!(
+                    &logger,
+                    "unable to create block_ingestor for {}: {}",
+                    chain_id,
+                    err.to_string()
+                ),
+            }
+
+            Ok(())
+        }
+
+        let mut res = vec![];
+        for ((kind, id), chain) in blockchain_map.iter() {
+            match kind {
+                BlockchainKind::Arweave => {
+                    block_ingestor::<graph_chain_arweave::Chain>(logger, id, chain, &mut res)
+                        .await?
+                }
+                BlockchainKind::Ethereum => {
+                    block_ingestor::<graph_chain_ethereum::Chain>(logger, id, chain, &mut res)
+                        .await?
+                }
+                BlockchainKind::Near => {
+                    block_ingestor::<graph_chain_near::Chain>(logger, id, chain, &mut res).await?
+                }
+                BlockchainKind::Cosmos => {
+                    block_ingestor::<graph_chain_cosmos::Chain>(logger, id, chain, &mut res).await?
+                }
+                BlockchainKind::Substreams => {
+                    // handle substreams later
+                }
+                BlockchainKind::Starknet => {
+                    block_ingestor::<graph_chain_starknet::Chain>(logger, id, chain, &mut res)
+                        .await?
+                }
+            }
+        }
+
+        // substreams networks that also have other types of chain(rpc or firehose), will have
+        // block ingestors already running.
+        let visited: Vec<_> = res.iter().map(|b| b.network_name()).collect();
+        for ((_, id), chain) in blockchain_map
+            .iter()
+            .filter(|((kind, id), _)| BlockchainKind::Substreams.eq(&kind) && !visited.contains(id))
+        {
+            block_ingestor::<graph_chain_substreams::Chain>(logger, id, chain, &mut res).await?
+        }
+
+        Ok(res)
+    }
+
+    pub async fn blockchain_map(
+        &self,
+        config: &Arc<EnvVars>,
+        node_id: &NodeId,
+        logger: &Logger,
+        store: Arc<BlockStore>,
+        logger_factory: &LoggerFactory,
+        metrics_registry: Arc<MetricsRegistry>,
+        chain_head_update_listener: Arc<ChainHeadUpdateListener>,
+    ) -> BlockchainMap {
+        let mut bm = BlockchainMap::new();
+
+        networks_as_chains(
+            config,
+            &mut bm,
+            node_id,
+            logger,
+            self,
+            store,
+            logger_factory,
+            metrics_registry,
+            chain_head_update_listener,
+        )
+        .await;
+
+        bm
+    }
+
+    pub fn firehose_endpoints(&self, chain_id: ChainId) -> FirehoseEndpoints {
+        FirehoseEndpoints::new(chain_id, self.firehose_provider_manager.cheap_clone())
+    }
+
+    pub fn substreams_endpoints(&self, chain_id: ChainId) -> FirehoseEndpoints {
+        FirehoseEndpoints::new(chain_id, self.substreams_provider_manager.cheap_clone())
+    }
+
+    pub fn ethereum_rpcs(&self, chain_id: ChainId) -> EthereumNetworkAdapters {
+        let eth_adapters = self
+            .adapters
+            .iter()
+            .filter(|a| a.chain_id().eq(&chain_id))
+            .flat_map(|a| a.as_rpc())
+            .flat_map(|eth_c| eth_c.call_only.clone())
+            .collect_vec();
+
+        EthereumNetworkAdapters::new(
+            chain_id,
+            self.rpc_provider_manager.cheap_clone(),
+            eth_adapters,
+            None,
+        )
+    }
+}

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -1,8 +1,6 @@
-use std::collections::BTreeMap;
 use std::iter::FromIterator;
 use std::{collections::HashMap, sync::Arc};
 
-use graph::blockchain::ChainIdentifier;
 use graph::futures03::future::join_all;
 use graph::prelude::{o, MetricsRegistry, NodeId};
 use graph::url::Url;
@@ -167,14 +165,14 @@ impl StoreBuilder {
         pools: HashMap<ShardName, ConnectionPool>,
         subgraph_store: Arc<SubgraphStore>,
         chains: HashMap<String, ShardName>,
-        networks: BTreeMap<String, ChainIdentifier>,
+        networks: Vec<String>,
         registry: Arc<MetricsRegistry>,
     ) -> Arc<DieselStore> {
         let networks = networks
             .into_iter()
-            .map(|(name, idents)| {
+            .map(|name| {
                 let shard = chains.get(&name).unwrap_or(&*PRIMARY_SHARD).clone();
-                (name, idents, shard)
+                (name, shard)
             })
             .collect();
 
@@ -281,13 +279,13 @@ impl StoreBuilder {
 
     /// Return a store that combines both a `Store` for subgraph data
     /// and a `BlockStore` for all chain related data
-    pub fn network_store(self, networks: BTreeMap<String, ChainIdentifier>) -> Arc<DieselStore> {
+    pub fn network_store(self, networks: Vec<impl Into<String>>) -> Arc<DieselStore> {
         Self::make_store(
             &self.logger,
             self.pools,
             self.subgraph_store,
             self.chains,
-            networks,
+            networks.into_iter().map(Into::into).collect(),
             self.registry,
         )
     }

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -267,7 +267,7 @@ impl<S: Store> IndexNodeResolver<S> {
 
         let chain = if let Ok(c) = self
             .blockchain_map
-            .get::<graph_chain_ethereum::Chain>(network.clone())
+            .get::<graph_chain_ethereum::Chain>(network.as_str().into())
         {
             c
         } else {
@@ -593,7 +593,7 @@ impl<S: Store> IndexNodeResolver<S> {
             }
             BlockchainKind::Starknet => {
                 let unvalidated_subgraph_manifest =
-                    UnvalidatedSubgraphManifest::<graph_chain_substreams::Chain>::resolve(
+                    UnvalidatedSubgraphManifest::<graph_chain_starknet::Chain>::resolve(
                         deployment_hash.clone(),
                         raw_yaml,
                         &self.link_resolver,
@@ -659,7 +659,7 @@ impl<S: Store> IndexNodeResolver<S> {
     ) -> Result<Option<BlockPtr>, QueryExecutionError> {
         macro_rules! try_resolve_for_chain {
             ( $typ:path ) => {
-                let blockchain = self.blockchain_map.get::<$typ>(network.to_string()).ok();
+                let blockchain = self.blockchain_map.get::<$typ>(network.as_str().into()).ok();
 
                 if let Some(blockchain) = blockchain {
                     debug!(

--- a/store/postgres/src/block_range.rs
+++ b/store/postgres/src/block_range.rs
@@ -134,6 +134,7 @@ impl<'a> QueryFragment<Pg> for BlockRangeUpperBoundClause<'a> {
 
 /// Helper for generating various SQL fragments for handling the block range
 /// of entity versions
+#[allow(unused)]
 #[derive(Debug, Clone, Copy)]
 pub enum BlockRangeColumn<'a> {
     Mutable {

--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -323,8 +323,6 @@ mod public {
 // the `large_notifications` table.
 #[derive(Debug)]
 pub struct JsonNotification {
-    pub process_id: i32,
-    pub channel: String,
     pub payload: serde_json::Value,
 }
 
@@ -373,16 +371,10 @@ impl JsonNotification {
                 let payload: String = payload_rows.get(0).unwrap().get(0);
 
                 Ok(JsonNotification {
-                    process_id: notification.process_id(),
-                    channel: notification.channel().to_string(),
                     payload: serde_json::from_str(&payload)?,
                 })
             }
-            serde_json::Value::Object(_) => Ok(JsonNotification {
-                process_id: notification.process_id(),
-                channel: notification.channel().to_string(),
-                payload: value,
-            }),
+            serde_json::Value::Object(_) => Ok(JsonNotification { payload: value }),
             _ => Err(anyhow!("JSON notifications must be numbers or objects"))?,
         }
     }

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -3197,8 +3197,6 @@ impl<'a> FilterCollection<'a> {
 
 #[derive(Debug, Clone)]
 pub struct ChildKeyDetails<'a> {
-    /// Table representing the parent entity
-    pub parent_table: &'a Table,
     /// Column in the parent table that stores the connection between the parent and the child
     pub parent_join_column: &'a Column,
     /// Table representing the child entity
@@ -3231,6 +3229,7 @@ pub struct ChildKeyAndIdSharedDetails<'a> {
     pub direction: &'static str,
 }
 
+#[allow(unused)]
 #[derive(Debug, Clone)]
 pub struct ChildIdDetails<'a> {
     /// Table representing the parent entity
@@ -3525,7 +3524,6 @@ impl<'a> SortKey<'a> {
                 }
 
                 Ok(SortKey::ChildKey(ChildKey::Single(ChildKeyDetails {
-                    parent_table,
                     child_table,
                     parent_join_column: parent_column,
                     child_join_column: child_column,
@@ -3659,7 +3657,6 @@ impl<'a> SortKey<'a> {
                         build_children_vec(layout, parent_table, entity_types, child, direction)?
                             .iter()
                             .map(|details| ChildKeyDetails {
-                                parent_table: details.parent_table,
                                 parent_join_column: details.parent_join_column,
                                 child_table: details.child_table,
                                 child_join_column: details.child_join_column,

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -1,6 +1,8 @@
 use diesel::{self, PgConnection};
 use graph::blockchain::mock::MockDataSource;
 use graph::blockchain::BlockTime;
+use graph::blockchain::ChainIdentifier;
+use graph::components::store::BlockStore;
 use graph::data::graphql::load_manager::LoadManager;
 use graph::data::query::QueryResults;
 use graph::data::query::QueryTarget;
@@ -13,9 +15,9 @@ use graph::schema::EntityType;
 use graph::schema::InputSchema;
 use graph::semver::Version;
 use graph::{
-    blockchain::block_stream::FirehoseCursor, blockchain::ChainIdentifier,
-    components::store::DeploymentLocator, components::store::StatusStore,
-    components::store::StoredDynamicDataSource, data::subgraph::status, prelude::NodeId,
+    blockchain::block_stream::FirehoseCursor, components::store::DeploymentLocator,
+    components::store::StatusStore, components::store::StoredDynamicDataSource,
+    data::subgraph::status, prelude::NodeId,
 };
 use graph_graphql::prelude::{
     execute_query, Query as PreparedQuery, QueryExecutionOptions, StoreResolver,
@@ -626,19 +628,30 @@ fn build_store() -> (Arc<Store>, ConnectionPool, Config, Arc<SubscriptionManager
                 genesis_block_hash: GENESIS_PTR.hash.clone(),
             };
 
-            (
-                builder.network_store(
-                    vec![
-                        (NETWORK_NAME.to_string(), ident.clone()),
-                        (FAKE_NETWORK_SHARED.to_string(), ident),
-                    ]
-                    .into_iter()
-                    .collect(),
-                ),
-                primary_pool,
-                config,
-                subscription_manager,
-            )
+            let store = builder.network_store(
+                vec![
+                    (NETWORK_NAME.to_string()),
+                    (FAKE_NETWORK_SHARED.to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            );
+            match store.block_store().chain_store(NETWORK_NAME) {
+                Some(cs) => {
+                    cs.set_chain_identifier(&ChainIdentifier {
+                        net_version: NETWORK_VERSION.to_string(),
+                        genesis_block_hash: GENESIS_PTR.hash.clone(),
+                    })
+                    .expect("unable to set identifier");
+                }
+                None => {
+                    store
+                        .block_store()
+                        .create_chain_store(NETWORK_NAME, ident)
+                        .expect("unable to create test network store");
+                }
+            }
+            (store, primary_pool, config, subscription_manager)
         })
     })
     .join()

--- a/tests/src/fixture/ethereum.rs
+++ b/tests/src/fixture/ethereum.rs
@@ -45,7 +45,7 @@ pub async fn chain(
     let static_block_stream = Arc::new(StaticStreamBuilder { chain: blocks });
     let block_stream_builder = Arc::new(MutexBlockStreamBuilder(Mutex::new(static_block_stream)));
 
-    let eth_adapters = Arc::new(EthereumNetworkAdapters::default());
+    let eth_adapters = Arc::new(EthereumNetworkAdapters::empty_for_testing());
 
     let chain = Chain::new(
         logger_factory,

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -17,6 +17,7 @@ use graph::blockchain::{
     TriggersAdapter, TriggersAdapterSelector,
 };
 use graph::cheap_clone::CheapClone;
+use graph::components::adapter::ChainId;
 use graph::components::link_resolver::{ArweaveClient, ArweaveResolver, FileSizeLimit};
 use graph::components::metrics::MetricsRegistry;
 use graph::components::store::{BlockStore, DeploymentLocator, EthereumCallCache};
@@ -26,7 +27,7 @@ use graph::data::query::{Query, QueryTarget};
 use graph::data::subgraph::schema::{SubgraphError, SubgraphHealth};
 use graph::endpoint::EndpointMetrics;
 use graph::env::EnvVars;
-use graph::firehose::{FirehoseEndpoint, FirehoseEndpoints, SubgraphLimit};
+use graph::firehose::{FirehoseEndpoint, FirehoseEndpoints, NoopGenesisDecoder, SubgraphLimit};
 use graph::futures03::{Stream, StreamExt};
 use graph::http_body_util::Full;
 use graph::hyper::body::Bytes;
@@ -96,17 +97,18 @@ impl CommonChainConfig {
         let chain_store = stores.chain_store.cheap_clone();
         let node_id = NodeId::new(NODE_ID).unwrap();
 
-        let firehose_endpoints: FirehoseEndpoints = vec![Arc::new(FirehoseEndpoint::new(
-            "",
-            "https://example.com",
-            None,
-            None,
-            true,
-            false,
-            SubgraphLimit::Unlimited,
-            Arc::new(EndpointMetrics::mock()),
-        ))]
-        .into();
+        let firehose_endpoints =
+            FirehoseEndpoints::for_testing(vec![Arc::new(FirehoseEndpoint::new(
+                "",
+                "https://example.com",
+                None,
+                None,
+                true,
+                false,
+                SubgraphLimit::Unlimited,
+                Arc::new(EndpointMetrics::mock()),
+                NoopGenesisDecoder::boxed(),
+            ))]);
 
         Self {
             logger_factory,
@@ -359,7 +361,7 @@ impl Drop for TestContext {
 }
 
 pub struct Stores {
-    network_name: String,
+    network_name: ChainId,
     chain_head_listener: Arc<ChainHeadUpdateListener>,
     pub network_store: Arc<Store>,
     chain_store: Arc<ChainStore>,
@@ -398,22 +400,26 @@ pub async fn stores(test_name: &str, store_config_path: &str) -> Stores {
     let store_builder =
         StoreBuilder::new(&logger, &node_id, &config, None, mock_registry.clone()).await;
 
-    let network_name: String = config.chains.chains.iter().next().unwrap().0.to_string();
+    let network_name: ChainId = config
+        .chains
+        .chains
+        .iter()
+        .next()
+        .unwrap()
+        .0
+        .as_str()
+        .into();
     let chain_head_listener = store_builder.chain_head_update_listener();
-    let network_identifiers = vec![(
-        network_name.clone(),
-        ChainIdentifier {
-            net_version: "".into(),
-            genesis_block_hash: test_ptr(0).hash,
-        },
-    )]
-    .into_iter()
-    .collect();
+    let network_identifiers: Vec<ChainId> = vec![network_name.clone()].into_iter().collect();
     let network_store = store_builder.network_store(network_identifiers);
+    let ident = ChainIdentifier {
+        net_version: "".into(),
+        genesis_block_hash: test_ptr(0).hash,
+    };
     let chain_store = network_store
         .block_store()
-        .chain_store(network_name.as_ref())
-        .unwrap_or_else(|| panic!("No chain store for {}", &network_name));
+        .create_chain_store(&network_name, ident)
+        .unwrap_or_else(|_| panic!("No chain store for {}", &network_name));
 
     Stores {
         network_name,

--- a/tests/src/fixture/substreams.rs
+++ b/tests/src/fixture/substreams.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use graph::blockchain::client::ChainClient;
+
 use super::{CommonChainConfig, Stores, TestChainSubstreams};
 
 pub async fn chain(test_name: &str, stores: &Stores) -> TestChainSubstreams {
@@ -12,10 +14,13 @@ pub async fn chain(test_name: &str, stores: &Stores) -> TestChainSubstreams {
     } = CommonChainConfig::new(test_name, stores).await;
 
     let block_stream_builder = Arc::new(graph_chain_substreams::BlockStreamBuilder::new());
+    let client = Arc::new(ChainClient::<graph_chain_substreams::Chain>::new_firehose(
+        firehose_endpoints,
+    ));
 
     let chain = Arc::new(graph_chain_substreams::Chain::new(
         logger_factory,
-        firehose_endpoints,
+        client,
         mock_registry,
         chain_store,
         block_stream_builder.clone(),


### PR DESCRIPTION
Fixes https://github.com/graphprotocol/graph-node/issues/3937

- New chain now created with `ChainIdentifier::default()` on start
- Adapter genesis+net_version now checked by `ProviderManager`
- Adapter checks will be disabled temporarily after an intermittent failure
- Adapter won't be returned by the `ProviderManager` if the ident returned is not the expected value.
- BlockIngestor now takes a `ChainClient` and tries to get an adapter with each poll, this means it won't stop if the first poll fails
- node/src/main.rs refactored so that most of the init code is automatically executed by the new `Networks` type.
- graphman run now uses the same init code as the node, should be able to run using any chain
- EthereumNetworks type removed
- FirehoseNetworks type removed 
- New chains require a working adapter for creation

Future improvements:
- Cache genesis once it's set
- Cache chain ident once it's set
