### PR TITLE
Centralize and clarify our use of futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1673,7 +1673,6 @@ dependencies = [
  "anyhow",
  "base64 0.20.0",
  "envconfig",
- "futures 0.1.31",
  "graph",
  "graph-runtime-derive",
  "graph-runtime-wasm",
@@ -1747,7 +1746,6 @@ dependencies = [
  "atomic_refcell",
  "bytes",
  "cid",
- "futures 0.1.31",
  "futures 0.3.16",
  "graph",
  "graph-chain-arweave",
@@ -1845,7 +1843,6 @@ dependencies = [
  "async-trait",
  "bs58",
  "ethabi",
- "futures 0.1.31",
  "graph",
  "graph-runtime-derive",
  "hex",
@@ -1861,7 +1858,6 @@ dependencies = [
 name = "graph-server-http"
 version = "0.35.0"
 dependencies = [
- "futures 0.1.31",
  "graph",
  "graph-core",
  "graph-graphql",
@@ -1905,7 +1901,6 @@ dependencies = [
 name = "graph-server-websocket"
 version = "0.35.0"
 dependencies = [
- "futures 0.1.31",
  "graph",
  "serde",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,7 +1746,6 @@ dependencies = [
  "atomic_refcell",
  "bytes",
  "cid",
- "futures 0.3.16",
  "graph",
  "graph-chain-arweave",
  "graph-chain-cosmos",
@@ -1785,7 +1784,6 @@ dependencies = [
  "clap",
  "diesel",
  "env_logger",
- "futures 0.3.16",
  "git-testament",
  "graph",
  "graph-chain-arweave",
@@ -1869,7 +1867,6 @@ name = "graph-server-index-node"
 version = "0.35.0"
 dependencies = [
  "blake3 1.5.0",
- "futures 0.3.16",
  "git-testament",
  "graph",
  "graph-chain-arweave",
@@ -1948,7 +1945,6 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "async-stream",
- "futures 0.3.16",
  "graph",
  "graph-chain-ethereum",
  "graph-chain-substreams",

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 
 [dependencies]
 envconfig = "0.10.0"
-futures = "0.1.21"
 jsonrpc-core = "18.0.0"
 graph = { path = "../../graph" }
 serde = { workspace = true }

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -1,12 +1,12 @@
 use anyhow::Error;
 use ethabi::{Error as ABIError, Function, ParamType, Token};
-use futures::Future;
 use graph::blockchain::ChainIdentifier;
 use graph::components::subgraph::MappingError;
 use graph::data::store::ethereum::call;
 use graph::firehose::CallToFilter;
 use graph::firehose::CombinedFilter;
 use graph::firehose::LogFilter;
+use graph::futures01::Future;
 use graph::prelude::web3::types::Bytes;
 use graph::prelude::web3::types::H160;
 use graph::prelude::web3::types::U256;
@@ -25,6 +25,7 @@ use graph::prelude::*;
 use graph::{
     blockchain as bc,
     components::metrics::{CounterVec, GaugeVec, HistogramVec},
+    futures01::Stream,
     petgraph::{self, graphmap::GraphMap},
 };
 

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -8,6 +8,7 @@ use graph::blockchain::{
 use graph::components::store::DeploymentCursorTracker;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::firehose::{FirehoseEndpoint, ForkStep};
+use graph::futures03::compat::Future01CompatExt;
 use graph::prelude::{
     BlockHash, ComponentLoggerConfig, ElasticComponentLoggerConfig, EthereumBlock,
     EthereumCallCache, LightEthereumBlock, LightEthereumBlockExt, MetricsRegistry,
@@ -30,7 +31,7 @@ use graph::{
     firehose,
     prelude::{
         async_trait, o, serde_json as json, BlockNumber, ChainStore, EthereumBlockWithCalls,
-        Future01CompatExt, Logger, LoggerFactory, NodeId,
+        Logger, LoggerFactory, NodeId,
     },
 };
 use prost::Message;

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -763,7 +763,7 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
     }
 
     async fn parent_ptr(&self, block: &BlockPtr) -> Result<Option<BlockPtr>, Error> {
-        use futures::stream::Stream;
+        use graph::futures01::stream::Stream;
         use graph::prelude::LightEthereumBlockExt;
 
         let block = match self.chain_client.as_ref() {

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -8,10 +8,11 @@ use graph::components::trigger_processor::RunnableTriggers;
 use graph::data::value::Word;
 use graph::data_source::CausalityRegion;
 use graph::env::ENV_VARS;
+use graph::futures03::future::try_join;
+use graph::futures03::stream::FuturesOrdered;
+use graph::futures03::TryStreamExt;
 use graph::prelude::ethabi::ethereum_types::H160;
 use graph::prelude::ethabi::{StateMutability, Token};
-use graph::prelude::futures03::future::try_join;
-use graph::prelude::futures03::stream::FuturesOrdered;
 use graph::prelude::lazy_static;
 use graph::prelude::regex::Regex;
 use graph::prelude::{Link, SubgraphManifestValidationError};
@@ -34,7 +35,7 @@ use graph::{
         serde_json, warn,
         web3::types::{Log, Transaction, H256},
         BlockNumber, CheapClone, Deserialize, EthereumCall, LightEthereumBlock,
-        LightEthereumBlockExt, LinkResolver, Logger, TryStreamExt,
+        LightEthereumBlockExt, LinkResolver, Logger,
     },
 };
 

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -10,9 +10,12 @@ use graph::data::subgraph::API_VERSION_0_0_7;
 use graph::futures01::stream;
 use graph::futures01::Future;
 use graph::futures01::Stream;
+use graph::futures03::future::try_join_all;
+use graph::futures03::{
+    self, compat::Future01CompatExt, FutureExt, StreamExt, TryFutureExt, TryStreamExt,
+};
 use graph::prelude::ethabi::ParamType;
 use graph::prelude::ethabi::Token;
-use graph::prelude::futures03::future::try_join_all;
 use graph::prelude::tokio::try_join;
 use graph::prelude::web3::types::U256;
 use graph::slog::o;
@@ -20,9 +23,8 @@ use graph::{
     blockchain::{block_stream::BlockWithTriggers, BlockPtr, IngestorError},
     prelude::{
         anyhow::{self, anyhow, bail, ensure, Context},
-        async_trait, debug, error, ethabi,
-        futures03::{self, compat::Future01CompatExt, FutureExt, StreamExt, TryStreamExt},
-        hex, info, retry, serde_json as json, tiny_keccak, trace, warn,
+        async_trait, debug, error, ethabi, hex, info, retry, serde_json as json, tiny_keccak,
+        trace, warn,
         web3::{
             self,
             types::{
@@ -31,7 +33,7 @@ use graph::{
             },
         },
         BlockNumber, ChainStore, CheapClone, DynTryFuture, Error, EthereumCallCache, Logger,
-        TimeoutError, TryFutureExt,
+        TimeoutError,
     },
 };
 use graph::{

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1,4 +1,3 @@
-use futures::prelude::*;
 use futures03::{future::BoxFuture, stream::FuturesUnordered};
 use graph::blockchain::client::ChainClient;
 use graph::blockchain::BlockHash;
@@ -8,6 +7,9 @@ use graph::data::store::ethereum::call;
 use graph::data::store::scalar;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::data::subgraph::API_VERSION_0_0_7;
+use graph::futures01::stream;
+use graph::futures01::Future;
+use graph::futures01::Stream;
 use graph::prelude::ethabi::ParamType;
 use graph::prelude::ethabi::Token;
 use graph::prelude::futures03::future::try_join_all;
@@ -20,7 +22,7 @@ use graph::{
         anyhow::{self, anyhow, bail, ensure, Context},
         async_trait, debug, error, ethabi,
         futures03::{self, compat::Future01CompatExt, FutureExt, StreamExt, TryStreamExt},
-        hex, info, retry, serde_json as json, stream, tiny_keccak, trace, warn,
+        hex, info, retry, serde_json as json, tiny_keccak, trace, warn,
         web3::{
             self,
             types::{
@@ -302,7 +304,7 @@ impl EthereumAdapter {
             } else {
                 debug!(logger, "Requesting traces for blocks [{}, {}]", start, end);
             }
-            Some(futures::future::ok((
+            Some(graph::futures01::future::ok((
                 eth.clone()
                     .traces(
                         logger.cheap_clone(),

--- a/chain/ethereum/src/ingestor.rs
+++ b/chain/ethereum/src/ingestor.rs
@@ -1,10 +1,11 @@
 use crate::{chain::BlockFinality, EthereumAdapter, EthereumAdapterTrait, ENV_VARS};
+use graph::futures03::compat::Future01CompatExt;
 use graph::{
     blockchain::{BlockHash, BlockIngestor, BlockPtr, IngestorError},
     cheap_clone::CheapClone,
     prelude::{
         async_trait, error, ethabi::ethereum_types::H256, info, tokio, trace, warn, ChainStore,
-        Error, EthereumBlockWithCalls, Future01CompatExt, LogCode, Logger,
+        Error, EthereumBlockWithCalls, LogCode, Logger,
     },
 };
 use std::{sync::Arc, time::Duration};

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -13,6 +13,7 @@ use graph::components::subgraph::HostMetrics;
 use graph::data::store::ethereum::call;
 use graph::data::store::scalar::BigInt;
 use graph::data::subgraph::API_VERSION_0_0_9;
+use graph::futures03::compat::Future01CompatExt;
 use graph::prelude::web3::types::H160;
 use graph::runtime::gas::Gas;
 use graph::runtime::{AscIndexId, IndexForAscTypeId};
@@ -22,7 +23,7 @@ use graph::{
     cheap_clone::CheapClone,
     prelude::{
         ethabi::{self, Address, Token},
-        EthereumCallCache, Future01CompatExt,
+        EthereumCallCache,
     },
     runtime::{asc_get, asc_new, AscPtr, HostExportError},
     semver::Version,

--- a/chain/near/src/chain.rs
+++ b/chain/near/src/chain.rs
@@ -11,7 +11,8 @@ use graph::components::store::DeploymentCursorTracker;
 use graph::data::subgraph::UnifiedMappingApiVersion;
 use graph::env::EnvVars;
 use graph::firehose::FirehoseEndpoint;
-use graph::prelude::{MetricsRegistry, TryFutureExt};
+use graph::futures03::TryFutureExt;
+use graph::prelude::MetricsRegistry;
 use graph::schema::InputSchema;
 use graph::substreams::{Clock, Package};
 use graph::{

--- a/chain/starknet/src/chain.rs
+++ b/chain/starknet/src/chain.rs
@@ -18,9 +18,10 @@ use graph::{
     data::subgraph::UnifiedMappingApiVersion,
     env::EnvVars,
     firehose::{self, FirehoseEndpoint, ForkStep},
+    futures03::future::TryFutureExt,
     prelude::{
         async_trait, BlockHash, BlockNumber, ChainStore, Error, Logger, LoggerFactory,
-        MetricsRegistry, TryFutureExt,
+        MetricsRegistry,
     },
     schema::InputSchema,
     slog::o,

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 async-trait = "0.1.50"
 atomic_refcell = "0.1.13"
 bytes = "1.0"
-futures01 = { package = "futures", version = "0.1.31" }
 futures = { version = "0.3.4", features = ["compat"] }
 graph = { path = "../graph" }
 # This dependency is temporary. The multiblockchain refactoring is not

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 async-trait = "0.1.50"
 atomic_refcell = "0.1.13"
 bytes = "1.0"
-futures = { version = "0.3.4", features = ["compat"] }
 graph = { path = "../graph" }
 # This dependency is temporary. The multiblockchain refactoring is not
 # finished as long as this dependency exists

--- a/core/src/polling_monitor/arweave_service.rs
+++ b/core/src/polling_monitor/arweave_service.rs
@@ -1,6 +1,6 @@
 use anyhow::Error;
 use bytes::Bytes;
-use futures::future::BoxFuture;
+use graph::futures03::future::BoxFuture;
 use graph::{
     components::link_resolver::{ArweaveClient, ArweaveResolver, FileSizeLimit},
     data_source::offchain::Base64,

--- a/core/src/polling_monitor/ipfs_service.rs
+++ b/core/src/polling_monitor/ipfs_service.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Error};
 use bytes::Bytes;
-use futures::future::BoxFuture;
+use graph::futures03::future::BoxFuture;
 use graph::{
     derive::CheapClone,
     ipfs_client::{CidFile, IpfsClient},

--- a/core/src/polling_monitor/mod.rs
+++ b/core/src/polling_monitor/mod.rs
@@ -9,10 +9,10 @@ use std::sync::Arc;
 use std::task::Poll;
 use std::time::Duration;
 
-use futures::future::BoxFuture;
-use futures::stream::StreamExt;
-use futures::{stream, Future, FutureExt, TryFutureExt};
 use graph::cheap_clone::CheapClone;
+use graph::futures03::future::BoxFuture;
+use graph::futures03::stream::StreamExt;
+use graph::futures03::{stream, Future, FutureExt, TryFutureExt};
 use graph::parking_lot::Mutex;
 use graph::prelude::tokio;
 use graph::prometheus::{Counter, Gauge};
@@ -132,7 +132,7 @@ where
 
                         // Nothing on the queue, wait for a queue wake up or cancellation.
                         None => {
-                            futures::future::select(
+                            graph::futures03::future::select(
                                 // Unwrap: `queue` holds a sender.
                                 queue_woken.changed().map(|r| r.unwrap()).boxed(),
                                 cancel_check.closed().boxed(),

--- a/core/src/subgraph/context/instance/mod.rs
+++ b/core/src/subgraph/context/instance/mod.rs
@@ -1,7 +1,7 @@
 mod hosts;
 
 use anyhow::ensure;
-use futures01::sync::mpsc::Sender;
+use graph::futures01::sync::mpsc::Sender;
 use graph::{
     blockchain::{Blockchain, TriggerData as _},
     data_source::{

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -14,6 +14,11 @@ use graph::futures01::future;
 use graph::futures01::stream;
 use graph::futures01::Future;
 use graph::futures01::Stream;
+use graph::futures03::compat::Future01CompatExt;
+use graph::futures03::compat::Stream01CompatExt;
+use graph::futures03::future::FutureExt;
+use graph::futures03::future::TryFutureExt;
+use graph::futures03::stream::TryStreamExt;
 use graph::prelude::{
     CreateSubgraphResult, SubgraphAssignmentProvider as SubgraphAssignmentProviderTrait,
     SubgraphRegistrar as SubgraphRegistrarTrait, *,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -9,6 +9,11 @@ use graph::components::store::{DeploymentId, DeploymentLocator, SubscriptionMana
 use graph::components::subgraph::Settings;
 use graph::data::subgraph::schema::DeploymentCreate;
 use graph::data::subgraph::Graft;
+use graph::futures01;
+use graph::futures01::future;
+use graph::futures01::stream;
+use graph::futures01::Future;
+use graph::futures01::Stream;
 use graph::prelude::{
     CreateSubgraphResult, SubgraphAssignmentProvider as SubgraphAssignmentProviderTrait,
     SubgraphRegistrar as SubgraphRegistrarTrait, *,

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -23,6 +23,8 @@ use graph::data_source::{
     offchain, CausalityRegion, DataSource, DataSourceCreationError, TriggerData,
 };
 use graph::env::EnvVars;
+use graph::futures03::stream::StreamExt;
+use graph::futures03::TryStreamExt;
 use graph::prelude::*;
 use graph::schema::EntityKey;
 use graph::util::{backoff::ExponentialBackoff, lfu_cache::LfuCache};

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -28,7 +28,7 @@ http = "0.2.3"
 hyper = { version = "1", features = ["full"] }
 http-body-util = "0.1"
 hyper-util = { version = "0.1", features = ["full"] }
-futures = { package = "futures", version = "0.1.31" }
+futures01 = { package = "futures", version = "0.1.31" }
 lru_time_cache = "0.11"
 graphql-parser = "0.4.0"
 humantime = "2.1.0"

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -17,6 +17,7 @@ use crate::anyhow::Result;
 use crate::components::store::{BlockNumber, DeploymentLocator};
 use crate::data::subgraph::UnifiedMappingApiVersion;
 use crate::firehose::{self, FirehoseEndpoint};
+use crate::futures03::stream::StreamExt as _;
 use crate::schema::InputSchema;
 use crate::substreams_rpc::response::Message;
 use crate::{prelude::*, prometheus::labels};

--- a/graph/src/components/graphql.rs
+++ b/graph/src/components/graphql.rs
@@ -1,11 +1,10 @@
-use futures::prelude::*;
-
 use crate::data::query::QueryResults;
 use crate::data::query::{Query, QueryTarget};
 use crate::data::subscription::{Subscription, SubscriptionError, SubscriptionResult};
 use crate::prelude::DeploymentHash;
 
 use async_trait::async_trait;
+use futures01::Future;
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/graph/src/components/link_resolver/ipfs.rs
+++ b/graph/src/components/link_resolver/ipfs.rs
@@ -2,13 +2,13 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crate::env::EnvVars;
+use crate::futures01::{stream::poll_fn, try_ready};
+use crate::futures01::{Async, Poll};
 use crate::ipfs_client::IpfsError;
 use crate::util::futures::RetryConfigNoTimeout;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use bytes::BytesMut;
-use futures::{stream::poll_fn, try_ready};
-use futures::{Async, Poll};
 use futures03::stream::FuturesUnordered;
 use lru_time_cache::LruCache;
 use serde_json::Value;
@@ -16,6 +16,7 @@ use serde_json::Value;
 use crate::{
     cheap_clone::CheapClone,
     derive::CheapClone,
+    futures01::stream::Stream,
     ipfs_client::IpfsClient,
     prelude::{LinkResolver as LinkResolverTrait, *},
 };

--- a/graph/src/components/link_resolver/ipfs.rs
+++ b/graph/src/components/link_resolver/ipfs.rs
@@ -9,7 +9,9 @@ use crate::util::futures::RetryConfigNoTimeout;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use bytes::BytesMut;
-use futures03::stream::FuturesUnordered;
+use futures03::compat::Stream01CompatExt;
+use futures03::future::TryFutureExt;
+use futures03::stream::{FuturesUnordered, StreamExt, TryStreamExt};
 use lru_time_cache::LruCache;
 use serde_json::Value;
 

--- a/graph/src/components/mod.rs
+++ b/graph/src/components/mod.rs
@@ -33,7 +33,7 @@
 //! that define common operations on event streams, facilitating the
 //! configuration of component graphs.
 
-use futures::prelude::*;
+use futures01::{Sink, Stream};
 
 /// Components dealing with subgraphs.
 pub mod subgraph;

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -14,8 +14,8 @@ use strum_macros::Display;
 pub use traits::*;
 pub use write::Batch;
 
-use futures::stream::poll_fn;
-use futures::{Async, Poll, Stream};
+use futures01::stream::poll_fn;
+use futures01::{Async, Poll, Stream};
 use serde::{Deserialize, Serialize};
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet, HashSet};
@@ -777,7 +777,7 @@ where
 
             // Check if interval has passed since the last time we sent something.
             // If it has, start a new delay timer
-            let should_send = match futures::future::Future::poll(&mut delay) {
+            let should_send = match futures01::future::Future::poll(&mut delay) {
                 Ok(Async::NotReady) => false,
                 // Timer errors are harmless. Treat them as if the timer had
                 // become ready.

--- a/graph/src/components/subgraph/host.rs
+++ b/graph/src/components/subgraph/host.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use anyhow::Error;
 use async_trait::async_trait;
-use futures::sync::mpsc;
+use futures01::sync::mpsc;
 
 use crate::blockchain::BlockTime;
 use crate::components::metrics::gas::GasMetrics;

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -45,6 +45,7 @@ pub use task_spawn::{
 
 pub use anyhow;
 pub use bytes;
+pub use futures01;
 pub use graph_derive as derive;
 pub use http;
 pub use http_body_util;
@@ -79,9 +80,6 @@ pub mod prelude {
     pub use diesel;
     pub use envconfig;
     pub use ethabi;
-    pub use futures::future;
-    pub use futures::prelude::*;
-    pub use futures::stream;
     pub use futures03;
     pub use futures03::compat::{Future01CompatExt, Sink01CompatExt, Stream01CompatExt};
     pub use futures03::future::{FutureExt as _, TryFutureExt};

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -46,6 +46,7 @@ pub use task_spawn::{
 pub use anyhow;
 pub use bytes;
 pub use futures01;
+pub use futures03;
 pub use graph_derive as derive;
 pub use http;
 pub use http_body_util;
@@ -80,11 +81,6 @@ pub mod prelude {
     pub use diesel;
     pub use envconfig;
     pub use ethabi;
-    pub use futures03;
-    pub use futures03::compat::{Future01CompatExt, Sink01CompatExt, Stream01CompatExt};
-    pub use futures03::future::{FutureExt as _, TryFutureExt};
-    pub use futures03::sink::SinkExt as _;
-    pub use futures03::stream::{StreamExt as _, TryStreamExt};
     pub use hex;
     pub use isatty;
     pub use lazy_static::lazy_static;

--- a/graph/src/util/futures.rs
+++ b/graph/src/util/futures.rs
@@ -439,7 +439,7 @@ where
 mod tests {
     use super::*;
 
-    use futures::future;
+    use futures01::future;
     use futures03::compat::Future01CompatExt;
     use slog::o;
     use std::sync::Mutex;

--- a/graphql/src/execution/execution.rs
+++ b/graphql/src/execution/execution.rs
@@ -6,6 +6,7 @@ use graph::{
         query::Trace,
         value::{Object, Word},
     },
+    futures03::future::TryFutureExt,
     prelude::{s, CheapClone},
     schema::{is_introspection_field, INTROSPECTION_QUERY_TYPE, META_FIELD_NAME},
     util::{herd_cache::HerdCache, lfu_cache::EvictStats, timed_rw_lock::TimedMutex},

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -5,7 +5,8 @@ use crate::metrics::GraphQLMetrics;
 use crate::prelude::{QueryExecutionOptions, StoreResolver, SubscriptionExecutionOptions};
 use crate::query::execute_query;
 use crate::subscription::execute_prepared_subscription;
-use graph::prelude::{futures03::future, MetricsRegistry};
+use graph::futures03::future;
+use graph::prelude::MetricsRegistry;
 use graph::{
     components::store::SubscriptionManager,
     prelude::{

--- a/graphql/src/subscription/mod.rs
+++ b/graphql/src/subscription/mod.rs
@@ -3,6 +3,8 @@ use std::time::{Duration, Instant};
 
 use graph::components::store::UnitStream;
 use graph::data::graphql::load_manager::LoadManager;
+use graph::futures03::future::FutureExt;
+use graph::futures03::stream::StreamExt;
 use graph::schema::ApiSchema;
 use graph::{components::store::SubscriptionManager, prelude::*, schema::ErrorPolicy};
 
@@ -143,7 +145,7 @@ fn map_source_to_response_stream(
     // at least once. This satisfies the GraphQL over Websocket protocol
     // requirement of "respond[ing] with at least one GQL_DATA message", see
     // https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md#gql_data
-    let trigger_stream = futures03::stream::once(async {});
+    let trigger_stream = graph::futures03::stream::once(async {});
 
     let SubscriptionExecutionOptions {
         logger,

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/bin/manager.rs"
 clap = { version = "3.2.25", features = ["derive", "env"] }
 env_logger = "0.11.3"
 git-testament = "0.2"
-futures = { version = "0.3.1", features = ["compat"] }
 lazy_static = "1.2.0"
 url = "2.5.0"
 graph = { path = "../graph" }

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -1,12 +1,12 @@
 use crate::config::{Config, ProviderDetails};
 use ethereum::{EthereumNetworks, ProviderEthRpcMetrics};
-use futures::future::{join_all, try_join_all};
-use futures::TryFutureExt;
 use graph::anyhow::{bail, Error};
 use graph::blockchain::{Block as BlockchainBlock, BlockchainKind, ChainIdentifier};
 use graph::cheap_clone::CheapClone;
 use graph::endpoint::EndpointMetrics;
 use graph::firehose::{FirehoseEndpoint, FirehoseNetworks, SubgraphLimit};
+use graph::futures03::future::{join_all, try_join_all};
+use graph::futures03::TryFutureExt;
 use graph::ipfs_client::IpfsClient;
 use graph::prelude::{anyhow, tokio};
 use graph::prelude::{prost, MetricsRegistry};

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -7,6 +7,8 @@ use ethereum::{BlockIngestor, EthereumNetworks};
 use git_testament::{git_testament, render_testament};
 use graph::blockchain::client::ChainClient;
 use graph::futures01::Future as _;
+use graph::futures03::compat::Future01CompatExt;
+use graph::futures03::future::TryFutureExt;
 use graph_chain_ethereum::codec::HeaderOnlyBlock;
 
 use graph::blockchain::{
@@ -703,7 +705,7 @@ async fn main() {
     std::thread::spawn(move || loop {
         std::thread::sleep(Duration::from_secs(1));
         let (pong_send, pong_receive) = std::sync::mpsc::sync_channel(1);
-        if futures::executor::block_on(ping_send.clone().send(pong_send)).is_err() {
+        if graph::futures03::executor::block_on(ping_send.clone().send(pong_send)).is_err() {
             debug!(contention_logger, "Shutting down contention checker thread");
             break;
         }
@@ -723,7 +725,7 @@ async fn main() {
         }
     });
 
-    futures::future::pending::<()>().await;
+    graph::futures03::future::pending::<()>().await;
 }
 
 /// Return the hashmap of chains and also add them to `blockchain_map`.

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -6,6 +6,7 @@ use ethereum::chain::{
 use ethereum::{BlockIngestor, EthereumNetworks};
 use git_testament::{git_testament, render_testament};
 use graph::blockchain::client::ChainClient;
+use graph::futures01::Future as _;
 use graph_chain_ethereum::codec::HeaderOnlyBlock;
 
 use graph::blockchain::{

--- a/node/src/manager/commands/check_blocks.rs
+++ b/node/src/manager/commands/check_blocks.rs
@@ -153,7 +153,7 @@ async fn handle_multiple_block_hashes(
 mod steps {
     use super::*;
 
-    use futures::compat::Future01CompatExt;
+    use graph::futures03::compat::Future01CompatExt;
     use graph::{
         anyhow::bail,
         prelude::serde_json::{self, Value},

--- a/node/src/manager/commands/listen.rs
+++ b/node/src/manager/commands/listen.rs
@@ -2,17 +2,17 @@ use std::iter::FromIterator;
 use std::sync::Arc;
 use std::{collections::BTreeSet, io::Write};
 
+use crate::manager::deployment::DeploymentSearch;
 use futures::compat::Future01CompatExt;
+use graph::futures01::Stream as _;
 use graph::prelude::DeploymentHash;
 use graph::schema::{EntityType, InputSchema};
 use graph::{
     components::store::SubscriptionManager as _,
-    prelude::{serde_json, Error, Stream, SubscriptionFilter},
+    prelude::{serde_json, Error, SubscriptionFilter},
 };
 use graph_store_postgres::connection_pool::ConnectionPool;
 use graph_store_postgres::SubscriptionManager;
-
-use crate::manager::deployment::DeploymentSearch;
 
 async fn listen(
     mgr: Arc<SubscriptionManager>,

--- a/node/src/manager/commands/listen.rs
+++ b/node/src/manager/commands/listen.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use std::{collections::BTreeSet, io::Write};
 
 use crate::manager::deployment::DeploymentSearch;
-use futures::compat::Future01CompatExt;
 use graph::futures01::Stream as _;
+use graph::futures03::compat::Future01CompatExt;
 use graph::prelude::DeploymentHash;
 use graph::schema::{EntityType, InputSchema};
 use graph::{

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeMap;
 use std::iter::FromIterator;
 use std::{collections::HashMap, sync::Arc};
 
-use futures::future::join_all;
 use graph::blockchain::ChainIdentifier;
+use graph::futures03::future::join_all;
 use graph::prelude::{o, MetricsRegistry, NodeId};
 use graph::url::Url;
 use graph::{

--- a/runtime/test/src/common.rs
+++ b/runtime/test/src/common.rs
@@ -117,7 +117,7 @@ pub fn mock_context(
             api_version,
         )),
         state: BlockState::new(
-            futures03::executor::block_on(store.writable(
+            graph::futures03::executor::block_on(store.writable(
                 LOGGER.clone(),
                 deployment.id,
                 Arc::new(Vec::new()),

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 [dependencies]
 async-trait = "0.1.50"
 ethabi = "17.2"
-futures = "0.1.21"
 hex = "0.4.3"
 graph = { path = "../../graph" }
 bs58 = "0.4.0"

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -2,8 +2,8 @@ use std::cmp::PartialEq;
 use std::time::Instant;
 
 use async_trait::async_trait;
-use futures::sync::mpsc::Sender;
 use futures03::channel::oneshot::channel;
+use graph::futures01::sync::mpsc::Sender;
 
 use graph::blockchain::{BlockTime, Blockchain, HostFn, RuntimeAdapter};
 use graph::components::store::{EnsLookup, SubgraphFork};
@@ -11,6 +11,7 @@ use graph::components::subgraph::{MappingError, SharedProofOfIndexing};
 use graph::data_source::{
     DataSource, DataSourceTemplate, MappingTrigger, TriggerData, TriggerWithHandler,
 };
+use graph::futures01::Sink as _;
 use graph::prelude::{
     RuntimeHost as RuntimeHostTrait, RuntimeHostBuilder as RuntimeHostBuilderTrait, *,
 };

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -2,8 +2,8 @@ use std::cmp::PartialEq;
 use std::time::Instant;
 
 use async_trait::async_trait;
-use futures03::channel::oneshot::channel;
 use graph::futures01::sync::mpsc::Sender;
+use graph::futures03::channel::oneshot::channel;
 
 use graph::blockchain::{BlockTime, Blockchain, HostFn, RuntimeAdapter};
 use graph::components::store::{EnsLookup, SubgraphFork};
@@ -12,6 +12,7 @@ use graph::data_source::{
     DataSource, DataSourceTemplate, MappingTrigger, TriggerData, TriggerWithHandler,
 };
 use graph::futures01::Sink as _;
+use graph::futures03::compat::Future01CompatExt;
 use graph::prelude::{
     RuntimeHost as RuntimeHostTrait, RuntimeHostBuilder as RuntimeHostBuilderTrait, *,
 };

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -6,6 +6,7 @@ use std::time::{Duration, Instant};
 use graph::data::subgraph::API_VERSION_0_0_8;
 use graph::data::value::Word;
 
+use graph::futures03::stream::StreamExt;
 use graph::schema::EntityType;
 use never::Never;
 use semver::Version;

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -1,11 +1,12 @@
 use crate::gas_rules::GasRules;
 use crate::module::{ExperimentalFeatures, ToAscPtr, WasmInstance};
-use futures::sync::mpsc;
 use futures03::channel::oneshot::Sender;
 use graph::blockchain::{BlockTime, Blockchain, HostFn};
 use graph::components::store::SubgraphFork;
 use graph::components::subgraph::{MappingError, SharedProofOfIndexing};
 use graph::data_source::{MappingTrigger, TriggerWithHandler};
+use graph::futures01::sync::mpsc;
+use graph::futures01::{Future as _, Stream as _};
 use graph::prelude::*;
 use graph::runtime::gas::Gas;
 use parity_wasm::elements::ExportEntry;

--- a/runtime/wasm/src/mapping.rs
+++ b/runtime/wasm/src/mapping.rs
@@ -1,12 +1,12 @@
 use crate::gas_rules::GasRules;
 use crate::module::{ExperimentalFeatures, ToAscPtr, WasmInstance};
-use futures03::channel::oneshot::Sender;
 use graph::blockchain::{BlockTime, Blockchain, HostFn};
 use graph::components::store::SubgraphFork;
 use graph::components::subgraph::{MappingError, SharedProofOfIndexing};
 use graph::data_source::{MappingTrigger, TriggerWithHandler};
 use graph::futures01::sync::mpsc;
 use graph::futures01::{Future as _, Stream as _};
+use graph::futures03::channel::oneshot::Sender;
 use graph::prelude::*;
 use graph::runtime::gas::Gas;
 use parity_wasm::elements::ExportEntry;

--- a/server/http/Cargo.toml
+++ b/server/http/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-futures = "0.1.21"
 serde = { workspace = true }
 graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }

--- a/server/http/src/lib.rs
+++ b/server/http/src/lib.rs
@@ -1,4 +1,3 @@
-extern crate futures;
 extern crate graph;
 extern crate graph_graphql;
 extern crate serde;

--- a/server/index-node/Cargo.toml
+++ b/server/index-node/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 
 [dependencies]
 blake3 = "1.5"
-futures = "0.3.4"
 graph = { path = "../../graph" }
 graph-graphql = { path = "../../graphql" }
 graph-chain-arweave = { path = "../../chain/arweave" }

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -13,6 +13,7 @@ use graph::components::versions::VERSIONS;
 use graph::data::graphql::{object, IntoValue, ObjectOrInterface, ValueMap};
 use graph::data::subgraph::{status, DeploymentFeatures};
 use graph::data::value::Object;
+use graph::futures03::TryFutureExt;
 use graph::prelude::*;
 use graph_graphql::prelude::{a, ExecutionContext, Resolver};
 
@@ -369,7 +370,7 @@ impl<S: Store> IndexNodeResolver<S> {
         let poi_fut = self
             .store
             .get_proof_of_indexing(&deployment_id, &indexer, block.clone());
-        let poi = match futures::executor::block_on(poi_fut) {
+        let poi = match graph::futures03::executor::block_on(poi_fut) {
             Ok(Some(poi)) => r::Value::String(format!("0x{}", hex::encode(poi))),
             Ok(None) => r::Value::Null,
             Err(e) => {

--- a/server/websocket/Cargo.toml
+++ b/server/websocket/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-futures = "0.1.23"
 graph = { path = "../../graph" }
 serde = { workspace = true }
 serde_derive = { workspace = true }

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -1,6 +1,8 @@
-use futures03::stream::SplitStream;
 use graph::futures01::sync::mpsc;
 use graph::futures01::{Future, IntoFuture, Sink as _, Stream as _};
+use graph::futures03::future::TryFutureExt;
+use graph::futures03::sink::SinkExt;
+use graph::futures03::stream::{SplitStream, StreamExt, TryStreamExt};
 use std::collections::HashMap;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_tungstenite::tungstenite::{
@@ -9,6 +11,7 @@ use tokio_tungstenite::tungstenite::{
 use tokio_tungstenite::WebSocketStream;
 use uuid::Uuid;
 
+use graph::futures03::compat::Future01CompatExt;
 use graph::{data::query::QueryTarget, prelude::*};
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/server/websocket/src/connection.rs
+++ b/server/websocket/src/connection.rs
@@ -1,5 +1,6 @@
-use futures::sync::mpsc;
 use futures03::stream::SplitStream;
+use graph::futures01::sync::mpsc;
+use graph::futures01::{Future, IntoFuture, Sink as _, Stream as _};
 use std::collections::HashMap;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_tungstenite::tungstenite::{

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -1,5 +1,7 @@
 use crate::connection::GraphQlConnection;
 use graph::futures01::IntoFuture as _;
+use graph::futures03::compat::Future01CompatExt;
+use graph::futures03::future::FutureExt;
 use graph::{
     data::query::QueryTarget,
     prelude::{SubscriptionServer as SubscriptionServerTrait, *},

--- a/server/websocket/src/server.rs
+++ b/server/websocket/src/server.rs
@@ -1,4 +1,5 @@
 use crate::connection::GraphQlConnection;
+use graph::futures01::IntoFuture as _;
 use graph::{
     data::query::QueryTarget,
     prelude::{SubscriptionServer as SubscriptionServerTrait, *},

--- a/store/postgres/src/chain_head_listener.rs
+++ b/store/postgres/src/chain_head_listener.rs
@@ -1,9 +1,7 @@
+use graph::futures03::{self, FutureExt};
 use graph::{
     blockchain::ChainHeadUpdateStream,
-    prelude::{
-        futures03::{self, FutureExt},
-        tokio, MetricsRegistry, StoreError,
-    },
+    prelude::{tokio, MetricsRegistry, StoreError},
     prometheus::{CounterVec, GaugeVec},
     util::timed_rw_lock::TimedRwLock,
 };

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -17,7 +17,7 @@ use graph::data::store::{Id, IdList};
 use graph::data::subgraph::{status, SPEC_VERSION_0_0_6};
 use graph::data_source::CausalityRegion;
 use graph::derive::CheapClone;
-use graph::prelude::futures03::FutureExt;
+use graph::futures03::FutureExt;
 use graph::prelude::{
     ApiVersion, CancelHandle, CancelToken, CancelableError, EntityOperation, PoolWaitStats,
     SubgraphDeploymentEntity,

--- a/store/postgres/src/store_events.rs
+++ b/store/postgres/src/store_events.rs
@@ -1,4 +1,5 @@
 use futures03::TryStreamExt;
+use graph::futures01::Stream;
 use graph::parking_lot::Mutex;
 use graph::tokio_stream::wrappers::ReceiverStream;
 use std::collections::BTreeSet;

--- a/store/postgres/src/store_events.rs
+++ b/store/postgres/src/store_events.rs
@@ -1,5 +1,7 @@
-use futures03::TryStreamExt;
 use graph::futures01::Stream;
+use graph::futures03::compat::Stream01CompatExt;
+use graph::futures03::stream::StreamExt;
+use graph::futures03::TryStreamExt;
 use graph::parking_lot::Mutex;
 use graph::tokio_stream::wrappers::ReceiverStream;
 use std::collections::BTreeSet;
@@ -106,7 +108,7 @@ impl<T: Clone + Debug + Send + Sync + 'static> Watcher<T> {
         self.sender.send(v).unwrap()
     }
 
-    fn stream(&self) -> Box<dyn futures03::Stream<Item = T> + Unpin + Send + Sync> {
+    fn stream(&self) -> Box<dyn graph::futures03::Stream<Item = T> + Unpin + Send + Sync> {
         Box::new(tokio_stream::wrappers::WatchStream::new(
             self.receiver.clone(),
         ))

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -11,6 +11,7 @@ use std::{
 };
 use std::{iter::FromIterator, time::Duration};
 
+use graph::futures03::future::join_all;
 use graph::{
     cheap_clone::CheapClone,
     components::{
@@ -24,10 +25,10 @@ use graph::{
     data::query::QueryTarget,
     data::subgraph::{schema::DeploymentCreate, status, DeploymentFeatures},
     prelude::{
-        anyhow, futures03::future::join_all, lazy_static, o, web3::types::Address, ApiVersion,
-        BlockNumber, BlockPtr, ChainStore, DeploymentHash, EntityOperation, Logger,
-        MetricsRegistry, NodeId, PartialBlockPtr, StoreError, SubgraphDeploymentEntity,
-        SubgraphName, SubgraphStore as SubgraphStoreTrait, SubgraphVersionSwitchingMode,
+        anyhow, lazy_static, o, web3::types::Address, ApiVersion, BlockNumber, BlockPtr,
+        ChainStore, DeploymentHash, EntityOperation, Logger, MetricsRegistry, NodeId,
+        PartialBlockPtr, StoreError, SubgraphDeploymentEntity, SubgraphName,
+        SubgraphStore as SubgraphStoreTrait, SubgraphVersionSwitchingMode,
     },
     prelude::{CancelableError, StoreEvent},
     schema::{ApiSchema, InputSchema},

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -350,7 +350,7 @@ pub async fn transact_entities_and_dynamic_data_sources(
     ops: Vec<EntityOperation>,
     manifest_idx_and_name: Vec<(u32, String)>,
 ) -> Result<(), StoreError> {
-    let store = futures03::executor::block_on(store.cheap_clone().writable(
+    let store = graph::futures03::executor::block_on(store.cheap_clone().writable(
         LOGGER.clone(),
         deployment.id,
         Arc::new(manifest_idx_and_name),

--- a/store/test-store/tests/graphql/query.rs
+++ b/store/test-store/tests/graphql/query.rs
@@ -18,6 +18,7 @@ use test_store::block_store::{
     FakeBlock, BLOCK_FOUR, BLOCK_ONE, BLOCK_THREE, BLOCK_TWO, GENESIS_BLOCK,
 };
 
+use graph::futures03::stream::StreamExt;
 use graph::{
     components::store::DeploymentLocator,
     data::graphql::{object, object_value},
@@ -27,11 +28,10 @@ use graph::{
         subgraph::SubgraphFeature,
     },
     prelude::{
-        futures03::stream::StreamExt, lazy_static, o, q, r, serde_json, slog, BlockPtr,
-        DeploymentHash, Entity, EntityOperation, FutureExtension, GraphQlRunner as _, Logger,
-        NodeId, Query, QueryError, QueryExecutionError, QueryResult, QueryStoreManager,
-        QueryVariables, SubgraphManifest, SubgraphName, SubgraphStore,
-        SubgraphVersionSwitchingMode, Subscription, SubscriptionError,
+        lazy_static, o, q, r, serde_json, slog, BlockPtr, DeploymentHash, Entity, EntityOperation,
+        FutureExtension, GraphQlRunner as _, Logger, NodeId, Query, QueryError,
+        QueryExecutionError, QueryResult, QueryStoreManager, QueryVariables, SubgraphManifest,
+        SubgraphName, SubgraphStore, SubgraphVersionSwitchingMode, Subscription, SubscriptionError,
     },
 };
 use graph_graphql::{prelude::*, subscription::execute_subscription};

--- a/store/test-store/tests/postgres/chain_head.rs
+++ b/store/test-store/tests/postgres/chain_head.rs
@@ -5,7 +5,7 @@ use graph::blockchain::{BlockHash, BlockPtr};
 use graph::data::store::ethereum::call;
 use graph::data::store::scalar::Bytes;
 use graph::env::ENV_VARS;
-use graph::prelude::futures03::executor;
+use graph::futures03::executor;
 use std::future::Future;
 use std::sync::Arc;
 

--- a/store/test-store/tests/postgres/store.rs
+++ b/store/test-store/tests/postgres/store.rs
@@ -4,6 +4,7 @@ use graph::data::graphql::ext::TypeDefinitionExt;
 use graph::data::query::QueryTarget;
 use graph::data::subgraph::schema::DeploymentCreate;
 use graph::futures01::{future, Stream};
+use graph::futures03::compat::Future01CompatExt;
 use graph::schema::{EntityType, InputSchema};
 use graph_chain_ethereum::{Mapping, MappingABI};
 use hex_literal::hex;

--- a/store/test-store/tests/postgres/store.rs
+++ b/store/test-store/tests/postgres/store.rs
@@ -3,6 +3,7 @@ use graph::blockchain::BlockTime;
 use graph::data::graphql::ext::TypeDefinitionExt;
 use graph::data::query::QueryTarget;
 use graph::data::subgraph::schema::DeploymentCreate;
+use graph::futures01::{future, Stream};
 use graph::schema::{EntityType, InputSchema};
 use graph_chain_ethereum::{Mapping, MappingABI};
 use hex_literal::hex;

--- a/store/test-store/tests/postgres/subgraph.rs
+++ b/store/test-store/tests/postgres/subgraph.rs
@@ -1,3 +1,4 @@
+use graph::futures03;
 use graph::{
     components::{
         server::index_node::VersionInfo,
@@ -13,11 +14,11 @@ use graph::{
     prelude::EntityChange,
     prelude::EntityChangeOperation,
     prelude::QueryStoreManager,
+    prelude::StoreEvent,
     prelude::SubgraphManifest,
     prelude::SubgraphName,
     prelude::SubgraphVersionSwitchingMode,
     prelude::UnfailOutcome,
-    prelude::{futures03, StoreEvent},
     prelude::{CheapClone, DeploymentHash, NodeId, SubgraphStore as _},
     schema::InputSchema,
     semver::Version,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,7 +7,6 @@ edition.workspace = true
 anyhow = "1.0"
 assert-json-diff = "2.0.2"
 async-stream = "0.3.5"
-futures = { version = "0.3", features = ["compat"] }
 graph = { path = "../graph" }
 graph-chain-ethereum = { path = "../chain/ethereum" }
 graph-chain-substreams= {path = "../chain/substreams"}

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -8,7 +8,6 @@ use std::time::{Duration, Instant};
 
 use anyhow::Error;
 use async_stream::stream;
-use futures::{Stream, StreamExt};
 use graph::blockchain::block_stream::{
     BlockRefetcher, BlockStream, BlockStreamBuilder, BlockStreamError, BlockStreamEvent,
     BlockWithTriggers, FirehoseCursor,
@@ -28,6 +27,7 @@ use graph::data::subgraph::schema::{SubgraphError, SubgraphHealth};
 use graph::endpoint::EndpointMetrics;
 use graph::env::EnvVars;
 use graph::firehose::{FirehoseEndpoint, FirehoseEndpoints, SubgraphLimit};
+use graph::futures03::{Stream, StreamExt};
 use graph::http_body_util::Full;
 use graph::hyper::body::Bytes;
 use graph::hyper::Request;

--- a/tests/tests/integration_tests.rs
+++ b/tests/tests/integration_tests.rs
@@ -14,7 +14,7 @@ use std::pin::Pin;
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context};
-use futures::StreamExt;
+use graph::futures03::StreamExt;
 use graph::prelude::serde_json::{json, Value};
 use graph_tests::contract::Contract;
 use graph_tests::helpers::{run_checked, TestFile};


### PR DESCRIPTION
We regrettably use both futures 0.1 and 0.3; these changes should make it a little clearer where we still use futures 01. It also simplifies how we use these crates and requires that the version is spelled out directly wherever something from either crate is used.

The hope is that we can remove the use of futures 01 completely at some point. This is a small step in that direction to make its uses more visible. 