### PR TITLE
Postpone creation of the attribute indexes

### DIFF
--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -259,7 +259,8 @@ impl EnvVars {
             subgraph_error_retry_ceil: Duration::from_secs(inner.subgraph_error_retry_ceil_in_secs),
             subgraph_error_retry_jitter: inner.subgraph_error_retry_jitter,
             enable_select_by_specific_attributes: inner.enable_select_by_specific_attributes.0,
-            postpone_attribute_index_creation: inner.postpone_attribute_index_creation.0,
+            postpone_attribute_index_creation: inner.postpone_attribute_index_creation.0
+                || cfg!(debug_assertions),
             log_trigger_data: inner.log_trigger_data.0,
             explorer_ttl: Duration::from_secs(inner.explorer_ttl_in_secs),
             explorer_lock_threshold: Duration::from_millis(inner.explorer_lock_threshold_in_msec),

--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -152,6 +152,10 @@ pub struct EnvVars {
     /// Set by the flag `GRAPH_ENABLE_SELECT_BY_SPECIFIC_ATTRIBUTES`. On by
     /// default.
     pub enable_select_by_specific_attributes: bool,
+    /// Experimental feature.
+    ///
+    /// Set the flag `GRAPH_POSTPONE_ATTRIBUTE_INDEX_CREATION`. Off by default.
+    pub postpone_attribute_index_creation: bool,
     /// Verbose logging of mapping inputs.
     ///
     /// Set by the flag `GRAPH_LOG_TRIGGER_DATA`. Off by
@@ -255,6 +259,7 @@ impl EnvVars {
             subgraph_error_retry_ceil: Duration::from_secs(inner.subgraph_error_retry_ceil_in_secs),
             subgraph_error_retry_jitter: inner.subgraph_error_retry_jitter,
             enable_select_by_specific_attributes: inner.enable_select_by_specific_attributes.0,
+            postpone_attribute_index_creation: inner.postpone_attribute_index_creation.0,
             log_trigger_data: inner.log_trigger_data.0,
             explorer_ttl: Duration::from_secs(inner.explorer_ttl_in_secs),
             explorer_lock_threshold: Duration::from_millis(inner.explorer_lock_threshold_in_msec),
@@ -377,6 +382,8 @@ struct Inner {
     subgraph_error_retry_jitter: f64,
     #[envconfig(from = "GRAPH_ENABLE_SELECT_BY_SPECIFIC_ATTRIBUTES", default = "true")]
     enable_select_by_specific_attributes: EnvVarBoolean,
+    #[envconfig(from = "GRAPH_POSTPONE_ATTRIBUTE_INDEX_CREATION", default = "false")]
+    postpone_attribute_index_creation: EnvVarBoolean,
     #[envconfig(from = "GRAPH_LOG_TRIGGER_DATA", default = "false")]
     log_trigger_data: EnvVarBoolean,
     #[envconfig(from = "GRAPH_EXPLORER_TTL", default = "10")]

--- a/store/postgres/examples/layout.rs
+++ b/store/postgres/examples/layout.rs
@@ -42,7 +42,7 @@ fn print_delete_all(layout: &Layout) {
 }
 
 fn print_ddl(layout: &Layout) {
-    let ddl = ensure(layout.as_ddl(), "Failed to generate DDL");
+    let ddl = ensure(layout.as_ddl(false), "Failed to generate DDL");
     println!("{}", ddl);
 }
 

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -180,6 +180,7 @@ impl DeploymentStore {
         graft_base: Option<Arc<Layout>>,
         replace: bool,
         on_sync: OnSync,
+        is_copy_op: bool,
     ) -> Result<(), StoreError> {
         let mut conn = self.get_conn()?;
         conn.transaction(|conn| -> Result<_, StoreError> {
@@ -212,6 +213,7 @@ impl DeploymentStore {
                     site.clone(),
                     schema,
                     entities_with_causality_region.into_iter().collect(),
+                    is_copy_op,
                 )?;
                 // See if we are grafting and check that the graft is permissible
                 if let Some(base) = graft_base {

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -384,12 +384,13 @@ impl Layout {
         site: Arc<Site>,
         schema: &InputSchema,
         entities_with_causality_region: BTreeSet<EntityType>,
+        is_copy_op: bool,
     ) -> Result<Layout, StoreError> {
         let catalog =
             Catalog::for_creation(conn, site.cheap_clone(), entities_with_causality_region)?;
         let layout = Self::new(site, schema, catalog)?;
         let sql = layout
-            .as_ddl()
+            .as_ddl(is_copy_op)
             .map_err(|_| StoreError::Unknown(anyhow!("failed to generate DDL for layout")))?;
         conn.batch_execute(&sql)?;
         Ok(layout)

--- a/store/postgres/src/relational/ddl.rs
+++ b/store/postgres/src/relational/ddl.rs
@@ -288,8 +288,10 @@ impl Table {
         for (column_index, column) in columns.enumerate() {
             let (method, index_expr) =
                 Self::calculate_attr_index_method_and_expression(self.immutable, column);
-            let delay_index = !column.is_list() && is_copy_op && method == "btree";
-            // TODO: add disabling it with an env. variable
+            let delay_index = ENV_VARS.postpone_attribute_index_creation
+                && !column.is_list()
+                && is_copy_op
+                && method == "btree";
             // TODO: check if skipping should be done for POI table!
 
             // If `create_gin_indexes` is set to false, we don't create

--- a/store/postgres/src/relational/ddl_tests.rs
+++ b/store/postgres/src/relational/ddl_tests.rs
@@ -155,31 +155,31 @@ fn test_manual_index_creation_ddl() {
 #[test]
 fn generate_ddl() {
     let layout = test_layout(THING_GQL);
-    let sql = layout.as_ddl().expect("Failed to generate DDL");
+    let sql = layout.as_ddl(false).expect("Failed to generate DDL");
     assert_eq!(THING_DDL, &sql); // Use `assert_eq!` to also test the formatting.
 
     let layout = test_layout(MUSIC_GQL);
-    let sql = layout.as_ddl().expect("Failed to generate DDL");
+    let sql = layout.as_ddl(false).expect("Failed to generate DDL");
     check_eqv(MUSIC_DDL, &sql);
 
     let layout = test_layout(FOREST_GQL);
-    let sql = layout.as_ddl().expect("Failed to generate DDL");
+    let sql = layout.as_ddl(false).expect("Failed to generate DDL");
     check_eqv(FOREST_DDL, &sql);
 
     let layout = test_layout(FULLTEXT_GQL);
-    let sql = layout.as_ddl().expect("Failed to generate DDL");
+    let sql = layout.as_ddl(false).expect("Failed to generate DDL");
     check_eqv(FULLTEXT_DDL, &sql);
 
     let layout = test_layout(FORWARD_ENUM_GQL);
-    let sql = layout.as_ddl().expect("Failed to generate DDL");
+    let sql = layout.as_ddl(false).expect("Failed to generate DDL");
     check_eqv(FORWARD_ENUM_SQL, &sql);
 
     let layout = test_layout(TS_GQL);
-    let sql = layout.as_ddl().expect("Failed to generate DDL");
+    let sql = layout.as_ddl(false).expect("Failed to generate DDL");
     check_eqv(TS_SQL, &sql);
 
     let layout = test_layout(LIFETIME_GQL);
-    let sql = layout.as_ddl().expect("Failed to generate DDL");
+    let sql = layout.as_ddl(false).expect("Failed to generate DDL");
     check_eqv(LIFETIME_SQL, &sql);
 }
 

--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -94,7 +94,7 @@ impl TablePair {
         if catalog::table_exists(conn, dst_nsp.as_str(), &dst.name)? {
             writeln!(query, "truncate table {};", dst.qualified_name)?;
         } else {
-            dst.as_ddl(schema, catalog, &mut query)?;
+            dst.as_ddl(schema, catalog, false, &mut query)?; // TODO: is it a copy?
         }
         conn.batch_execute(&query)?;
 

--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -94,7 +94,9 @@ impl TablePair {
         if catalog::table_exists(conn, dst_nsp.as_str(), &dst.name)? {
             writeln!(query, "truncate table {};", dst.qualified_name)?;
         } else {
-            dst.as_ddl(schema, catalog, false, &mut query)?; // TODO: is it a copy?
+            // In case of pruning we don't do delayed creation of indexes,
+            // as the asumption is that there is not that much data inserted.
+            dst.as_ddl(schema, catalog, false, &mut query)?;
         }
         conn.batch_execute(&query)?;
 

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -577,6 +577,7 @@ impl SubgraphStoreInner {
             graft_base,
             replace,
             OnSync::None,
+            false,
         )?;
 
         let exists_and_synced = |id: &DeploymentHash| {
@@ -667,6 +668,7 @@ impl SubgraphStoreInner {
             Some(graft_base),
             false,
             on_sync,
+            true,
         )?;
 
         let mut pconn = self.primary_conn()?;

--- a/store/test-store/tests/postgres/relational.rs
+++ b/store/test-store/tests/postgres/relational.rs
@@ -477,7 +477,7 @@ fn create_schema(conn: &mut PgConnection) -> Layout {
     let query = format!("create schema {}", NAMESPACE.as_str());
     conn.batch_execute(&query).unwrap();
 
-    Layout::create_relational_schema(conn, Arc::new(site), &schema, BTreeSet::new())
+    Layout::create_relational_schema(conn, Arc::new(site), &schema, BTreeSet::new(), false)
         .expect("Failed to create relational schema")
 }
 

--- a/store/test-store/tests/postgres/relational_bytes.rs
+++ b/store/test-store/tests/postgres/relational_bytes.rs
@@ -151,7 +151,7 @@ fn create_schema(conn: &mut PgConnection) -> Layout {
         NAMESPACE.clone(),
         NETWORK_NAME.to_string(),
     );
-    Layout::create_relational_schema(conn, Arc::new(site), &schema, BTreeSet::new())
+    Layout::create_relational_schema(conn, Arc::new(site), &schema, BTreeSet::new(), false)
         .expect("Failed to create relational schema")
 }
 


### PR DESCRIPTION
It contains the first part of the functionality for the https://github.com/graphprotocol/graph-node/issues/5140 by postponing the creation of the attribute indexes after a copy operation has finished.