### PR TITLE
graph, store: Avoid using to_jsonb when looking up a single entity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ axum = "0.7.5"
 chrono = "0.4.38"
 clap = { version = "4.5.4", features = ["derive", "env"] }
 derivative = "2.2.0"
-diesel = { version = "2.2.4", features = ["postgres", "serde_json", "numeric", "r2d2", "chrono", "uuid"] }
+diesel = { version = "2.2.4", features = ["postgres", "serde_json", "numeric", "r2d2", "chrono", "uuid", "i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }
 diesel-derive-enum = { version = "2.1.0", features = ["postgres"] }
-diesel-dynamic-schema = "0.2.1"
+diesel-dynamic-schema = { version = "0.2.1", features = ["postgres"] }
 diesel_derives = "2.1.4"
 diesel_migrations = "2.1.0"
 graph = { path = "./graph" }

--- a/graph/src/data/store/scalar/bigdecimal.rs
+++ b/graph/src/data/store/scalar/bigdecimal.rs
@@ -1,6 +1,6 @@
 use diesel::deserialize::FromSqlRow;
 use diesel::expression::AsExpression;
-use num_bigint;
+use num_bigint::{self, ToBigInt};
 use num_traits::FromPrimitive;
 use serde::{self, Deserialize, Serialize};
 use stable_hash::{FieldAddress, StableHash};
@@ -10,8 +10,8 @@ use std::fmt::{self, Display, Formatter};
 use std::ops::{Add, Div, Mul, Sub};
 use std::str::FromStr;
 
+use crate::anyhow::anyhow;
 use crate::runtime::gas::{Gas, GasSizeOf};
-
 use old_bigdecimal::BigDecimal as OldBigDecimal;
 pub use old_bigdecimal::ToPrimitive;
 
@@ -58,6 +58,26 @@ impl BigDecimal {
 
     pub fn as_bigint_and_exponent(&self) -> (num_bigint::BigInt, i64) {
         self.0.as_bigint_and_exponent()
+    }
+
+    pub fn is_integer(&self) -> bool {
+        self.0.is_integer()
+    }
+
+    /// Convert this `BigDecimal` to a `BigInt` if it is an integer, and
+    /// return an error if it is not. Also return an error if the integer
+    /// would use too many digits as definied by `BigInt::new`
+    pub fn to_bigint(&self) -> Result<BigInt, anyhow::Error> {
+        if !self.is_integer() {
+            return Err(anyhow!(
+                "Cannot convert non-integer `BigDecimal` to `BigInt`: {:?}",
+                self
+            ));
+        }
+        let bi = self.0.to_bigint().ok_or_else(|| {
+            anyhow!("The implementation of `to_bigint` for `OldBigDecimal` always returns `Some`")
+        })?;
+        BigInt::new(bi)
     }
 
     pub fn digits(&self) -> u64 {

--- a/graph/src/data/store/scalar/bytes.rs
+++ b/graph/src/data/store/scalar/bytes.rs
@@ -1,3 +1,5 @@
+use diesel::deserialize::FromSql;
+use diesel::pg::PgValue;
 use diesel::serialize::ToSql;
 use hex;
 use serde::{self, Deserialize, Serialize};
@@ -113,5 +115,11 @@ impl ToSql<diesel::sql_types::Binary, diesel::pg::Pg> for Bytes {
         out: &mut diesel::serialize::Output<'b, '_, diesel::pg::Pg>,
     ) -> diesel::serialize::Result {
         <_ as ToSql<diesel::sql_types::Binary, _>>::to_sql(self.as_slice(), &mut out.reborrow())
+    }
+}
+
+impl FromSql<diesel::sql_types::Binary, diesel::pg::Pg> for Bytes {
+    fn from_sql(value: PgValue) -> diesel::deserialize::Result<Self> {
+        <Vec<u8> as FromSql<diesel::sql_types::Binary, _>>::from_sql(value).map(Bytes::from)
     }
 }

--- a/graph/src/data/store/scalar/timestamp.rs
+++ b/graph/src/data/store/scalar/timestamp.rs
@@ -1,4 +1,6 @@
 use chrono::{DateTime, Utc};
+use diesel::deserialize::FromSql;
+use diesel::pg::PgValue;
 use diesel::serialize::ToSql;
 use serde::{self, Deserialize, Serialize};
 use stable_hash::StableHash;
@@ -105,5 +107,12 @@ impl ToSql<diesel::sql_types::Timestamptz, diesel::pg::Pg> for Timestamp {
 impl GasSizeOf for Timestamp {
     fn const_gas_size_of() -> Option<Gas> {
         Some(Gas::new(std::mem::size_of::<Timestamp>().saturating_into()))
+    }
+}
+
+impl FromSql<diesel::sql_types::Timestamptz, diesel::pg::Pg> for Timestamp {
+    fn from_sql(value: PgValue) -> diesel::deserialize::Result<Self> {
+        <DateTime<Utc> as FromSql<diesel::sql_types::Timestamptz, _>>::from_sql(value)
+            .map(Timestamp)
     }
 }

--- a/graph/src/data/value.rs
+++ b/graph/src/data/value.rs
@@ -115,6 +115,24 @@ impl PartialEq<&str> for Word {
     }
 }
 
+impl PartialEq<str> for Word {
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<String> for Word {
+    fn eq(&self, other: &String) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<Word> for String {
+    fn eq(&self, other: &Word) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
 impl PartialEq<Word> for &str {
     fn eq(&self, other: &Word) -> bool {
         self == &other.as_str()

--- a/graph/src/data_source/causality_region.rs
+++ b/graph/src/data_source/causality_region.rs
@@ -4,6 +4,7 @@ use diesel::{
     serialize::{Output, ToSql},
     sql_types::Integer,
 };
+use diesel_derives::AsExpression;
 use std::fmt;
 
 use crate::components::subgraph::Entity;
@@ -20,7 +21,10 @@ use crate::derive::CacheWeight;
 /// This necessary for determinism because offchain data sources don't have a deterministic order of
 /// execution, for example an IPFS file may become available at any point in time. The isolation
 /// rules make the indexing result reproducible, given a set of available files.
-#[derive(Debug, CacheWeight, Copy, Clone, PartialEq, Eq, FromSqlRow, Hash, PartialOrd, Ord)]
+#[derive(
+    Debug, CacheWeight, Copy, Clone, PartialEq, Eq, FromSqlRow, Hash, PartialOrd, Ord, AsExpression,
+)]
+#[diesel(sql_type = Integer)]
 pub struct CausalityRegion(i32);
 
 impl fmt::Display for CausalityRegion {

--- a/store/postgres/src/block_range.rs
+++ b/store/postgres/src/block_range.rs
@@ -280,14 +280,6 @@ impl<'a> BlockRangeColumn<'a> {
         }
     }
 
-    /// Output the name of the block range column without the table prefix
-    pub(crate) fn bare_name(&self, out: &mut AstPass<Pg>) {
-        match self {
-            BlockRangeColumn::Mutable { .. } => out.push_sql(BLOCK_RANGE_COLUMN),
-            BlockRangeColumn::Immutable { .. } => out.push_sql(BLOCK_COLUMN),
-        }
-    }
-
     /// Output an expression that matches all rows that have been changed
     /// after `block` (inclusive)
     pub(crate) fn changed_since<'b>(&'b self, out: &mut AstPass<'_, 'b, Pg>) -> QueryResult<()> {

--- a/store/postgres/src/block_range.rs
+++ b/store/postgres/src/block_range.rs
@@ -165,13 +165,6 @@ impl<'a> BlockRangeColumn<'a> {
             }
         }
     }
-
-    pub fn block(&self) -> BlockNumber {
-        match self {
-            BlockRangeColumn::Mutable { block, .. } => *block,
-            BlockRangeColumn::Immutable { block, .. } => *block,
-        }
-    }
 }
 
 impl<'a> BlockRangeColumn<'a> {
@@ -224,13 +217,6 @@ impl<'a> BlockRangeColumn<'a> {
                     out.push_bind_param::<Integer, _>(block)
                 }
             }
-        }
-    }
-
-    pub fn column_name(&self) -> &str {
-        match self {
-            BlockRangeColumn::Mutable { .. } => BLOCK_RANGE_COLUMN,
-            BlockRangeColumn::Immutable { .. } => BLOCK_COLUMN,
         }
     }
 

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -296,6 +296,12 @@ impl Borrow<str> for Namespace {
     }
 }
 
+impl Borrow<str> for &Namespace {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
 /// A marker that an `i32` references a deployment. Values of this type hold
 /// the primary key from the `deployment_schemas` table
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, AsExpression, FromSqlRow)]

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -14,16 +14,20 @@ mod ddl_tests;
 #[cfg(test)]
 mod query_tests;
 
+pub(crate) mod dsl;
 pub(crate) mod index;
 mod prune;
 mod rollup;
+pub(crate) mod value;
 
 use diesel::deserialize::FromSql;
 use diesel::pg::Pg;
 use diesel::serialize::{Output, ToSql};
 use diesel::sql_types::Text;
 use diesel::{connection::SimpleConnection, Connection};
-use diesel::{debug_query, sql_query, OptionalExtension, PgConnection, QueryResult, RunQueryDsl};
+use diesel::{
+    debug_query, sql_query, OptionalExtension, PgConnection, QueryDsl, QueryResult, RunQueryDsl,
+};
 use graph::blockchain::BlockTime;
 use graph::cheap_clone::CheapClone;
 use graph::components::store::write::{RowGroup, WriteChunk};
@@ -50,6 +54,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use crate::relational::value::{FromOidRow, OidRow};
 use crate::relational_queries::{
     ConflictingEntitiesData, ConflictingEntitiesQuery, FindChangesQuery, FindDerivedQuery,
     FindPossibleDeletionsQuery, ReturnedEntityData,
@@ -58,10 +63,10 @@ use crate::{
     primary::{Namespace, Site},
     relational_queries::{
         ClampRangeQuery, EntityData, EntityDeletion, FilterCollection, FilterQuery, FindManyQuery,
-        FindQuery, InsertQuery, RevertClampQuery, RevertRemoveQuery,
+        InsertQuery, RevertClampQuery, RevertRemoveQuery,
     },
 };
-use graph::components::store::DerivedEntityQuery;
+use graph::components::store::{AttributeNames, DerivedEntityQuery};
 use graph::data::store::{Id, IdList, IdType, BYTES_SCALAR};
 use graph::data::subgraph::schema::POI_TABLE;
 use graph::prelude::{
@@ -172,6 +177,12 @@ impl From<String> for SqlName {
     }
 }
 
+impl From<SqlName> for Word {
+    fn from(name: SqlName) -> Self {
+        Word::from(name.0)
+    }
+}
+
 impl fmt::Display for SqlName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
@@ -181,6 +192,12 @@ impl fmt::Display for SqlName {
 impl Borrow<str> for &SqlName {
     fn borrow(&self) -> &str {
         self.as_str()
+    }
+}
+
+impl PartialEq<str> for SqlName {
+    fn eq(&self, other: &str) -> bool {
+        self.0 == other
     }
 }
 
@@ -361,9 +378,11 @@ impl Layout {
         }
 
         let table_name = SqlName::verbatim(POI_TABLE.to_owned());
+        let nsp = catalog.site.namespace.clone();
         Table {
             object: poi_type.to_owned(),
             qualified_name: SqlName::qualified_name(&catalog.site.namespace, &table_name),
+            nsp,
             name: table_name,
             columns,
             // The position of this table in all the tables for this layout; this
@@ -469,11 +488,19 @@ impl Layout {
         key: &EntityKey,
         block: BlockNumber,
     ) -> Result<Option<Entity>, StoreError> {
-        let table = self.table_for_entity(&key.entity_type)?;
-        FindQuery::new(table.as_ref(), key, block)
-            .get_result::<EntityData>(conn)
+        let table = self.table_for_entity(&key.entity_type)?.dsl_table();
+        let columns = table.selected_columns::<Entity>(&AttributeNames::All, None)?;
+
+        let query = table
+            .select_cols(&columns)
+            .filter(table.id_eq(&key.entity_id))
+            .filter(table.at_block(block))
+            .filter(table.belongs_to_causality_region(key.causality_region));
+
+        query
+            .get_result::<OidRow>(conn)
             .optional()?
-            .map(|entity_data| entity_data.deserialize_with_layout(self, None))
+            .map(|row| Entity::from_oid_row(row, &self.input_schema, &columns))
             .transpose()
     }
 
@@ -1348,6 +1375,21 @@ impl Column {
         })
     }
 
+    pub fn pseudo_column(name: &str, column_type: ColumnType) -> Column {
+        let field_type = q::Type::NamedType(column_type.to_string());
+        let name = SqlName::verbatim(name.to_string());
+        let field = Word::from(name.as_str());
+        Column {
+            name,
+            field,
+            field_type,
+            column_type,
+            fulltext_fields: None,
+            is_reference: false,
+            use_prefix_comparison: false,
+        }
+    }
+
     fn new_fulltext(def: &FulltextDefinition) -> Result<Column, StoreError> {
         SqlName::check_valid_identifier(&def.name, "attribute")?;
         let sql_name = SqlName::from(def.name.as_str());
@@ -1440,6 +1482,9 @@ pub struct Table {
     /// `Stats_hour`, not the overall aggregation type `Stats`.
     pub object: EntityType,
 
+    /// The namespace in which the table lives
+    nsp: Namespace,
+
     /// The name of the database table for this type ('thing'), snakecased
     /// version of `object`
     pub name: SqlName,
@@ -1494,10 +1539,11 @@ impl Table {
             .collect::<Result<Vec<Column>, StoreError>>()?;
         let qualified_name = SqlName::qualified_name(&catalog.site.namespace, &table_name);
         let immutable = defn.is_immutable();
-
+        let nsp = catalog.site.namespace.clone();
         let table = Table {
             object: defn.cheap_clone(),
             name: table_name,
+            nsp,
             qualified_name,
             // Default `is_account_like` to `false`; the caller should call
             // `refresh` after constructing the layout, but that requires a
@@ -1516,6 +1562,7 @@ impl Table {
     pub fn new_like(&self, namespace: &Namespace, name: &SqlName) -> Arc<Table> {
         let other = Table {
             object: self.object.clone(),
+            nsp: self.nsp.clone(),
             name: name.clone(),
             qualified_name: SqlName::qualified_name(namespace, name),
             columns: self.columns.clone(),
@@ -1589,6 +1636,10 @@ impl Table {
         } else {
             &crate::block_range::BLOCK_RANGE_COLUMN_SQL
         }
+    }
+
+    pub fn dsl_table(&self) -> dsl::Table<'_> {
+        dsl::Table::new(self)
     }
 }
 

--- a/store/postgres/src/relational/dsl.rs
+++ b/store/postgres/src/relational/dsl.rs
@@ -693,6 +693,26 @@ impl<'a> Column<'a> {
     pub fn name(&self) -> &'a str {
         &self.column.name
     }
+
+    pub(crate) fn is_list(&self) -> bool {
+        self.column.is_list()
+    }
+
+    pub(crate) fn is_primary_key(&self) -> bool {
+        self.column.is_primary_key()
+    }
+
+    pub(crate) fn is_fulltext(&self) -> bool {
+        self.column.is_fulltext()
+    }
+
+    pub(crate) fn column_type(&self) -> &'a ColumnType {
+        &self.column.column_type
+    }
+
+    pub(crate) fn use_prefix_comparison(&self) -> bool {
+        self.column.use_prefix_comparison
+    }
 }
 
 impl std::fmt::Display for Column<'_> {

--- a/store/postgres/src/relational/dsl.rs
+++ b/store/postgres/src/relational/dsl.rs
@@ -1,0 +1,761 @@
+//! Helpers for creating relational queries using diesel. A lot of this code
+//! is copied from `diesel_dynamic_schema` and adapted to our data
+//! structures, especially the `Table` and `Column` types.
+
+use std::marker::PhantomData;
+
+use diesel::backend::Backend;
+use diesel::dsl::sql;
+use diesel::expression::{expression_types, is_aggregate, TypedExpressionType, ValidGrouping};
+use diesel::pg::Pg;
+use diesel::query_builder::{
+    AsQuery, AstPass, BoxedSelectStatement, FromClause, Query, QueryFragment, QueryId,
+    SelectStatement,
+};
+use diesel::query_dsl::methods::SelectDsl;
+use diesel::query_source::QuerySource;
+
+use diesel::sql_types::{
+    Array, BigInt, Binary, Bool, Integer, Nullable, Numeric, SingleValue, Text, Timestamptz,
+    Untyped,
+};
+use diesel::{AppearsOnTable, Expression, QueryDsl, QueryResult, SelectableExpression};
+use diesel_dynamic_schema::DynamicSelectClause;
+use graph::components::store::{AttributeNames, BlockNumber, StoreError, BLOCK_NUMBER_MAX};
+use graph::data::store::{Id, IdType, ID};
+use graph::data_source::CausalityRegion;
+use graph::prelude::{lazy_static, ENV_VARS};
+
+use crate::relational::ColumnType;
+use crate::relational_queries::PARENT_ID;
+
+use super::value::FromOidRow;
+use super::Column as RelColumn;
+use super::SqlName;
+use super::{BLOCK_COLUMN, BLOCK_RANGE_COLUMN};
+
+const TYPENAME: &str = "__typename";
+
+lazy_static! {
+    pub static ref TYPENAME_SQL: SqlName = TYPENAME.into();
+    pub static ref VID_SQL: SqlName = "vid".into();
+    pub static ref PARENT_SQL: SqlName = PARENT_ID.into();
+    pub static ref TYPENAME_COL: RelColumn = RelColumn::pseudo_column(TYPENAME, ColumnType::String);
+    pub static ref VID_COL: RelColumn = RelColumn::pseudo_column("vid", ColumnType::Int8);
+    pub static ref BLOCK_COL: RelColumn = RelColumn::pseudo_column(BLOCK_COLUMN, ColumnType::Int8);
+    // The column type is a placeholder, we can't deserialize in4range; but
+    // we also never try to use it when we get data from the database
+    pub static ref BLOCK_RANGE_COL: RelColumn =
+        RelColumn::pseudo_column(BLOCK_RANGE_COLUMN, ColumnType::Bytes);
+    pub static ref PARENT_STRING_COL: RelColumn = RelColumn::pseudo_column(PARENT_ID, ColumnType::String);
+    pub static ref PARENT_BYTES_COL: RelColumn = RelColumn::pseudo_column(PARENT_ID, ColumnType::Bytes);
+    pub static ref PARENT_INT_COL: RelColumn = RelColumn::pseudo_column(PARENT_ID, ColumnType::Int8);
+
+    pub static ref META_COLS: [&'static RelColumn; 2] = [&*TYPENAME_COL, &*VID_COL];
+}
+
+#[doc(hidden)]
+/// A dummy expression.
+pub struct DummyExpression;
+
+impl DummyExpression {
+    pub(crate) fn new() -> Self {
+        DummyExpression
+    }
+}
+
+impl<QS> SelectableExpression<QS> for DummyExpression {}
+
+impl<QS> AppearsOnTable<QS> for DummyExpression {}
+
+impl Expression for DummyExpression {
+    type SqlType = expression_types::NotSelectable;
+}
+
+impl ValidGrouping<()> for DummyExpression {
+    type IsAggregate = is_aggregate::No;
+}
+
+/// A fixed size string for the table alias. We want to make sure that
+/// converting these to `&str` doesn't allocate and that they are small
+/// enough that the `Table` struct is only 16 bytes and can be `Copy`
+#[derive(Debug, Clone, Copy)]
+pub struct ChildAliasStr {
+    alias: [u8; 4],
+}
+
+impl ChildAliasStr {
+    fn new(idx: u8) -> Self {
+        let c = 'i' as u8;
+        let alias = if idx == 0 {
+            [c, 0, 0, 0]
+        } else if idx < 10 {
+            let ones = char::from_digit(idx as u32, 10).unwrap() as u8;
+            [c, ones, 0, 0]
+        } else if idx < 100 {
+            let tens = char::from_digit((idx / 10) as u32, 10).unwrap() as u8;
+            let ones = char::from_digit((idx % 10) as u32, 10).unwrap() as u8;
+            [c, tens, ones, 0]
+        } else {
+            let hundreds = char::from_digit((idx / 100) as u32, 10).unwrap() as u8;
+            let idx = idx % 100;
+            let tens = char::from_digit((idx / 10) as u32, 10).unwrap() as u8;
+            let ones = char::from_digit((idx % 10) as u32, 10).unwrap() as u8;
+            [c, hundreds, tens, ones]
+        };
+        ChildAliasStr { alias }
+    }
+
+    fn as_str(&self) -> &str {
+        let alias = if self.alias[1] == 0 {
+            return "i";
+        } else if self.alias[2] == 0 {
+            &self.alias[..2]
+        } else if self.alias[3] == 0 {
+            &self.alias[..3]
+        } else {
+            &self.alias
+        };
+        unsafe { std::str::from_utf8_unchecked(alias) }
+    }
+}
+
+/// A table alias. We use `c` as the main table alias and `i`, `i1`, `i2`,
+/// ... for child tables. The fact that we use these specific letters is
+/// historical and doesn't have any meaning.
+#[derive(Debug, Clone, Copy)]
+pub enum Alias {
+    Main,
+    Child(ChildAliasStr),
+}
+
+impl Alias {
+    fn as_str(&self) -> &str {
+        match self {
+            Alias::Main => "c",
+            Alias::Child(idx) => idx.as_str(),
+        }
+    }
+
+    fn child(idx: u8) -> Self {
+        Alias::Child(ChildAliasStr::new(idx))
+    }
+}
+
+#[test]
+fn alias() {
+    assert_eq!(Alias::Main.as_str(), "c");
+    assert_eq!(Alias::Child(ChildAliasStr::new(0)).as_str(), "i");
+    assert_eq!(Alias::Child(ChildAliasStr::new(1)).as_str(), "i1");
+    assert_eq!(Alias::Child(ChildAliasStr::new(10)).as_str(), "i10");
+    assert_eq!(Alias::Child(ChildAliasStr::new(100)).as_str(), "i100");
+    assert_eq!(Alias::Child(ChildAliasStr::new(255)).as_str(), "i255");
+}
+
+#[derive(Debug, Clone, Copy)]
+/// A wrapper around the `super::Table` struct that provides helper
+/// functions for generating SQL queries
+pub struct Table<'a> {
+    /// The metadata for this table
+    pub meta: &'a super::Table,
+    alias: Alias,
+}
+
+impl<'a> Table<'a> {
+    pub(crate) fn new(meta: &'a super::Table) -> Self {
+        Self {
+            meta,
+            alias: Alias::Main,
+        }
+    }
+
+    /// Change the alias for this table to be a child table.
+    pub fn child(mut self, idx: u8) -> Self {
+        self.alias = Alias::child(idx);
+        self
+    }
+
+    /// Reference a column in this table and use the correct SQL type `ST`
+    fn bind<ST>(&self, name: &str) -> Option<BoundColumn<ST>> {
+        self.column(name).map(|c| c.bind())
+    }
+
+    /// Reference a column without regard to the underlying SQL type. This
+    /// is useful if just the name of the column qualified with the table
+    /// name/alias is needed
+    pub fn column(&self, name: &str) -> Option<Column<'a>> {
+        self.meta
+            .columns
+            .iter()
+            .chain(META_COLS.into_iter())
+            .find(|c| &c.name == name)
+            .map(|c| Column::new(self.clone(), c))
+    }
+
+    pub fn name(&self) -> &str {
+        &self.meta.name
+    }
+
+    pub fn column_for_field(&self, field: &str) -> Result<Column<'a>, StoreError> {
+        self.meta
+            .column_for_field(field)
+            .map(|column| Column::new(*self, column))
+    }
+
+    pub fn primary_key(&self) -> Column<'a> {
+        Column::new(*self, self.meta.primary_key())
+    }
+
+    /// Return a filter expression that generates the SQL for `id = $id`
+    pub fn id_eq(&'a self, id: &'a Id) -> IdEq<'a> {
+        IdEq::new(*self, id)
+    }
+
+    /// Return an expression that generates the SQL for `block_range @>
+    /// $block` or `block = $block` depending on whether the table is
+    /// mutable or not
+    pub fn at_block(&self, block: BlockNumber) -> AtBlock<'a> {
+        AtBlock::new(*self, block)
+    }
+
+    /// The block column for this table for places where the just the
+    /// qualified name is needed
+    pub fn block_column(&self) -> BlockColumn<'a> {
+        BlockColumn::new(*self)
+    }
+
+    /// An expression that is true if the entity has changed since `block`
+    pub fn changed_since(&self, block: BlockNumber) -> ChangedSince<'a> {
+        let column = self.block_column();
+        ChangedSince { column, block }
+    }
+
+    /// Return an expression that generates the SQL for `causality_region =
+    /// $cr` if the table uses causality regions
+    pub fn belongs_to_causality_region(
+        &'a self,
+        cr: CausalityRegion,
+    ) -> BelongsToCausalityRegion<'a> {
+        BelongsToCausalityRegion::new(*self, cr)
+    }
+
+    /// Produce a list of the columns that should be selected for a query
+    /// based on `column_names`. The result needs to be used both to create
+    /// the actual select statement with `Self::select_cols` and to decode
+    /// query results with `FromOidRow`.
+    pub fn selected_columns<T: FromOidRow>(
+        &self,
+        column_names: &'a AttributeNames,
+        parent_type: Option<IdType>,
+    ) -> Result<Vec<&'a super::Column>, StoreError> {
+        let mut cols = Vec::new();
+        if T::WITH_INTERNAL_KEYS {
+            cols.push(&*TYPENAME_COL);
+        }
+
+        match column_names {
+            AttributeNames::All => cols.extend(self.meta.columns.iter()),
+            AttributeNames::Select(names) => {
+                let pk = self.meta.primary_key();
+                cols.push(pk);
+                let mut names: Vec<_> = names.iter().filter(|name| *name != &*ID).collect();
+                names.sort();
+                for name in names {
+                    let column = self.meta.column_for_field(&name)?;
+                    cols.push(column);
+                }
+            }
+        };
+
+        if T::WITH_INTERNAL_KEYS {
+            match parent_type {
+                Some(IdType::String) => cols.push(&*PARENT_STRING_COL),
+                Some(IdType::Bytes) => cols.push(&*PARENT_BYTES_COL),
+                Some(IdType::Int8) => cols.push(&*PARENT_INT_COL),
+                None => (),
+            }
+        }
+
+        if T::WITH_SYSTEM_COLUMNS {
+            cols.push(&*VID_COL);
+            if self.meta.immutable {
+                cols.push(&*BLOCK_COL);
+            } else {
+                // TODO: We can't deserialize in4range
+                cols.push(&*BLOCK_RANGE_COL);
+            }
+        }
+        Ok(cols)
+    }
+
+    /// Create a Diesel select statement that selects the columns in
+    /// `columns`. Use to generate a query via
+    /// `table.select_cols(columns).filter(...)`. For a full example, see
+    /// `Layout::find`
+    pub fn select_cols(
+        &'a self,
+        columns: &[&'a RelColumn],
+    ) -> BoxedSelectStatement<'a, Untyped, FromClause<Table<'a>>, Pg> {
+        type SelectClause<'b> = DynamicSelectClause<'b, Pg, Table<'b>>;
+
+        fn add_field<'b, ST: SingleValue + Send>(
+            select: &mut SelectClause<'b>,
+            table: &'b Table<'b>,
+            column: &'b RelColumn,
+        ) {
+            let name = &column.name;
+
+            match (column.is_list(), column.is_nullable()) {
+                (true, true) => select.add_field(table.bind::<Nullable<Array<ST>>>(name).unwrap()),
+                (true, false) => select.add_field(table.bind::<Array<ST>>(name).unwrap()),
+                (false, true) => select.add_field(table.bind::<Nullable<ST>>(name).unwrap()),
+                (false, false) => select.add_field(table.bind::<ST>(name).unwrap()),
+            }
+        }
+
+        fn add_enum_field<'b>(
+            select: &mut SelectClause<'b>,
+            table: &'b Table<'b>,
+            column: &'b RelColumn,
+        ) {
+            let name = format!("{}.{}::text", table.alias.as_str(), &column.name);
+
+            match (column.is_list(), column.is_nullable()) {
+                (true, true) => select.add_field(sql::<Nullable<Array<Text>>>(&name)),
+                (true, false) => select.add_field(sql::<Array<Text>>(&name)),
+                (false, true) => select.add_field(sql::<Nullable<Text>>(&name)),
+                (false, false) => select.add_field(sql::<Text>(&name)),
+            }
+        }
+
+        let mut selection = DynamicSelectClause::new();
+        for column in columns {
+            if column.name == TYPENAME_COL.name {
+                selection.add_field(sql::<Text>(&format!(
+                    "'{}' as __typename",
+                    self.meta.object.typename()
+                )));
+                continue;
+            }
+            match column.column_type {
+                ColumnType::Boolean => add_field::<Bool>(&mut selection, self, column),
+                ColumnType::BigDecimal => add_field::<Numeric>(&mut selection, self, column),
+                ColumnType::BigInt => add_field::<Numeric>(&mut selection, self, column),
+                ColumnType::Bytes => add_field::<Binary>(&mut selection, self, column),
+                ColumnType::Int => add_field::<Integer>(&mut selection, self, column),
+                ColumnType::Int8 => add_field::<BigInt>(&mut selection, self, column),
+                ColumnType::Timestamp => add_field::<Timestamptz>(&mut selection, self, column),
+                ColumnType::String => add_field::<Text>(&mut selection, self, column),
+                ColumnType::TSVector(_) => add_field::<Text>(&mut selection, self, column),
+                ColumnType::Enum(_) => add_enum_field(&mut selection, self, column),
+            };
+        }
+        <Self as SelectDsl<SelectClause<'a>>>::select(*self, selection).into_boxed()
+    }
+}
+
+/// Generate the SQL to use a table in the `from` clause, complete with
+/// giving the table an alias
+#[derive(Debug, Clone, Copy)]
+pub struct FromTable<'a>(Table<'a>);
+
+impl<'a, DB> QueryFragment<DB> for FromTable<'a>
+where
+    DB: Backend,
+{
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+
+        out.push_identifier(self.0.meta.nsp.as_str())?;
+        out.push_sql(".");
+        out.push_identifier(&self.0.meta.name)?;
+        out.push_sql(" as ");
+        out.push_sql(self.0.alias.as_str());
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for Table<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{} as {}", self.meta.name, self.alias.as_str())
+    }
+}
+
+impl std::fmt::Display for FromTable<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<'a> QuerySource for Table<'a> {
+    type FromClause = FromTable<'a>;
+    type DefaultSelection = DummyExpression;
+
+    fn from_clause(&self) -> FromTable<'a> {
+        FromTable(*self)
+    }
+
+    fn default_selection(&self) -> Self::DefaultSelection {
+        DummyExpression::new()
+    }
+}
+
+impl<'a> AsQuery for Table<'a>
+where
+    SelectStatement<FromClause<Self>>: Query<SqlType = expression_types::NotSelectable>,
+{
+    type SqlType = expression_types::NotSelectable;
+    type Query = SelectStatement<FromClause<Self>>;
+
+    fn as_query(self) -> Self::Query {
+        SelectStatement::simple(self)
+    }
+}
+
+impl<'a> diesel::Table for Table<'a>
+where
+    Self: QuerySource + AsQuery,
+{
+    type PrimaryKey = DummyExpression;
+    type AllColumns = DummyExpression;
+
+    fn primary_key(&self) -> Self::PrimaryKey {
+        DummyExpression::new()
+    }
+
+    fn all_columns() -> Self::AllColumns {
+        DummyExpression::new()
+    }
+}
+
+impl<'a, DB> QueryFragment<DB> for Table<'a>
+where
+    DB: Backend,
+{
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+
+        out.push_sql(self.alias.as_str());
+        Ok(())
+    }
+}
+
+impl<'a> QueryId for Table<'a> {
+    type QueryId = ();
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+/// Generated by `Table.id_eq`
+pub struct IdEq<'a> {
+    table: Table<'a>,
+    id: &'a Id,
+}
+
+impl<'a> IdEq<'a> {
+    fn new(table: Table<'a>, id: &'a Id) -> Self {
+        IdEq { table, id }
+    }
+}
+
+impl Expression for IdEq<'_> {
+    type SqlType = Bool;
+}
+
+impl<'a> QueryFragment<Pg> for IdEq<'a> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+        self.table.walk_ast(out.reborrow())?;
+        out.push_sql(".id = ");
+        match self.id {
+            Id::String(s) => out.push_bind_param::<Text, _>(s.as_str())?,
+            Id::Bytes(b) => out.push_bind_param::<Binary, _>(b)?,
+            Id::Int8(i) => out.push_bind_param::<BigInt, _>(i)?,
+        }
+        Ok(())
+    }
+}
+
+impl ValidGrouping<()> for IdEq<'_> {
+    type IsAggregate = is_aggregate::No;
+}
+
+impl<'a> AppearsOnTable<Table<'a>> for IdEq<'a> {}
+
+/// Generated by `Table.block_column`
+#[derive(Debug, Clone, Copy)]
+pub struct BlockColumn<'a> {
+    table: Table<'a>,
+}
+
+impl<'a> BlockColumn<'a> {
+    fn new(table: Table<'a>) -> Self {
+        BlockColumn { table }
+    }
+
+    fn immutable(&self) -> bool {
+        self.table.meta.immutable
+    }
+
+    pub fn name(&self) -> &str {
+        if self.immutable() {
+            BLOCK_COLUMN
+        } else {
+            BLOCK_RANGE_COLUMN
+        }
+    }
+}
+
+impl std::fmt::Display for BlockColumn<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}.{}", self.table.alias.as_str(), self.name())
+    }
+}
+
+impl QueryFragment<Pg> for BlockColumn<'_> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+        self.table.walk_ast(out.reborrow())?;
+        out.push_sql(".");
+        out.push_sql(self.name());
+        Ok(())
+    }
+}
+
+/// Generated by `Table.at_block`
+#[derive(Debug, Clone, Copy)]
+pub struct AtBlock<'a> {
+    column: BlockColumn<'a>,
+    block: BlockNumber,
+    filters_by_id: bool,
+}
+
+impl<'a> AtBlock<'a> {
+    fn new(table: Table<'a>, block: BlockNumber) -> Self {
+        let column = BlockColumn::new(table);
+        AtBlock {
+            column,
+            block,
+            filters_by_id: false,
+        }
+    }
+
+    pub fn filters_by_id(mut self, by_id: bool) -> Self {
+        self.filters_by_id = by_id;
+        self
+    }
+}
+
+impl Expression for AtBlock<'_> {
+    type SqlType = Bool;
+}
+
+impl<'a> QueryFragment<Pg> for AtBlock<'a> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+
+        if self.column.immutable() {
+            if self.block == BLOCK_NUMBER_MAX {
+                // `self.block <= BLOCK_NUMBER_MAX` is always true
+                out.push_sql("true");
+            } else {
+                self.column.walk_ast(out.reborrow())?;
+                out.push_sql(" <= ");
+                out.push_bind_param::<Integer, _>(&self.block)?;
+            }
+        } else {
+            // Table is mutable and has a block_range column
+            self.column.walk_ast(out.reborrow())?;
+            out.push_sql(" @> ");
+            out.push_bind_param::<Integer, _>(&self.block)?;
+
+            let should_use_brin =
+                !self.filters_by_id || ENV_VARS.store.use_brin_for_all_query_types;
+            if self.column.table.meta.is_account_like
+                && self.block < BLOCK_NUMBER_MAX
+                && should_use_brin
+            {
+                // When block is BLOCK_NUMBER_MAX, these checks would be wrong; we
+                // don't worry about adding the equivalent in that case since
+                // we generally only see BLOCK_NUMBER_MAX here for metadata
+                // queries where block ranges don't matter anyway.
+                //
+                // We also don't need to add these if the query already filters by ID,
+                // because the ideal index is the GiST index on id and block_range.
+                out.push_sql(" and coalesce(upper(");
+                self.column.walk_ast(out.reborrow())?;
+                out.push_sql("), 2147483647) > ");
+                out.push_bind_param::<Integer, _>(&self.block)?;
+                out.push_sql(" and lower(");
+                self.column.walk_ast(out.reborrow())?;
+                out.push_sql(") <= ");
+                out.push_bind_param::<Integer, _>(&self.block)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl ValidGrouping<()> for AtBlock<'_> {
+    type IsAggregate = is_aggregate::No;
+}
+
+impl<'a> AppearsOnTable<Table<'a>> for AtBlock<'a> {}
+
+/// Generated by `Table.changed_since`
+#[derive(Debug)]
+pub struct ChangedSince<'a> {
+    column: BlockColumn<'a>,
+    block: BlockNumber,
+}
+
+impl std::fmt::Display for ChangedSince<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{} >= {}", self.column, self.block)
+    }
+}
+
+impl Expression for ChangedSince<'_> {
+    type SqlType = Bool;
+}
+
+impl QueryFragment<Pg> for ChangedSince<'_> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+        if self.column.table.meta.immutable {
+            self.column.walk_ast(out.reborrow())?;
+            out.push_sql(" >= ");
+            out.push_bind_param::<Integer, _>(&self.block)
+        } else {
+            out.push_sql("lower(");
+            self.column.walk_ast(out.reborrow())?;
+            out.push_sql(") >= ");
+            out.push_bind_param::<Integer, _>(&self.block)
+        }
+    }
+}
+
+/// Generated by `Table.belongs_to_causality_region`
+pub struct BelongsToCausalityRegion<'a> {
+    table: Table<'a>,
+    cr: CausalityRegion,
+}
+
+impl<'a> BelongsToCausalityRegion<'a> {
+    fn new(table: Table<'a>, cr: CausalityRegion) -> Self {
+        BelongsToCausalityRegion { table, cr }
+    }
+}
+
+impl Expression for BelongsToCausalityRegion<'_> {
+    type SqlType = Bool;
+}
+
+impl<'a> QueryFragment<Pg> for BelongsToCausalityRegion<'a> {
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+
+        if self.table.meta.has_causality_region {
+            self.table.walk_ast(out.reborrow())?;
+            out.push_sql(".causality_region");
+            out.push_sql(" = ");
+            out.push_bind_param::<Integer, _>(&self.cr)?;
+        } else {
+            out.push_sql("true");
+        }
+        Ok(())
+    }
+}
+
+impl ValidGrouping<()> for BelongsToCausalityRegion<'_> {
+    type IsAggregate = is_aggregate::No;
+}
+
+impl<'a> AppearsOnTable<Table<'a>> for BelongsToCausalityRegion<'a> {}
+
+/// A specific column in a specific table
+#[derive(Debug, Clone, Copy)]
+pub struct Column<'a> {
+    table: Table<'a>,
+    column: &'a super::Column,
+}
+
+impl<'a> Column<'a> {
+    fn new(table: Table<'a>, column: &'a super::Column) -> Self {
+        Column { table, column }
+    }
+
+    /// Bind this column to a specific SQL type for use in contexts where
+    /// Diesel requires that
+    pub fn bind<ST>(&self) -> BoundColumn<'a, ST> {
+        BoundColumn::new(self.table, self.column)
+    }
+
+    pub fn name(&self) -> &'a str {
+        &self.column.name
+    }
+}
+
+impl std::fmt::Display for Column<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}.{}", self.table.alias.as_str(), self.column.name)
+    }
+}
+
+impl<'a, DB> QueryFragment<DB> for Column<'a>
+where
+    DB: Backend,
+{
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        out.unsafe_to_cache_prepared();
+        self.table.walk_ast(out.reborrow())?;
+        out.push_sql(".");
+        out.push_identifier(&self.column.name)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+/// A database table column bound to the SQL type for the column
+pub struct BoundColumn<'a, ST> {
+    column: Column<'a>,
+    _sql_type: PhantomData<ST>,
+}
+
+impl<'a, ST> BoundColumn<'a, ST> {
+    fn new(table: Table<'a>, column: &'a super::Column) -> Self {
+        let column = Column::new(table, column);
+        Self {
+            column,
+            _sql_type: PhantomData,
+        }
+    }
+}
+
+impl<'a, ST> QueryId for BoundColumn<'a, ST> {
+    type QueryId = ();
+    const HAS_STATIC_QUERY_ID: bool = false;
+}
+
+impl<'a, ST, QS> SelectableExpression<QS> for BoundColumn<'a, ST> where Self: Expression {}
+
+impl<'a, ST, QS> AppearsOnTable<QS> for BoundColumn<'a, ST> where Self: Expression {}
+
+impl<'a, ST> Expression for BoundColumn<'a, ST>
+where
+    ST: TypedExpressionType,
+{
+    type SqlType = ST;
+}
+
+impl<'a, ST> ValidGrouping<()> for BoundColumn<'a, ST> {
+    type IsAggregate = is_aggregate::No;
+}
+
+impl<'a, ST, DB> QueryFragment<DB> for BoundColumn<'a, ST>
+where
+    DB: Backend,
+{
+    fn walk_ast<'b>(&'b self, out: AstPass<'_, 'b, DB>) -> QueryResult<()> {
+        self.column.walk_ast(out)
+    }
+}

--- a/store/postgres/src/relational/query_tests.rs
+++ b/store/postgres/src/relational/query_tests.rs
@@ -49,8 +49,9 @@ fn filter_contains(filter: EntityFilter, sql: &str) {
     let layout = test_layout(SCHEMA);
     let table = layout
         .table_for_entity(&layout.input_schema.entity_type("Thing").unwrap())
-        .unwrap();
-    let filter = Filter::main(&layout, table.as_ref(), &filter, Default::default()).unwrap();
+        .unwrap()
+        .dsl_table();
+    let filter = Filter::main(&layout, table, &filter, Default::default()).unwrap();
     let query = debug_query::<Pg, _>(&filter);
     assert!(
         query.to_string().contains(sql),

--- a/store/postgres/src/relational/value.rs
+++ b/store/postgres/src/relational/value.rs
@@ -1,0 +1,263 @@
+//! Helpers to use diesel dynamic schema to retrieve values from Postgres
+
+use std::num::NonZeroU32;
+
+use diesel::sql_types::{Array, BigInt, Binary, Bool, Integer, Numeric, Text, Timestamptz};
+use diesel::{deserialize::FromSql, pg::Pg};
+use diesel_dynamic_schema::dynamic_value::{Any, DynamicRow};
+
+use graph::{
+    components::store::StoreError,
+    data::{
+        store::{
+            scalar::{BigDecimal, Bytes, Timestamp},
+            Entity, QueryObject,
+        },
+        value::{Object, Word},
+    },
+    prelude::r,
+    schema::InputSchema,
+};
+
+use super::ColumnType;
+use crate::relational::Column;
+
+/// Represent values of the database types we care about as a single value.
+/// The deserialization of these values is completely governed by the oid we
+/// get from Postgres; in a second step, these values need to be transformed
+/// into our internal values using the underlying `ColumnType`. Diesel's API
+/// doesn't let us do that in one go, so we do a first transformation into
+/// `OidValue` and then use `FromOidValue` to transform guided by the
+/// `ColumnType`
+#[derive(Debug)]
+pub enum OidValue {
+    String(String),
+    StringArray(Vec<String>),
+    Bytes(Bytes),
+    BytesArray(Vec<Bytes>),
+    Bool(bool),
+    BoolArray(Vec<bool>),
+    Int(i32),
+    Ints(Vec<i32>),
+    Int8(i64),
+    Int8Array(Vec<i64>),
+    BigDecimal(BigDecimal),
+    BigDecimalArray(Vec<BigDecimal>),
+    Timestamp(Timestamp),
+    TimestampArray(Vec<Timestamp>),
+    Null,
+}
+
+impl FromSql<Any, Pg> for OidValue {
+    fn from_sql(value: diesel::pg::PgValue) -> diesel::deserialize::Result<Self> {
+        const VARCHAR_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1043) };
+        const VARCHAR_ARY_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1015) };
+        const TEXT_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(25) };
+        const TEXT_ARY_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1009) };
+        const BYTEA_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(17) };
+        const BYTEA_ARY_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1001) };
+        const BOOL_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(16) };
+        const BOOL_ARY_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1000) };
+        const INTEGER_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(23) };
+        const INTEGER_ARY_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1007) };
+        const INT8_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(20) };
+        const INT8_ARY_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1016) };
+        const NUMERIC_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1700) };
+        const NUMERIC_ARY_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1231) };
+        const TIMESTAMPTZ_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1184) };
+        const TIMESTAMPTZ_ARY_OID: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1185) };
+
+        match value.get_oid() {
+            VARCHAR_OID | TEXT_OID => {
+                <String as FromSql<Text, Pg>>::from_sql(value).map(OidValue::String)
+            }
+            VARCHAR_ARY_OID | TEXT_ARY_OID => {
+                <Vec<String> as FromSql<Array<Text>, Pg>>::from_sql(value)
+                    .map(OidValue::StringArray)
+            }
+            BYTEA_OID => <Bytes as FromSql<Binary, Pg>>::from_sql(value).map(OidValue::Bytes),
+            BYTEA_ARY_OID => <Vec<Bytes> as FromSql<Array<Binary>, Pg>>::from_sql(value)
+                .map(OidValue::BytesArray),
+            BOOL_OID => <bool as FromSql<Bool, Pg>>::from_sql(value).map(OidValue::Bool),
+            BOOL_ARY_OID => {
+                <Vec<bool> as FromSql<Array<Bool>, Pg>>::from_sql(value).map(OidValue::BoolArray)
+            }
+            INTEGER_OID => <i32 as FromSql<Integer, Pg>>::from_sql(value).map(OidValue::Int),
+            INTEGER_ARY_OID => {
+                <Vec<i32> as FromSql<Array<Integer>, Pg>>::from_sql(value).map(OidValue::Ints)
+            }
+            INT8_OID => <i64 as FromSql<BigInt, Pg>>::from_sql(value).map(OidValue::Int8),
+            INT8_ARY_OID => {
+                <Vec<i64> as FromSql<Array<BigInt>, Pg>>::from_sql(value).map(OidValue::Int8Array)
+            }
+            NUMERIC_OID => {
+                <BigDecimal as FromSql<Numeric, Pg>>::from_sql(value).map(OidValue::BigDecimal)
+            }
+            NUMERIC_ARY_OID => <Vec<BigDecimal> as FromSql<Array<Numeric>, Pg>>::from_sql(value)
+                .map(OidValue::BigDecimalArray),
+            TIMESTAMPTZ_OID => {
+                <Timestamp as FromSql<Timestamptz, Pg>>::from_sql(value).map(OidValue::Timestamp)
+            }
+            TIMESTAMPTZ_ARY_OID => {
+                <Vec<Timestamp> as FromSql<Array<Timestamptz>, Pg>>::from_sql(value)
+                    .map(OidValue::TimestampArray)
+            }
+            e => Err(format!("Unknown type: {e}").into()),
+        }
+    }
+
+    fn from_nullable_sql(bytes: Option<diesel::pg::PgValue>) -> diesel::deserialize::Result<Self> {
+        match bytes {
+            Some(bytes) => Self::from_sql(bytes),
+            None => Ok(OidValue::Null),
+        }
+    }
+}
+
+pub trait FromOidValue: Sized {
+    fn from_oid_value(value: OidValue, column_type: &ColumnType) -> Result<Self, StoreError>;
+}
+
+impl FromOidValue for r::Value {
+    fn from_oid_value(value: OidValue, _: &ColumnType) -> Result<Self, StoreError> {
+        fn as_list<T, F>(values: Vec<T>, f: F) -> r::Value
+        where
+            F: Fn(T) -> r::Value,
+        {
+            r::Value::List(values.into_iter().map(f).collect())
+        }
+
+        use OidValue as O;
+        let value = match value {
+            O::String(s) => Self::String(s),
+            O::StringArray(s) => as_list(s, Self::String),
+            O::Bytes(b) => Self::String(b.to_string()),
+            O::BytesArray(b) => as_list(b, |b| Self::String(b.to_string())),
+            O::Bool(b) => Self::Boolean(b),
+            O::BoolArray(b) => as_list(b, Self::Boolean),
+            O::Int(i) => Self::Int(i as i64),
+            O::Ints(i) => as_list(i, |i| Self::Int(i as i64)),
+            O::Int8(i) => Self::String(i.to_string()),
+            O::Int8Array(i) => as_list(i, |i| Self::String(i.to_string())),
+            O::BigDecimal(b) => Self::String(b.to_string()),
+            O::BigDecimalArray(b) => as_list(b, |b| Self::String(b.to_string())),
+            O::Timestamp(t) => Self::Timestamp(t),
+            O::TimestampArray(t) => as_list(t, Self::Timestamp),
+            O::Null => Self::Null,
+        };
+        Ok(value)
+    }
+}
+
+impl FromOidValue for graph::prelude::Value {
+    fn from_oid_value(value: OidValue, column_type: &ColumnType) -> Result<Self, StoreError> {
+        fn as_list<T, F>(values: Vec<T>, f: F) -> graph::prelude::Value
+        where
+            F: Fn(T) -> graph::prelude::Value,
+        {
+            graph::prelude::Value::List(values.into_iter().map(f).collect())
+        }
+
+        fn as_list_err<T, F>(values: Vec<T>, f: F) -> Result<graph::prelude::Value, StoreError>
+        where
+            F: Fn(T) -> Result<graph::prelude::Value, StoreError>,
+        {
+            values
+                .into_iter()
+                .map(f)
+                .collect::<Result<_, _>>()
+                .map(graph::prelude::Value::List)
+        }
+
+        use OidValue as O;
+        let value = match value {
+            O::String(s) => Self::String(s),
+            O::StringArray(s) => as_list(s, Self::String),
+            O::Bytes(b) => Self::Bytes(b),
+            O::BytesArray(b) => as_list(b, Self::Bytes),
+            O::Bool(b) => Self::Bool(b),
+            O::BoolArray(b) => as_list(b, Self::Bool),
+            O::Int(i) => Self::Int(i),
+            O::Ints(i) => as_list(i, Self::Int),
+            O::Int8(i) => Self::Int8(i),
+            O::Int8Array(i) => as_list(i, Self::Int8),
+            O::BigDecimal(b) => match column_type {
+                ColumnType::BigDecimal => Self::BigDecimal(b),
+                ColumnType::BigInt => Self::BigInt(b.to_bigint()?),
+                _ => unreachable!("only BigInt and BigDecimal are stored as numeric"),
+            },
+            O::BigDecimalArray(b) => match column_type {
+                ColumnType::BigDecimal => as_list(b, Self::BigDecimal),
+                ColumnType::BigInt => as_list_err(b, |b| {
+                    b.to_bigint().map(Self::BigInt).map_err(StoreError::from)
+                })?,
+                _ => unreachable!("only BigInt and BigDecimal are stored as numeric[]"),
+            },
+            O::Timestamp(t) => Self::Timestamp(t),
+            O::TimestampArray(t) => as_list(t, Self::Timestamp),
+            O::Null => Self::Null,
+        };
+        Ok(value)
+    }
+}
+
+pub type OidRow = DynamicRow<OidValue>;
+
+pub trait FromOidRow: Sized {
+    // Should the columns for `__typename` and `g$parent_id` be selected
+    const WITH_INTERNAL_KEYS: bool;
+    // Should the system columns for block/block_range and vid be selected
+    const WITH_SYSTEM_COLUMNS: bool = false;
+
+    fn from_oid_row(
+        row: DynamicRow<OidValue>,
+        schema: &InputSchema,
+        columns: &[&Column],
+    ) -> Result<Self, StoreError>;
+}
+
+impl FromOidRow for Entity {
+    const WITH_INTERNAL_KEYS: bool = false;
+
+    fn from_oid_row(
+        row: DynamicRow<OidValue>,
+        schema: &InputSchema,
+        columns: &[&Column],
+    ) -> Result<Self, StoreError> {
+        let x = row
+            .into_iter()
+            .zip(columns)
+            .filter(|(value, _)| !matches!(value, OidValue::Null))
+            .map(|(value, column)| {
+                graph::prelude::Value::from_oid_value(value, &column.column_type)
+                    .map(|value| (Word::from(column.field.clone()), value))
+            });
+        schema.try_make_entity(x).map_err(StoreError::from)
+    }
+}
+
+impl FromOidRow for QueryObject {
+    const WITH_INTERNAL_KEYS: bool = true;
+
+    fn from_oid_row(
+        row: DynamicRow<OidValue>,
+        _schema: &InputSchema,
+        columns: &[&Column],
+    ) -> Result<Self, StoreError> {
+        let pairs = row
+            .into_iter()
+            .zip(columns)
+            .filter(|(value, _)| !matches!(value, OidValue::Null))
+            .map(|(value, column)| -> Result<_, StoreError> {
+                let name = &column.name;
+                let value = r::Value::from_oid_value(value, &column.column_type)?;
+                Ok((Word::from(name.clone()), value))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let entity = Object::from_iter(pairs);
+        Ok(QueryObject {
+            entity,
+            parent: None,
+        })
+    }
+}

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -3056,7 +3056,7 @@ pub struct ChildKeyDetails<'a> {
     /// Column of the child table that sorting is done on
     pub sort_by_column: dsl::Column<'a>,
     /// Either `asc` or `desc`
-    pub direction: &'static str,
+    pub direction: SortDirection,
 }
 
 #[derive(Debug, Clone)]
@@ -3074,7 +3074,7 @@ pub struct ChildKeyAndIdSharedDetails<'a> {
     /// Column of the child table that sorting is done on
     pub sort_by_column: dsl::Column<'a>,
     /// Either `asc` or `desc`
-    pub direction: &'static str,
+    pub direction: SortDirection,
 }
 
 #[allow(unused)]
@@ -3130,7 +3130,7 @@ pub enum SortKey<'a> {
     Key {
         column: dsl::Column<'a>,
         value: Option<&'a str>,
-        direction: &'static str,
+        direction: SortDirection,
     },
     /// Order by some other column; `column` will never be `id`
     ChildKey(ChildKey<'a>),
@@ -3232,8 +3232,26 @@ impl<'a> fmt::Display for SortKey<'a> {
     }
 }
 
-const ASC: &str = "asc";
-const DESC: &str = "desc";
+#[derive(Debug, Clone, Copy)]
+pub enum SortDirection {
+    Asc,
+    Desc,
+}
+
+impl SortDirection {
+    fn as_str(&self) -> &'static str {
+        match self {
+            SortDirection::Asc => "asc",
+            SortDirection::Desc => "desc",
+        }
+    }
+}
+
+impl std::fmt::Display for SortDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
 
 impl<'a> SortKey<'a> {
     fn new(
@@ -3246,7 +3264,7 @@ impl<'a> SortKey<'a> {
         fn sort_key_from_value<'a>(
             column: dsl::Column<'a>,
             value: &'a Value,
-            direction: &'static str,
+            direction: SortDirection,
         ) -> Result<SortKey<'a>, QueryExecutionError> {
             let sort_value = value.as_str();
 
@@ -3261,7 +3279,7 @@ impl<'a> SortKey<'a> {
             table: dsl::Table<'a>,
             attribute: String,
             filter: Option<&'a EntityFilter>,
-            direction: &'static str,
+            direction: SortDirection,
             use_block_column: UseBlockColumn,
         ) -> Result<SortKey<'a>, QueryExecutionError> {
             let column = table.column_for_field(&attribute)?;
@@ -3280,10 +3298,10 @@ impl<'a> SortKey<'a> {
                 }
             } else if column.is_primary_key() {
                 let block_column = use_block_column.block_column(table);
+                use SortDirection::*;
                 match direction {
-                    ASC => Ok(SortKey::IdAsc(block_column)),
-                    DESC => Ok(SortKey::IdDesc(block_column)),
-                    _ => unreachable!("direction is 'asc' or 'desc'"),
+                    Asc => Ok(SortKey::IdAsc(block_column)),
+                    Desc => Ok(SortKey::IdDesc(block_column)),
                 }
             } else {
                 Ok(SortKey::Key {
@@ -3302,7 +3320,7 @@ impl<'a> SortKey<'a> {
             derived: bool,
             attribute: String,
             use_block_column: UseBlockColumn,
-            direction: &'static str,
+            direction: SortDirection,
         ) -> Result<SortKey<'a>, QueryExecutionError> {
             let child_table = child_table.child(1);
             let sort_by_column = child_table.column_for_field(&attribute)?;
@@ -3341,8 +3359,9 @@ impl<'a> SortKey<'a> {
                     let child_pk = child_table.primary_key();
                     let child_br = child_table.block_column();
                     let child_at_block = child_table.at_block(block);
+                    use SortDirection::*;
                     return match direction {
-                        ASC => Ok(SortKey::ChildKey(ChildKey::IdAsc(
+                        Asc => Ok(SortKey::ChildKey(ChildKey::IdAsc(
                             ChildIdDetails {
                                 child_table,
                                 child_from,
@@ -3354,7 +3373,7 @@ impl<'a> SortKey<'a> {
                             },
                             use_block_column,
                         ))),
-                        DESC => Ok(SortKey::ChildKey(ChildKey::IdDesc(
+                        Desc => Ok(SortKey::ChildKey(ChildKey::IdDesc(
                             ChildIdDetails {
                                 child_table,
                                 child_from,
@@ -3366,7 +3385,6 @@ impl<'a> SortKey<'a> {
                             },
                             use_block_column,
                         ))),
-                        _ => unreachable!("direction is 'asc' or 'desc'"),
                     };
                 }
 
@@ -3392,7 +3410,7 @@ impl<'a> SortKey<'a> {
             parent_table: dsl::Table<'a>,
             entity_types: Vec<EntityType>,
             child: EntityOrderByChildInfo,
-            direction: &'static str,
+            direction: SortDirection,
         ) -> Result<Vec<ChildKeyAndIdSharedDetails<'a>>, QueryExecutionError> {
             assert!(entity_types.len() < 255);
             return entity_types
@@ -3463,7 +3481,7 @@ impl<'a> SortKey<'a> {
             child: EntityOrderByChildInfo,
             entity_types: Vec<EntityType>,
             use_block_column: UseBlockColumn,
-            direction: &'static str,
+            direction: SortDirection,
         ) -> Result<SortKey<'a>, QueryExecutionError> {
             if entity_types.is_empty() {
                 return Err(QueryExecutionError::ConstraintViolation(
@@ -3480,8 +3498,9 @@ impl<'a> SortKey<'a> {
                     "Sorting by fulltext fields".to_string(),
                 ))
             } else if sort_by_column.is_primary_key() {
-                if direction == ASC {
-                    Ok(SortKey::ChildKey(ChildKey::ManyIdAsc(
+                use SortDirection::*;
+                match direction {
+                    Asc => Ok(SortKey::ChildKey(ChildKey::ManyIdAsc(
                         build_children_vec(
                             layout,
                             block,
@@ -3502,9 +3521,8 @@ impl<'a> SortKey<'a> {
                         })
                         .collect(),
                         use_block_column,
-                    )))
-                } else {
-                    Ok(SortKey::ChildKey(ChildKey::ManyIdDesc(
+                    ))),
+                    Desc => Ok(SortKey::ChildKey(ChildKey::ManyIdDesc(
                         build_children_vec(
                             layout,
                             block,
@@ -3525,7 +3543,7 @@ impl<'a> SortKey<'a> {
                         })
                         .collect(),
                         use_block_column,
-                    )))
+                    ))),
                 }
             } else {
                 Ok(SortKey::ChildKey(ChildKey::Many(
@@ -3567,10 +3585,11 @@ impl<'a> SortKey<'a> {
             UseBlockColumn::No
         };
 
+        use SortDirection::*;
         match order {
-            EntityOrder::Ascending(attr, _) => with_key(table, attr, filter, ASC, use_block_column),
+            EntityOrder::Ascending(attr, _) => with_key(table, attr, filter, Asc, use_block_column),
             EntityOrder::Descending(attr, _) => {
-                with_key(table, attr, filter, DESC, use_block_column)
+                with_key(table, attr, filter, Desc, use_block_column)
             }
             EntityOrder::Default => Ok(SortKey::IdAsc(use_block_column.block_column(table))),
             EntityOrder::Unordered => Ok(SortKey::None),
@@ -3583,7 +3602,7 @@ impl<'a> SortKey<'a> {
                     child.derived,
                     child.sort_by_attribute,
                     use_block_column,
-                    ASC,
+                    Asc,
                 ),
                 EntityOrderByChild::Interface(child, entity_types) => with_child_interface_key(
                     layout,
@@ -3592,7 +3611,7 @@ impl<'a> SortKey<'a> {
                     child,
                     entity_types,
                     use_block_column,
-                    ASC,
+                    Asc,
                 ),
             },
             EntityOrder::ChildDescending(kind) => match kind {
@@ -3604,7 +3623,7 @@ impl<'a> SortKey<'a> {
                     child.derived,
                     child.sort_by_attribute,
                     use_block_column,
-                    DESC,
+                    Desc,
                 ),
                 EntityOrderByChild::Interface(child, entity_types) => with_child_interface_key(
                     layout,
@@ -3613,7 +3632,7 @@ impl<'a> SortKey<'a> {
                     child,
                     entity_types,
                     use_block_column,
-                    DESC,
+                    Desc,
                 ),
             },
         }
@@ -3724,6 +3743,7 @@ impl<'a> SortKey<'a> {
         out: &mut AstPass<'_, 'b, Pg>,
         use_sort_key_alias: bool,
     ) -> QueryResult<()> {
+        use SortDirection::*;
         match self {
             SortKey::None => Ok(()),
             SortKey::IdAsc(br_column) => {
@@ -3770,7 +3790,7 @@ impl<'a> SortKey<'a> {
                     ChildKey::Single(child) => SortKey::sort_expr(
                         &child.sort_by_column,
                         &None,
-                        child.direction,
+                        &child.direction,
                         Some("c"),
                         use_sort_key_alias,
                         out,
@@ -3778,15 +3798,15 @@ impl<'a> SortKey<'a> {
                     ChildKey::Many(parent_pk, children) => SortKey::multi_sort_expr(
                         parent_pk,
                         children,
-                        children.first().unwrap().direction,
+                        &children.first().unwrap().direction,
                         out,
                     ),
 
                     ChildKey::ManyIdAsc(children, use_block_column) => {
-                        SortKey::multi_sort_id_expr(children, ASC, *use_block_column, out)
+                        SortKey::multi_sort_id_expr(children, Asc, *use_block_column, out)
                     }
                     ChildKey::ManyIdDesc(children, use_block_column) => {
-                        SortKey::multi_sort_id_expr(children, DESC, *use_block_column, out)
+                        SortKey::multi_sort_id_expr(children, Desc, *use_block_column, out)
                     }
 
                     ChildKey::IdAsc(child, use_block_column) => {
@@ -3859,7 +3879,7 @@ impl<'a> SortKey<'a> {
     fn sort_expr<'b>(
         column: &'b dsl::Column<'b>,
         value: &'b Option<&str>,
-        direction: &str,
+        direction: &'b SortDirection,
         rest_prefix: Option<&str>,
         use_sort_key_alias: bool,
         out: &mut AstPass<'_, 'b, Pg>,
@@ -3905,14 +3925,14 @@ impl<'a> SortKey<'a> {
             }
         }
         out.push_sql(" ");
-        out.push_sql(direction);
+        out.push_sql(direction.as_str());
         out.push_sql(", ");
         if !use_sort_key_alias {
             push_prefix(rest_prefix, out);
         }
         out.push_identifier(PRIMARY_KEY_COLUMN)?;
         out.push_sql(" ");
-        out.push_sql(direction);
+        out.push_sql(direction.as_str());
         Ok(())
     }
 
@@ -3921,7 +3941,7 @@ impl<'a> SortKey<'a> {
     fn multi_sort_expr<'b>(
         parent_pk: &'b dsl::Column<'b>,
         children: &'b [ChildKeyDetails<'b>],
-        direction: &str,
+        direction: &'b SortDirection,
         out: &mut AstPass<'_, 'b, Pg>,
     ) -> QueryResult<()> {
         for child in children {
@@ -3956,12 +3976,12 @@ impl<'a> SortKey<'a> {
 
         out.push_sql(") ");
 
-        out.push_sql(direction);
+        out.push_sql(direction.as_str());
         out.push_sql(", ");
 
         parent_pk.walk_ast(out.reborrow())?;
         out.push_sql(" ");
-        out.push_sql(direction);
+        out.push_sql(direction.as_str());
         Ok(())
     }
 
@@ -3969,7 +3989,7 @@ impl<'a> SortKey<'a> {
     ///   COALESCE(id1, id2) direction, [COALESCE(br_column1, br_column2) direction]
     fn multi_sort_id_expr<'b>(
         children: &'b [ChildIdDetails<'b>],
-        direction: &str,
+        direction: SortDirection,
         use_block_column: UseBlockColumn,
         out: &mut AstPass<'_, 'b, Pg>,
     ) -> QueryResult<()> {
@@ -3986,7 +4006,7 @@ impl<'a> SortKey<'a> {
         }
         out.push_sql(") ");
 
-        out.push_sql(direction);
+        out.push_sql(direction.as_str());
 
         if UseBlockColumn::Yes == use_block_column {
             out.push_sql(", coalesce(");
@@ -4001,7 +4021,7 @@ impl<'a> SortKey<'a> {
                 child.child_br.walk_ast(out.reborrow())?;
             }
             out.push_sql(") ");
-            out.push_sql(direction);
+            out.push_sql(direction.as_str());
         }
 
         Ok(())


### PR DESCRIPTION
Our queries all ultimately get their data by doing something like `select to_jsonb(c.*) from ( ... complicated query ... ) c` because when these queries were written it was far from obvious how to generate queries with Diesel that select columns whose number and types aren't known at compile time.

The call to `to_jsonb` forces Postgres to encode all data as JSON, which graph-node then has to deserialize which is pretty wasteful both in terms of memory and CPU.

This commit is focused on the groundwork for getting rid of these JSON conversions and querying data in a more compact and native form with fewer conversions. It only uses it in the fairly simple case of `Layout.find`, but future changes will expand that use

