### PR TITLE
fix handling of transactions with an empty 'to' field on rpc-polled chains

### DIFF
--- a/chain/ethereum/src/codec.rs
+++ b/chain/ethereum/src/codec.rs
@@ -193,7 +193,10 @@ impl<'a> TryInto<web3::types::Transaction> for TransactionTraceAt<'a> {
                     .try_decode_proto("transaction from address")?,
             ),
             to: match self.trace.calls.len() {
-                0 => Some(self.trace.to.try_decode_proto("transaction to address")?),
+                0 => match self.trace.to.len() {
+                    0 => None, // without a 'to' address, this is a 'Create' transaction
+                    _ => Some(self.trace.to.try_decode_proto("transaction 'to' address")?),
+                },
                 _ => {
                     match CallType::from_i32(self.trace.calls[0].call_type).ok_or_else(|| {
                         format_err!("invalid call type: {}", self.trace.calls[0].call_type,)


### PR DESCRIPTION
Firehose blocks for chains like Avalanche and Optimism are produced using the "rpc poller" mechanism.
On those chains, there is no 'extended tracer' instrumentation to populate the "to" field in the case of a "Create" transaction.

Currently, encountering a block with those transactions fails with the following error:
`ERRO Mapping block to BlockStreamEvent failed: unknown error: invalid transaction to address: TryFromSliceError(())`

This changeset fixes the behavior, returning a transaction with the `to` field set to `None` in those cases, the same way fully instrumented evm chains blocks are handled.
