### PR TITLE
Check if subgraph head exists before trying to unfail

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -175,27 +175,29 @@ where
         // revert the deployment head. It should lead to the same result since the error was
         // deterministic.
         if let Some(current_ptr) = self.inputs.store.block_ptr() {
-            if let Some(parent_ptr) = self
-                .inputs
-                .triggers_adapter
-                .parent_ptr(&current_ptr)
-                .await?
-            {
-                // This reverts the deployment head to the parent_ptr if
-                // deterministic errors happened.
-                //
-                // There's no point in calling it if we have no current or parent block
-                // pointers, because there would be: no block to revert to or to search
-                // errors from (first execution).
-                //
-                // We attempt to unfail deterministic errors to mitigate deterministic
-                // errors caused by wrong data being consumed from the providers. It has
-                // been a frequent case in the past so this helps recover on a larger scale.
-                let _outcome = self
-                    .inputs
-                    .store
-                    .unfail_deterministic_error(&current_ptr, &parent_ptr)
-                    .await?;
+            let adapter = &self.inputs.triggers_adapter;
+            let is_on_main_chain = adapter.is_on_main_chain(current_ptr.cheap_clone()).await?;
+
+            // If the subgraph is not on the main chain, the first thing the block stream will do is
+            // revert the deployment head, and with it any errors.
+            if is_on_main_chain {
+                if let Some(parent_ptr) = adapter.parent_ptr(&current_ptr).await? {
+                    // This reverts the deployment head to the parent_ptr if
+                    // deterministic errors happened.
+                    //
+                    // There's no point in calling it if we have no current or parent block
+                    // pointers, because there would be: no block to revert to or to search
+                    // errors from (first execution).
+                    //
+                    // We attempt to unfail deterministic errors to mitigate deterministic
+                    // errors caused by wrong data being consumed from the providers. It has
+                    // been a frequent case in the past so this helps recover on a larger scale.
+                    let _outcome = self
+                        .inputs
+                        .store
+                        .unfail_deterministic_error(&current_ptr, &parent_ptr)
+                        .await?;
+                }
             }
         }
 

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -966,7 +966,7 @@ impl<C: Blockchain> TriggersAdapter<C> for MockTriggersAdapter<C> {
     }
 
     async fn is_on_main_chain(&self, _ptr: BlockPtr) -> Result<bool, Error> {
-        todo!()
+        Ok(true)
     }
 
     async fn parent_ptr(&self, block: &BlockPtr) -> Result<Option<BlockPtr>, Error> {


### PR DESCRIPTION
Otherwise, looking for the parent ptr will fail and the subgraph simply won't start, logging `Trying again after load block 0x2a74…e47e failed`. When a chain does a re-genensis or re-hashing this can happen en masse so we need to deal with it.

