### PR TITLE
graph, store: Improve error message when write fails

### DIFF
--- a/graph/src/components/store/write.rs
+++ b/graph/src/components/store/write.rs
@@ -69,6 +69,16 @@ pub struct EntityWrite<'a> {
     pub end: Option<BlockNumber>,
 }
 
+impl std::fmt::Display for EntityWrite<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let range = match self.end {
+            Some(end) => format!("[{}, {}]", self.block, end - 1),
+            None => format!("[{}, ∞)", self.block),
+        };
+        write!(f, "{}@{}", self.id, range)
+    }
+}
+
 impl<'a> TryFrom<&'a EntityModification> for EntityWrite<'a> {
     type Error = ();
 
@@ -849,6 +859,10 @@ pub struct WriteChunk<'a> {
 impl<'a> WriteChunk<'a> {
     pub fn is_empty(&'a self) -> bool {
         self.iter().next().is_none()
+    }
+
+    pub fn len(&self) -> usize {
+        (self.group.row_count() - self.position).min(self.chunk_size)
     }
 
     pub fn iter(&self) -> WriteChunkIter<'a> {

--- a/tests/tests/runner_tests.rs
+++ b/tests/tests/runner_tests.rs
@@ -601,10 +601,10 @@ async fn end_block() -> anyhow::Result<()> {
         // Verify that after the reorg, the last Block entity still reflects block number 8, but with a different hash.
         let query_res = ctx
             .query(
-                r#"{ 
-                blocks(first: 1, orderBy: number, orderDirection: desc) { 
-                    number 
-                    hash 
+                r#"{
+                blocks(first: 1, orderBy: number, orderDirection: desc) {
+                    number
+                    hash
                 }
             }"#,
             )
@@ -786,9 +786,11 @@ async fn file_data_sources() {
             .err()
             .unwrap_or_else(|| panic!("subgraph ran successfully but an error was expected"));
 
-        let message =
-            "store error: conflicting key value violates exclusion constraint \"ipfs_file_id_block_range_excl\""
-                .to_string();
+        let message = "writing IpfsFile entities at block 7 failed: \
+            conflicting key value violates exclusion constraint \"ipfs_file_id_block_range_excl\" \
+            Query: insert 1 rows \
+            with ids [QmQ2REmceVtzawp7yrnxLQXgNNCtFHEnig6fL9aqE1kcWq@[7, ∞)]"
+            .to_string();
         assert_eq!(err.to_string(), message);
     }
 
@@ -813,9 +815,11 @@ async fn file_data_sources() {
             .err()
             .unwrap_or_else(|| panic!("subgraph ran successfully but an error was expected"));
 
-        let message =
-            "store error: conflicting key value violates exclusion constraint \"ipfs_file_1_id_block_range_excl\""
-                .to_string();
+        let message = "writing IpfsFile1 entities at block 7 failed: \
+            conflicting key value violates exclusion constraint \"ipfs_file_1_id_block_range_excl\" \
+            Query: insert 1 rows \
+            with ids [QmQ2REmceVtzawp7yrnxLQXgNNCtFHEnig6fL9aqE1kcWq@[7, ∞)]"
+            .to_string();
         assert_eq!(err.to_string(), message);
     }
 


### PR DESCRIPTION
When a write fails because Postgres is unhappy with it, e.g., because of an invalid block_range, it is very hard to understand what happened from the error message. This change improves that by including the entity type and the block at which the write failed as well as some other detail in the error message.

