### PR TITLE
graphman: Add chain rewind subcommand

### DIFF
--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -210,16 +210,16 @@ pub enum Command {
         sleep: Duration,
         /// The block hash of the target block
         #[clap(
-            required_unless_present = "start-block",
-            conflicts_with = "start-block",
+            required_unless_present = "start_block",
+            conflicts_with = "start_block",
             long,
             short = 'H'
         )]
         block_hash: Option<String>,
         /// The block number of the target block
         #[clap(
-            required_unless_present = "start-block",
-            conflicts_with = "start-block",
+            required_unless_present = "start_block",
+            conflicts_with = "start_block",
             long,
             short = 'n'
         )]
@@ -564,6 +564,43 @@ pub enum ChainCommand {
         /// Chain name (must be an existing chain, see 'chain list')
         #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new())]
         chain_name: String,
+    },
+    /// Rewind all subgraphs from a given chain.
+    Rewind {
+        /// Force rewinding even if the block hash is not found in the local
+        /// database
+        #[clap(long, short)]
+        force: bool,
+        /// Rewind to the start block of the subgraph
+        #[clap(long)]
+        start_block: bool,
+        /// Chain name (must be an existing chain, see 'chain list')
+        #[clap(required = true, value_parser = clap::builder::NonEmptyStringValueParser::new())]
+        chain_name: String,
+        /// The block hash of the target block
+        #[clap(
+            required_unless_present = "start_block",
+            conflicts_with = "start_block",
+            long,
+            short = 'H'
+        )]
+        block_hash: Option<String>,
+        /// The block number of the target block
+        #[clap(
+            required_unless_present = "start_block",
+            conflicts_with = "start_block",
+            long,
+            short = 'n'
+        )]
+        block_number: Option<i32>,
+        /// Sleep for this many seconds after pausing subgraphs
+        #[clap(
+            long,
+            short,
+            default_value = "20",
+            value_parser = parse_duration_in_secs
+        )]
+        sleep: Duration,
     },
 }
 
@@ -1390,6 +1427,31 @@ async fn main() -> anyhow::Result<()> {
                             commands::chain::clear_call_cache(chain_store, from, to).await
                         }
                     }
+                }
+                Rewind {
+                    chain_name,
+                    block_hash,
+                    block_number,
+                    sleep,
+                    force,
+                    start_block,
+                } => {
+                    let notification_sender = ctx.notification_sender();
+                    let (store, primary) = ctx.store_and_primary();
+                    let deployments = vec![DeploymentSearch::AllOnChain { chain_name }];
+
+                    commands::rewind::run(
+                        primary,
+                        store,
+                        deployments,
+                        block_hash,
+                        block_number,
+                        &notification_sender,
+                        force,
+                        sleep,
+                        start_block,
+                    )
+                    .await
                 }
             }
         }

--- a/node/src/manager/deployment.rs
+++ b/node/src/manager/deployment.rs
@@ -33,6 +33,7 @@ pub enum DeploymentSearch {
     Name { name: String },
     Hash { hash: String, shard: Option<String> },
     All,
+    AllOnChain { chain_name: String },
     Deployment { namespace: String },
 }
 
@@ -45,6 +46,7 @@ impl fmt::Display for DeploymentSearch {
                 shard: Some(shard),
             } => write!(f, "{}:{}", hash, shard),
             DeploymentSearch::All => Ok(()),
+            DeploymentSearch::AllOnChain { chain_name: _ } => Ok(()),
             DeploymentSearch::Hash { hash, shard: None } => write!(f, "{}", hash),
             DeploymentSearch::Deployment { namespace } => write!(f, "{}", namespace),
         }
@@ -82,6 +84,7 @@ impl DeploymentSearch {
                     unused::Filter::All
                 }
             }
+            DeploymentSearch::AllOnChain { chain_name } => unused::Filter::AllOnChain(chain_name),
             DeploymentSearch::Deployment { namespace } => unused::Filter::Deployment(namespace),
         }
     }
@@ -137,6 +140,9 @@ impl DeploymentSearch {
                 query.filter(ds::name.eq(&namespace)).load(conn)?
             }
             DeploymentSearch::All => query.load(conn)?,
+            DeploymentSearch::AllOnChain { chain_name } => {
+                query.filter(ds::network.eq(&chain_name)).load(conn)?
+            }
         };
         Ok(deployments)
     }

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -1663,6 +1663,7 @@ impl<'a> Connection<'a> {
         &mut self,
         filter: unused::Filter,
     ) -> Result<Vec<UnusedDeployment>, StoreError> {
+        use deployment_schemas as ds;
         use unused::Filter::*;
         use unused_deployments as u;
 
@@ -1707,6 +1708,14 @@ impl<'a> Connection<'a> {
             Deployment(id) => Ok(u::table
                 .filter(u::namespace.eq(id))
                 .order_by(u::entity_count)
+                .load(conn)?),
+
+            AllOnChain(chain_name) => Ok(u::table
+                .inner_join(ds::table.on(u::id.eq(ds::id)))
+                .filter(u::removed_at.is_null())
+                .filter(ds::network.eq(&chain_name))
+                .order_by(u::unused_at.desc())
+                .select(u::all_columns)
                 .load(conn)?),
         }
     }

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -144,6 +144,8 @@ pub mod unused {
         Hash(String),
         /// Lists deployments with a specific deployment id
         Deployment(String),
+        /// Lists all deployments on a specified chain
+        AllOnChain(String),
     }
 }
 


### PR DESCRIPTION
This rewinds all subgraphs on a chain to a specified block. It has most of the same arguments as `graphman rewind`, but takes a chain name instead of a list of deployments.

Remaining work:

- [ ] Clear block cache up to target block
- [ ] Clear call cache up to target block

#3728