### PR TITLE
graphman: skip parsing block data in chain info

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -761,6 +761,7 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
             .cheap_clone()
             .ancestor_block(ptr, offset, root)
             .await?
+            .map(|x| x.0)
             .map(json::from_value)
             .transpose()?;
         Ok(block.map(|block| {

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -497,7 +497,7 @@ pub trait ChainStore: Send + Sync + 'static {
         block_ptr: BlockPtr,
         offset: BlockNumber,
         root: Option<BlockHash>,
-    ) -> Result<Option<serde_json::Value>, Error>;
+    ) -> Result<Option<(serde_json::Value, BlockPtr)>, Error>;
 
     /// Remove old blocks from the cache we maintain in the database and
     /// return a pair containing the number of the oldest block retained

--- a/node/src/manager/commands/chain.rs
+++ b/node/src/manager/commands/chain.rs
@@ -8,12 +8,8 @@ use graph::cheap_clone::CheapClone;
 use graph::components::store::StoreError;
 use graph::prelude::BlockNumber;
 use graph::prelude::ChainStore as _;
-use graph::prelude::EthereumBlock;
-use graph::prelude::LightEthereumBlockExt as _;
 use graph::prelude::{anyhow, anyhow::bail};
-use graph::{
-    components::store::BlockStore as _, prelude::anyhow::Error, prelude::serde_json as json,
-};
+use graph::{components::store::BlockStore as _, prelude::anyhow::Error};
 use graph_store_postgres::add_chain;
 use graph_store_postgres::find_chain;
 use graph_store_postgres::update_chain_name;
@@ -111,9 +107,7 @@ pub async fn info(
         Some(head_block) => chain_store
             .ancestor_block(head_block.clone(), offset, None)
             .await?
-            .map(json::from_value::<EthereumBlock>)
-            .transpose()?
-            .map(|b| b.block.block_ptr()),
+            .map(|x| x.1),
     };
 
     row("name", chain.name);

--- a/store/test-store/tests/postgres/chain_head.rs
+++ b/store/test-store/tests/postgres/chain_head.rs
@@ -305,10 +305,17 @@ fn check_ancestor(
         offset,
         root,
     ))?
-    .map(json::from_value::<EthereumBlock>)
-    .transpose()?
     .ok_or_else(|| anyhow!("block {} has no ancestor at offset {}", child.hash, offset))?;
-    let act_hash = format!("{:x}", act.block.hash.unwrap());
+
+    let act_ptr = act.1;
+    let exp_ptr = exp.block_ptr();
+
+    if exp_ptr != act_ptr {
+        return Err(anyhow!("expected ptr `{}` but got `{}`", exp_ptr, act_ptr));
+    }
+
+    let act_block = json::from_value::<EthereumBlock>(act.0)?;
+    let act_hash = format!("{:x}", act_block.block.hash.unwrap());
     let exp_hash = &exp.hash;
 
     if &act_hash != exp_hash {


### PR DESCRIPTION
Block data is not guaranteed to have a fixed format, so it was not a reliable source from which to extract the block ptr required by the `graphman chain info` command. Skipped the block data parsing and returned block ptr directly from the store.

Fixes #5268