### PR TITLE
fix deployment_head metrics not progressing for substreams (sps)

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -1207,6 +1207,11 @@ where
 
         debug!(logger, "Start processing wasm block";);
 
+        self.metrics
+            .stream
+            .deployment_head
+            .set(block_ptr.number as f64);
+
         let proof_of_indexing = if self.inputs.store.supports_proof_of_indexing().await? {
             Some(Arc::new(AtomicRefCell::new(ProofOfIndexing::new(
                 block_ptr.number,


### PR DESCRIPTION
`handle_process_wasm_block` was not causing the deployment_head metric to follow the block_ptr.
Copied over the call from `handle_process_block`