### PR TITLE
Fix genesis block fetching for substreams

### DIFF
--- a/graph/src/firehose/endpoints.rs
+++ b/graph/src/firehose/endpoints.rs
@@ -119,7 +119,7 @@ impl GenesisDecoder for SubstreamsGenesisDecoder {
                 substreams_rpc::Request {
                     start_block_num: 0,
                     start_cursor: "".to_string(),
-                    stop_block_num: 1,
+                    stop_block_num: 0,
                     final_blocks_only: true,
                     production_mode: false,
                     output_module: "map_blocks".to_string(),


### PR DESCRIPTION
After #5337 substreams support is broken for some chains.

The issue is when fetching genesis block, [we stream only block 0](https://github.com/graphprotocol/graph-node/blob/08f10a86bbbb14ea0fa1e5575e8d7a552b7867d2/graph/src/firehose/endpoints.rs#L119-L127). For some chains genesis block number is 2 (EOS, WAX), 3 (Telos) or even 79123881 (Sei).

This PR fixes it by removing `stop_block_num` from the request, so the first block we receive is the genesis block no matter where it is.