### PR TITLE
Improve net_identifiers call with timeout

### DIFF
--- a/graph/src/components/adapter.rs
+++ b/graph/src/components/adapter.rs
@@ -1,3 +1,4 @@
+use core::time;
 use std::{
     collections::HashMap,
     ops::{Add, Deref},
@@ -42,6 +43,12 @@ pub enum ProviderManagerError {
 
 #[async_trait]
 pub trait NetIdentifiable: Sync + Send {
+    async fn net_identifiers_with_timeout(
+        &self,
+        timeout: time::Duration,
+    ) -> Result<ChainIdentifier, anyhow::Error> {
+        tokio::time::timeout(timeout, async move { self.net_identifiers().await }).await?
+    }
     async fn net_identifiers(&self) -> Result<ChainIdentifier, anyhow::Error>;
     fn provider_name(&self) -> ProviderName;
 }

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -1057,6 +1057,10 @@ async fn main() -> anyhow::Result<()> {
     );
 
     let mut config = Cfg::load(&logger, &opt.clone().into()).context("Configuration error")?;
+    config.stores.iter_mut().for_each(|(_, shard)| {
+        shard.pool_size = PoolSize::Fixed(5);
+        shard.fdw_pool_size = PoolSize::Fixed(5);
+    });
 
     if opt.pool_size > 0 && !opt.cmd.use_configured_pool_size() {
         // Override pool size from configuration

--- a/node/src/network_setup.rs
+++ b/node/src/network_setup.rs
@@ -146,20 +146,30 @@ impl Networks {
         &ChainId,
         Vec<(ProviderName, Result<ChainIdentifier, anyhow::Error>)>,
     )> {
+        let timeout = Duration::from_secs(20);
         let mut out = vec![];
         for chain_id in self.adapters.iter().map(|a| a.chain_id()).sorted().dedup() {
             let mut inner = vec![];
             for adapter in self.rpc_provider_manager.get_all_unverified(chain_id) {
-                inner.push((adapter.provider_name(), adapter.net_identifiers().await));
+                inner.push((
+                    adapter.provider_name(),
+                    adapter.net_identifiers_with_timeout(timeout).await,
+                ));
             }
             for adapter in self.firehose_provider_manager.get_all_unverified(chain_id) {
-                inner.push((adapter.provider_name(), adapter.net_identifiers().await));
+                inner.push((
+                    adapter.provider_name(),
+                    adapter.net_identifiers_with_timeout(timeout).await,
+                ));
             }
             for adapter in self
                 .substreams_provider_manager
                 .get_all_unverified(chain_id)
             {
-                inner.push((adapter.provider_name(), adapter.net_identifiers().await));
+                inner.push((
+                    adapter.provider_name(),
+                    adapter.net_identifiers_with_timeout(timeout).await,
+                ));
             }
 
             out.push((chain_id, inner));


### PR DESCRIPTION
- Add timeout when checking providers
- When running graphman patch the pool-size to avoid unnecessary errors

