### PR TITLE
fix: resolves #5550 - make graphql  value nullable

### DIFF
--- a/server/index-node/src/schema.graphql
+++ b/server/index-node/src/schema.graphql
@@ -70,8 +70,12 @@ type SubgraphIndexingStatus {
   nonFatalErrors: [SubgraphError!]!
   chains: [ChainIndexingStatus!]!
   entityCount: BigInt!
+
+  "null if deployment is not assigned to an indexing node"
   node: String
-  paused: Boolean!
+  "null if deployment is not assigned to an indexing node"
+  paused: Boolean
+
   historyBlocks: Int!
 }
 


### PR DESCRIPTION
This PR fixes #5550 by making the `paused` field in the status graphql nullable, which matches the struct field of `Option<bool>` and allows the indexer-agent to handle the `None/null` case when appropriate.