### PR TITLE
timeout when trying to get net_identifiers at startup

### DIFF
--- a/graph/src/components/adapter.rs
+++ b/graph/src/components/adapter.rs
@@ -290,7 +290,6 @@ impl<T: NetIdentifiable + Clone + 'static> ProviderManager<T> {
             .unwrap_or_default()
     }
 
-    #[cfg(debug_assertions)]
     pub async fn mark_all_valid(&self) {
         for (_, status) in self.inner.status.iter() {
             let mut s = status.write().await;

--- a/graph/src/firehose/endpoints.rs
+++ b/graph/src/firehose/endpoints.rs
@@ -121,7 +121,7 @@ impl GenesisDecoder for SubstreamsGenesisDecoder {
                     start_cursor: "".to_string(),
                     stop_block_num: 0,
                     final_blocks_only: true,
-                    production_mode: false,
+                    production_mode: true,
                     output_module: "map_blocks".to_string(),
                     modules: package.modules,
                     debug_initial_store_snapshot_for_modules: vec![],

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -1009,7 +1009,7 @@ impl Context {
         let logger = self.logger.clone();
         let registry = self.metrics_registry();
         let metrics = Arc::new(EndpointMetrics::mock());
-        Networks::from_config(logger, &self.config, registry, metrics, block_store).await
+        Networks::from_config(logger, &self.config, registry, metrics, block_store, false).await
     }
 
     fn chain_store(self, chain_name: &str) -> anyhow::Result<Arc<ChainStore>> {

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -713,10 +713,16 @@ mod test {
         let metrics_registry = Arc::new(MetricsRegistry::mock());
         let ident_validator = Arc::new(NoopIdentValidator);
 
-        let networks =
-            Networks::from_config(logger, &config, metrics_registry, metrics, ident_validator)
-                .await
-                .expect("can parse config");
+        let networks = Networks::from_config(
+            logger,
+            &config,
+            metrics_registry,
+            metrics,
+            ident_validator,
+            false,
+        )
+        .await
+        .expect("can parse config");
         let mut network_names = networks
             .adapters
             .iter()

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -271,6 +271,7 @@ async fn main() {
             metrics_registry.cheap_clone(),
             endpoint_metrics,
             validator,
+            env_vars.genesis_validation_enabled,
         )
         .await
         .expect("unable to parse network configuration");

--- a/node/src/manager/commands/config.rs
+++ b/node/src/manager/commands/config.rs
@@ -177,6 +177,7 @@ pub async fn provider(
         registry,
         metrics,
         Arc::new(NoopIdentValidator),
+        false,
     )
     .await?;
     let network: ChainId = network.into();

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -100,6 +100,7 @@ pub async fn run(
         metrics_registry.cheap_clone(),
         endpoint_metrics,
         ident_validator,
+        env_vars.genesis_validation_enabled,
     )
     .await
     .expect("unable to parse network configuration");


### PR DESCRIPTION
1. If an error occurs during startup net_identifier calls, just ignore an use a default value 
2. If validation is enabled, this will cause the adapter to eventually fail because whatever genesis the adapter returns won't match the default (0x00) genesis value. 

This change prevents the graph-node from failing to start due to broken adapters but if genesis validation is enabled it should eventually update the store