### PR TITLE
Add BlockDetailLevel

### DIFF
--- a/chain/ethereum/proto/ethereum.proto
+++ b/chain/ethereum/proto/ethereum.proto
@@ -22,6 +22,31 @@ message Block {
 
   repeated TransactionTrace transaction_traces = 10;
   repeated BalanceChange balance_changes = 11;
+
+  enum DetailLevel{
+    DETAILLEVEL_EXTENDED = 0;
+    // DETAILLEVEL_TRACE = 1; // TBD
+    DETAILLEVEL_BASE = 2;
+  }
+
+  // DetailLevel affects the data available in this block.
+  //
+  // ## DetailLevel_EXTENDED
+  //
+  // Describes the most complete block, with traces, balance changes, storage
+  // changes. It is extracted during the execution of the block.
+  //
+  // ## DetailLevel_BASE
+  //
+  // Describes a block that contains only the block header, transaction receipts
+  // and event logs: everything that can be extracted using the base JSON-RPC
+  // interface
+  // (https://ethereum.org/en/developers/docs/apis/json-rpc/#json-rpc-methods)
+  // Furthermore, the eth_getTransactionReceipt call has been avoided because it
+  // brings only minimal improvements at the cost of requiring an archive node
+  // or a full node with complete transaction index.
+  DetailLevel detail_level = 12;
+  
   repeated CodeChange code_changes = 20;
 
   reserved 40; // bool filtering_applied = 40 [deprecated = true];

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -1,6 +1,7 @@
 use anyhow::Error;
 use ethabi::{Error as ABIError, Function, ParamType, Token};
 use graph::blockchain::ChainIdentifier;
+use graph::components::ethereum::BlockDetailLevel;
 use graph::components::subgraph::MappingError;
 use graph::data::store::ethereum::call;
 use graph::firehose::CallToFilter;
@@ -261,6 +262,15 @@ impl TriggerFilter {
     #[cfg(debug_assertions)]
     pub fn block(&self) -> &EthereumBlockFilter {
         &self.block
+    }
+
+    /// Always require full blocks until we are able to strip down the block from the WASM ABI.
+    pub fn minimum_detail_level(&self) -> BlockDetailLevel {
+        if self.call.is_empty() && self.block.is_empty() {
+            return BlockDetailLevel::Light;
+        }
+
+        BlockDetailLevel::Full
     }
 }
 

--- a/chain/ethereum/src/codec.rs
+++ b/chain/ethereum/src/codec.rs
@@ -7,9 +7,12 @@ use graph::{
     blockchain::{
         self, Block as BlockchainBlock, BlockPtr, BlockTime, ChainStoreBlock, ChainStoreData,
     },
+    components::ethereum::BlockDetailLevel,
     prelude::{
-        web3,
-        web3::types::{Bytes, H160, H2048, H256, H64, U256, U64},
+        web3::{
+            self,
+            types::{Bytes, H160, H2048, H256, H64, U256, U64},
+        },
         BlockNumber, Error, EthereumBlock, EthereumBlockWithCalls, EthereumCall,
         LightEthereumBlock,
     },
@@ -217,6 +220,15 @@ impl TryInto<BlockFinality> for &Block {
     }
 }
 
+impl Into<BlockDetailLevel> for block::DetailLevel {
+    fn into(self) -> BlockDetailLevel {
+        match self {
+            block::DetailLevel::DetaillevelExtended => BlockDetailLevel::Full,
+            block::DetailLevel::DetaillevelBase => BlockDetailLevel::Light,
+        }
+    }
+}
+
 impl TryInto<EthereumBlockWithCalls> for &Block {
     type Error = Error;
 
@@ -370,6 +382,7 @@ impl TryInto<EthereumBlockWithCalls> for &Block {
                     })
                     .collect::<Result<_, _>>()?,
             ),
+            detail_level: self.detail_level().into(),
         };
 
         Ok(block)

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1892,15 +1892,13 @@ pub(crate) async fn get_calls(
     // For final blocks, or nonfinal blocks where we already checked
     // (`calls.is_some()`), do nothing; if we haven't checked for calls, do
     // that now
-    match block {
+    let block_finality = match block {
         BlockFinality::Final(_)
-        | BlockFinality::NonFinal(EthereumBlockWithCalls {
-            ethereum_block: _,
-            calls: Some(_),
-        }) => Ok(block),
+        | BlockFinality::NonFinal(EthereumBlockWithCalls { calls: Some(_), .. }) => Ok(block),
         BlockFinality::NonFinal(EthereumBlockWithCalls {
             ethereum_block,
             calls: None,
+            detail_level,
         }) => {
             let calls = if !requires_traces || ethereum_block.transaction_receipts.is_empty() {
                 vec![]
@@ -1921,9 +1919,11 @@ pub(crate) async fn get_calls(
             Ok(BlockFinality::NonFinal(EthereumBlockWithCalls {
                 ethereum_block,
                 calls: Some(calls),
+                detail_level,
             }))
         }
-    }
+    };
+    block_finality
 }
 
 pub(crate) fn parse_log_triggers(
@@ -2607,6 +2607,7 @@ mod tests {
         EthereumBlockWithCalls,
     };
     use graph::blockchain::BlockPtr;
+    use graph::components::ethereum::BlockDetailLevel;
     use graph::prelude::ethabi::ethereum_types::U64;
     use graph::prelude::tokio::{self};
     use graph::prelude::web3::transports::test::TestTransport;
@@ -2634,6 +2635,7 @@ mod tests {
                 input: bytes(vec![1; 36]),
                 ..Default::default()
             }]),
+            detail_level: BlockDetailLevel::Full,
         };
 
         assert_eq!(
@@ -2800,6 +2802,7 @@ mod tests {
                 input: bytes(vec![1; 36]),
                 ..Default::default()
             }]),
+            detail_level: BlockDetailLevel::Full,
         };
 
         assert_eq!(
@@ -2832,6 +2835,7 @@ mod tests {
                 input: bytes(vec![1; 36]),
                 ..Default::default()
             }]),
+            detail_level: BlockDetailLevel::Full,
         };
 
         assert_eq!(

--- a/chain/ethereum/src/ingestor.rs
+++ b/chain/ethereum/src/ingestor.rs
@@ -3,6 +3,7 @@ use crate::{EthereumAdapter, EthereumAdapterTrait as _};
 use graph::blockchain::client::ChainClient;
 use graph::blockchain::BlockchainKind;
 use graph::components::adapter::ChainId;
+use graph::components::ethereum::BlockDetailLevel;
 use graph::futures03::compat::Future01CompatExt as _;
 use graph::slog::o;
 use graph::util::backoff::ExponentialBackoff;
@@ -182,10 +183,12 @@ impl PollingBlockIngestor {
 
         // We need something that implements `Block` to store the block; the
         // store does not care whether the block is final or not
-        let ethereum_block = BlockFinality::NonFinal(EthereumBlockWithCalls {
+        let ethereum_block_with_calls = EthereumBlockWithCalls {
             ethereum_block,
             calls: None,
-        });
+            detail_level: BlockDetailLevel::Full,
+        };
+        let ethereum_block = BlockFinality::NonFinal(ethereum_block_with_calls);
 
         // Store it in the database and try to advance the chain head pointer
         self.chain_store

--- a/chain/ethereum/src/protobuf/sf.ethereum.r#type.v2.rs
+++ b/chain/ethereum/src/protobuf/sf.ethereum.r#type.v2.rs
@@ -23,8 +23,66 @@ pub struct Block {
     pub transaction_traces: ::prost::alloc::vec::Vec<TransactionTrace>,
     #[prost(message, repeated, tag = "11")]
     pub balance_changes: ::prost::alloc::vec::Vec<BalanceChange>,
+    /// DetailLevel affects the data available in this block.
+    ///
+    /// ## DetailLevel_EXTENDED
+    ///
+    /// Describes the most complete block, with traces, balance changes, storage
+    /// changes. It is extracted during the execution of the block.
+    ///
+    /// ## DetailLevel_BASE
+    ///
+    /// Describes a block that contains only the block header, transaction receipts
+    /// and event logs: everything that can be extracted using the base JSON-RPC
+    /// interface
+    /// (<https://ethereum.org/en/developers/docs/apis/json-rpc/#json-rpc-methods>)
+    /// Furthermore, the eth_getTransactionReceipt call has been avoided because it
+    /// brings only minimal improvements at the cost of requiring an archive node
+    /// or a full node with complete transaction index.
+    #[prost(enumeration = "block::DetailLevel", tag = "12")]
+    pub detail_level: i32,
     #[prost(message, repeated, tag = "20")]
     pub code_changes: ::prost::alloc::vec::Vec<CodeChange>,
+}
+/// Nested message and enum types in `Block`.
+pub mod block {
+    #[derive(
+        Clone,
+        Copy,
+        Debug,
+        PartialEq,
+        Eq,
+        Hash,
+        PartialOrd,
+        Ord,
+        ::prost::Enumeration
+    )]
+    #[repr(i32)]
+    pub enum DetailLevel {
+        DetaillevelExtended = 0,
+        /// DETAILLEVEL_TRACE = 1; // TBD
+        DetaillevelBase = 2,
+    }
+    impl DetailLevel {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                DetailLevel::DetaillevelExtended => "DETAILLEVEL_EXTENDED",
+                DetailLevel::DetaillevelBase => "DETAILLEVEL_BASE",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "DETAILLEVEL_EXTENDED" => Some(Self::DetaillevelExtended),
+                "DETAILLEVEL_BASE" => Some(Self::DetaillevelBase),
+                _ => None,
+            }
+        }
+    }
 }
 /// HeaderOnlyBlock is used to optimally unpack the \[Block\] structure (note the
 /// corresponding message number for the `header` field) while consuming less

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -1,3 +1,4 @@
+use crate::components::ethereum::BlockDetailLevel;
 use crate::substreams::Clock;
 use crate::substreams_rpc::response::Message as SubstreamsMessage;
 use crate::substreams_rpc::BlockScopedData;
@@ -518,6 +519,10 @@ impl SubstreamsError {
 pub enum BlockStreamError {
     #[error("Failed to decode protobuf {0}")]
     ProtobufDecodingError(#[from] prost::DecodeError),
+    #[error(
+        "subgraph requires block detail level: {0}, check firehose documentation for more details"
+    )]
+    BlockLevelRequirementUnet(BlockDetailLevel),
     #[error("substreams error: {0}")]
     SubstreamsError(#[from] SubstreamsError),
     #[error("block stream error {0}")]

--- a/graph/src/components/ethereum/mod.rs
+++ b/graph/src/components/ethereum/mod.rs
@@ -1,6 +1,6 @@
 mod types;
 
 pub use self::types::{
-    evaluate_transaction_status, EthereumBlock, EthereumBlockWithCalls, EthereumCall,
-    LightEthereumBlock, LightEthereumBlockExt,
+    evaluate_transaction_status, BlockDetailLevel, EthereumBlock, EthereumBlockWithCalls,
+    EthereumCall, LightEthereumBlock, LightEthereumBlockExt,
 };

--- a/graph/src/components/ethereum/types.rs
+++ b/graph/src/components/ethereum/types.rs
@@ -66,12 +66,25 @@ impl LightEthereumBlockExt for LightEthereumBlock {
     }
 }
 
+#[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq)]
+pub enum BlockDetailLevel {
+    Light,
+    Full,
+}
+
+impl std::fmt::Display for BlockDetailLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&format!("{:?}", self))
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct EthereumBlockWithCalls {
     pub ethereum_block: EthereumBlock,
     /// The calls in this block; `None` means we haven't checked yet,
     /// `Some(vec![])` means that we checked and there were none
     pub calls: Option<Vec<EthereumCall>>,
+    pub detail_level: BlockDetailLevel,
 }
 
 impl EthereumBlockWithCalls {

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -8,6 +8,7 @@ use ethereum::chain::{
 };
 use ethereum::network::EthereumNetworkAdapter;
 use ethereum::ProviderEthRpcMetrics;
+use ethereum::ENV_VARS as ETH_VARS;
 use graph::anyhow::bail;
 use graph::blockchain::client::ChainClient;
 use graph::blockchain::{
@@ -547,7 +548,11 @@ pub async fn networks_as_chains(
                     call_cache,
                     client,
                     chain_head_update_listener.clone(),
-                    Arc::new(EthereumStreamBuilder {}),
+                    Arc::new(EthereumStreamBuilder {
+                        firehose_chains_detail_level_check_disabled: ETH_VARS
+                            .chains_firehose_disable_detail_level_check
+                            .clone(),
+                    }),
                     Arc::new(EthereumBlockRefetcher {}),
                     Arc::new(adapter_selector),
                     Arc::new(EthereumRuntimeAdapterBuilder {}),


### PR DESCRIPTION
Firehose block detail level introduced a source of non deterministic behavior. This PR ensures that if Call or block handlers are used, the incoming blocks are required to use Extended Block Details, this essentially means rpc poller based chains will not be allowed as they currently introduce some behaviors for which the graph-node cannot ensure deterministic subgraph data.

- Expose the existing DetailLevel information to graph-node's protobuf
- Enforce a minimum value based on the handler type
- Add env var to disable this behavior, in some changes extended block types are not yet available, so for those chains the new env var needs to be used. 

Optimism at the time of writing is still a WIP. Arbitrum has a mix of block detail level and may require the env var to be used to bypass validation.