### PR TITLE
Enable graft validation checks for debug

### DIFF
--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -500,13 +500,7 @@ impl Graft {
             // The graft point must be at least `reorg_threshold` blocks
             // behind the subgraph head so that a reorg can not affect the
             // data that we copy for grafting
-            //
-            // This is pretty nasty: we have tests in the subgraph runner
-            // tests that graft onto the subgraph head directly. We
-            // therefore skip this check in debug builds and only turn it on
-            // in release builds
-            #[cfg(not(debug_assertions))]
-            (Some(ptr), true) if self.block + ENV_VARS.reorg_threshold >= ptr.number => Err(GraftBaseInvalid(format!(
+            (Some(ptr), true) if self.block + ENV_VARS.reorg_threshold > ptr.number => Err(GraftBaseInvalid(format!(
                 "failed to graft onto `{}` at block {} since it's only at block {} which is within the reorg threshold of {} blocks",
                 self.base, self.block, ptr.number, ENV_VARS.reorg_threshold
             ))),


### PR DESCRIPTION
Closes https://github.com/graphprotocol/graph-node/issues/5197

Fix graft validation checks

- Removed the conditional compilation for reorg threshold checks in debug builds

This will be good to go as we have `reorg_threshold` set to 0 on debug builds.
 https://github.com/graphprotocol/graph-node/blob/b0c89526fd932393f3e43350ee664404eb858040/graph/src/env/mod.rs#L238-L241
