### PR TITLE
[Feature]: handle multiple deployments on graphman restart

### DIFF
--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -1219,17 +1219,17 @@ async fn main() -> anyhow::Result<()> {
             let sender = ctx.notification_sender();
             let pool = ctx.primary_pool();
             let mut locators: Vec<DeploymentLocator> = Vec::new();
-            let mut failed: Vec<String> = Vec::new();
+            let mut deployments_not_found: Vec<String> = Vec::new();
             for deployment in deployments {
                 match deployment.locate_unique(&pool) {
                     Ok(locator) => {
                         locators.push(locator);
                     }
-                    Err(_) => failed.push(deployment.get_name()),
+                    Err(_) => deployments_not_found.push(deployment.get_name()),
                 }
             }
-            if failed.len() > 0 {
-                println!("No deployments found : {:?}", failed);
+            if deployments_not_found.len() > 0 {
+                println!("No deployments found : {:?}", deployments_not_found);
             }
             if locators.len() > 0 {
                 commands::assign::restart(pool, &sender, &locators, sleep)

--- a/node/src/manager/commands/assign.rs
+++ b/node/src/manager/commands/assign.rs
@@ -114,15 +114,17 @@ pub fn pause_or_resume(
 pub fn restart(
     primary: ConnectionPool,
     sender: &NotificationSender,
-    locator: &DeploymentLocator,
+    locators: &Vec<DeploymentLocator>,
     sleep: Duration,
 ) -> Result<(), Error> {
-    pause_or_resume(primary.clone(), sender, locator, true)?;
-    println!(
-        "Waiting {}s to make sure pausing was processed",
-        sleep.as_secs()
-    );
-    thread::sleep(sleep);
-    pause_or_resume(primary, sender, locator, false)?;
+    for locator in locators {
+        pause_or_resume(primary.clone(), sender, locator, true)?;
+        println!(
+            "Waiting {}s to make sure pausing was processed",
+            sleep.as_secs()
+        );
+        thread::sleep(sleep);
+        pause_or_resume(primary.clone(), sender, locator, false)?;
+    }
     Ok(())
 }

--- a/node/src/manager/deployment.rs
+++ b/node/src/manager/deployment.rs
@@ -183,6 +183,15 @@ impl DeploymentSearch {
         };
         Ok(deployment_locator)
     }
+
+    pub fn get_name(self) -> String {
+        match self {
+            DeploymentSearch::All => String::from(""),
+            DeploymentSearch::Name { name } => name,
+            DeploymentSearch::Hash { hash, shard: _ } => hash,
+            DeploymentSearch::Deployment { namespace } => namespace,
+        }
+    }
 }
 
 #[derive(Queryable, PartialEq, Eq, Hash, Debug)]


### PR DESCRIPTION
With this PR, multiple subgraphs can be restarted in a single command using `graphman restart` command.

```
// Example
graphman restart <deployment-id> <namespace> <subgraph-name>
```


<img width="1092" alt="Screenshot 2024-08-08 at 4 14 55 PM" src="https://github.com/user-attachments/assets/ca3bf5d0-126a-4e8f-bb76-d54f7f71fc07">