### PR TITLE
Store `synced_at_block_number` when a deployment syncs

### DIFF
--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -350,7 +350,7 @@ pub trait WritableStore: ReadStore + DeploymentCursorTracker {
     ) -> Result<(), StoreError>;
 
     /// Force synced status, used for testing.
-    fn deployment_synced(&self) -> Result<(), StoreError>;
+    fn deployment_synced(&self, block_ptr: BlockPtr) -> Result<(), StoreError>;
 
     /// Return true if the deployment with the given id is fully synced, and return false otherwise.
     /// Cheap, cached operation.

--- a/store/postgres/migrations/2024-08-14-205601_store_synced_at_block/down.sql
+++ b/store/postgres/migrations/2024-08-14-205601_store_synced_at_block/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE subgraphs.subgraph_deployment DROP COLUMN synced_at_block_number;
+ALTER TABLE unused_deployments            DROP COLUMN synced_at_block_number;

--- a/store/postgres/migrations/2024-08-14-205601_store_synced_at_block/up.sql
+++ b/store/postgres/migrations/2024-08-14-205601_store_synced_at_block/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE subgraphs.subgraph_deployment ADD COLUMN synced_at_block_number NUMERIC;
+ALTER TABLE unused_deployments            ADD COLUMN synced_at_block_number INTEGER;

--- a/store/postgres/migrations/2024-08-14-205601_store_synced_at_block/up.sql
+++ b/store/postgres/migrations/2024-08-14-205601_store_synced_at_block/up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE subgraphs.subgraph_deployment ADD COLUMN synced_at_block_number NUMERIC;
-ALTER TABLE unused_deployments            ADD COLUMN synced_at_block_number INTEGER;
+ALTER TABLE subgraphs.subgraph_deployment ADD COLUMN synced_at_block_number INT4;
+ALTER TABLE unused_deployments            ADD COLUMN synced_at_block_number INT4;

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -739,9 +739,6 @@ pub fn set_synced(
 ) -> Result<(), StoreError> {
     use subgraph_deployment as d;
 
-    // Work around a Diesel issue with serializing BigDecimals to numeric
-    let number = format!("{}::int4", block_ptr.number);
-
     update(
         d::table
             .filter(d::deployment.eq(id.as_str()))
@@ -749,7 +746,7 @@ pub fn set_synced(
     )
     .set((
         d::synced_at.eq(now),
-        d::synced_at_block_number.eq(sql(&number)),
+        d::synced_at_block_number.eq(block_ptr.number),
     ))
     .execute(conn)?;
     Ok(())

--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -133,7 +133,7 @@ table! {
         failed -> Bool,
         health -> crate::deployment::SubgraphHealthMapping,
         synced_at -> Nullable<Timestamptz>,
-        synced_at_block_number -> Nullable<Numeric>,
+        synced_at_block_number -> Nullable<Int4>,
         fatal_error -> Nullable<Text>,
         non_fatal_errors -> Array<Text>,
         earliest_block_number -> Integer,
@@ -740,7 +740,7 @@ pub fn set_synced(
     use subgraph_deployment as d;
 
     // Work around a Diesel issue with serializing BigDecimals to numeric
-    let number = format!("{}::numeric", block_ptr.number);
+    let number = format!("{}::int4", block_ptr.number);
 
     update(
         d::table

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -563,9 +563,13 @@ impl DeploymentStore {
         deployment::exists_and_synced(&mut conn, id.as_str())
     }
 
-    pub(crate) fn deployment_synced(&self, id: &DeploymentHash) -> Result<(), StoreError> {
+    pub(crate) fn deployment_synced(
+        &self,
+        id: &DeploymentHash,
+        block_ptr: BlockPtr,
+    ) -> Result<(), StoreError> {
         let mut conn = self.get_conn()?;
-        conn.transaction(|conn| deployment::set_synced(conn, id))
+        conn.transaction(|conn| deployment::set_synced(conn, id, block_ptr))
     }
 
     /// Look up the on_sync action for this deployment

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -50,7 +50,7 @@ pub struct DeploymentDetail {
     pub failed: bool,
     health: HealthType,
     pub synced_at: Option<DateTime<Utc>>,
-    pub synced_at_block_number: Option<BigDecimal>,
+    pub synced_at_block_number: Option<i32>,
     fatal_error: Option<String>,
     non_fatal_errors: Vec<String>,
     /// The earliest block for which we have history

--- a/store/postgres/src/detail.rs
+++ b/store/postgres/src/detail.rs
@@ -50,6 +50,7 @@ pub struct DeploymentDetail {
     pub failed: bool,
     health: HealthType,
     pub synced_at: Option<DateTime<Utc>>,
+    pub synced_at_block_number: Option<BigDecimal>,
     fatal_error: Option<String>,
     non_fatal_errors: Vec<String>,
     /// The earliest block for which we have history

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -39,8 +39,8 @@ use graph::{
     prelude::{
         anyhow,
         chrono::{DateTime, Utc},
-        serde_json, DeploymentHash, EntityChange, EntityChangeOperation, NodeId, StoreError,
-        SubgraphName, SubgraphVersionSwitchingMode,
+        serde_json, BigDecimal, DeploymentHash, EntityChange, EntityChangeOperation, NodeId,
+        StoreError, SubgraphName, SubgraphVersionSwitchingMode,
     },
 };
 use graph::{
@@ -180,6 +180,7 @@ table! {
         latest_ethereum_block_number -> Nullable<Integer>,
         failed -> Bool,
         synced_at -> Nullable<Timestamptz>,
+        synced_at_block_number -> Nullable<Numeric>,
     }
 }
 
@@ -233,6 +234,7 @@ pub struct UnusedDeployment {
     pub latest_ethereum_block_number: Option<i32>,
     pub failed: bool,
     pub synced_at: Option<DateTime<Utc>>,
+    pub synced_at_block_number: Option<BigDecimal>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, AsExpression, FromSqlRow)]
@@ -1681,6 +1683,7 @@ impl<'a> Connection<'a> {
                     u::latest_ethereum_block_number.eq(latest_number),
                     u::failed.eq(detail.failed),
                     u::synced_at.eq(detail.synced_at),
+                    u::synced_at_block_number.eq(detail.synced_at_block_number.clone()),
                 ))
                 .execute(self.conn.as_mut())?;
         }

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -39,8 +39,8 @@ use graph::{
     prelude::{
         anyhow,
         chrono::{DateTime, Utc},
-        serde_json, BigDecimal, DeploymentHash, EntityChange, EntityChangeOperation, NodeId,
-        StoreError, SubgraphName, SubgraphVersionSwitchingMode,
+        serde_json, DeploymentHash, EntityChange, EntityChangeOperation, NodeId, StoreError,
+        SubgraphName, SubgraphVersionSwitchingMode,
     },
 };
 use graph::{
@@ -180,7 +180,7 @@ table! {
         latest_ethereum_block_number -> Nullable<Integer>,
         failed -> Bool,
         synced_at -> Nullable<Timestamptz>,
-        synced_at_block_number -> Nullable<Numeric>,
+        synced_at_block_number -> Nullable<Int4>,
     }
 }
 
@@ -234,7 +234,7 @@ pub struct UnusedDeployment {
     pub latest_ethereum_block_number: Option<i32>,
     pub failed: bool,
     pub synced_at: Option<DateTime<Utc>>,
-    pub synced_at_block_number: Option<BigDecimal>,
+    pub synced_at_block_number: Option<i32>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, AsExpression, FromSqlRow)]

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -156,7 +156,7 @@ impl WritableStore for MockStore {
         unimplemented!()
     }
 
-    fn deployment_synced(&self) -> Result<(), StoreError> {
+    fn deployment_synced(&self, _block_ptr: BlockPtr) -> Result<(), StoreError> {
         unimplemented!()
     }
 

--- a/store/test-store/tests/postgres/graft.rs
+++ b/store/test-store/tests/postgres/graft.rs
@@ -482,7 +482,7 @@ fn on_sync() {
                     .await?;
 
                 writable.start_subgraph_deployment(&LOGGER).await?;
-                writable.deployment_synced()?;
+                writable.deployment_synced(BLOCKS[0].clone())?;
 
                 let mut primary = primary_connection();
                 let src_site = primary.locate_site(src)?.unwrap();
@@ -539,7 +539,7 @@ fn on_sync() {
             store.activate(&dst)?;
             store.remove_deployment(src.id.into())?;
 
-            let res = writable.deployment_synced();
+            let res = writable.deployment_synced(BLOCKS[2].clone());
             assert!(res.is_ok());
         }
         Ok(())

--- a/store/test-store/tests/postgres/subgraph.rs
+++ b/store/test-store/tests/postgres/subgraph.rs
@@ -209,14 +209,18 @@ fn create_subgraph() {
         changes
     }
 
-    fn deployment_synced(store: &Arc<SubgraphStore>, deployment: &DeploymentLocator) {
+    fn deployment_synced(
+        store: &Arc<SubgraphStore>,
+        deployment: &DeploymentLocator,
+        block_ptr: BlockPtr,
+    ) {
         futures03::executor::block_on(store.cheap_clone().writable(
             LOGGER.clone(),
             deployment.id,
             Arc::new(Vec::new()),
         ))
         .expect("can get writable")
-        .deployment_synced()
+        .deployment_synced(block_ptr)
         .unwrap();
     }
 
@@ -259,7 +263,7 @@ fn create_subgraph() {
         assert!(pending.is_none());
 
         // Sync deployment
-        deployment_synced(&store, &deployment2);
+        deployment_synced(&store, &deployment2, GENESIS_PTR.clone());
 
         // Deploying again still overwrites current
         let (deployment3, events) = deploy(store.as_ref(), ID3, MODE);
@@ -319,7 +323,7 @@ fn create_subgraph() {
         assert!(pending.is_none());
 
         // Deploy when current is synced leaves current alone and adds pending
-        deployment_synced(&store, &deployment2);
+        deployment_synced(&store, &deployment2, GENESIS_PTR.clone());
         let (deployment3, events) = deploy(store.as_ref(), ID3, MODE);
         let expected = deploy_event(&deployment3);
         assert_eq!(expected, events);
@@ -354,7 +358,7 @@ fn create_subgraph() {
         assert_eq!(None, pending.as_deref());
 
         // Mark `ID3` as synced and deploy that again
-        deployment_synced(&store, &deployment3);
+        deployment_synced(&store, &deployment3, GENESIS_PTR.clone());
         let expected = HashSet::from([unassigned(&deployment2), assigned(&deployment3)]);
         let (deployment3_again, events) = deploy(store.as_ref(), ID3, MODE);
         assert_eq!(&deployment3, &deployment3_again);

--- a/store/test-store/tests/postgres/writable.rs
+++ b/store/test-store/tests/postgres/writable.rs
@@ -146,7 +146,7 @@ where
         let read_count = || read_count(writable.as_ref());
 
         if !batch {
-            writable.deployment_synced().unwrap();
+            writable.deployment_synced(block_pointer(0)).unwrap();
         }
 
         for count in 1..4 {


### PR DESCRIPTION
This is a follow up to #5566 

We use both `INTEGER` and `NUMERIC` types in the database to match how other block numbers are stored in the same table.

