### PR TITLE
Use correct store when loading indexes for graft base

### DIFF
--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -579,7 +579,12 @@ impl SubgraphStoreInner {
 
         let index_def = if let Some(graft) = &graft_base.clone() {
             if let Some(site) = self.sites.get(graft) {
-                Some(deployment_store.load_indexes(site)?)
+                let store = self
+                    .stores
+                    .get(&site.shard)
+                    .ok_or_else(|| StoreError::UnknownShard(site.shard.to_string()))?;
+
+                Some(store.load_indexes(site)?)
             } else {
                 None
             }


### PR DESCRIPTION
Previously, we were trying to load indexes from the store corresponding to the subgraph being deployed. This was the wrong shard, resulting in deployment failures when a subgraph is on a different shard from its graft based.

This updates the call to use the correct store.