### PR TITLE
feat(docker): build multiarch docker images

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -3,7 +3,10 @@ options:
 timeout: 1800s
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--target', 'graph-node-build',
+  args: ['buildx', 'create', '--driver', 'docker-container', '--name', 'container', '--use']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['buildx', 'build', '--platform', 'linux/amd64,linux/arm64',
+         '--target', 'graph-node-build',
          '--build-arg', 'COMMIT_SHA=$COMMIT_SHA',
          '--build-arg', 'REPO_NAME=$REPO_NAME',
          '--build-arg', 'BRANCH_NAME=$BRANCH_NAME',
@@ -11,7 +14,8 @@ steps:
          '-t', 'gcr.io/$PROJECT_ID/graph-node-build:$SHORT_SHA',
          '-f', 'docker/Dockerfile', '.']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--target', 'graph-node',
+  args: ['buildx', 'build', '--platform', 'linux/amd64,linux/arm64',
+         '--target', 'graph-node',
          '--build-arg', 'COMMIT_SHA=$COMMIT_SHA',
          '--build-arg', 'REPO_NAME=$REPO_NAME',
          '--build-arg', 'BRANCH_NAME=$BRANCH_NAME',
@@ -19,7 +23,8 @@ steps:
          '-t', 'gcr.io/$PROJECT_ID/graph-node:$SHORT_SHA',
          '-f', 'docker/Dockerfile', '.']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--target', 'graph-node-debug',
+  args: ['buildx', 'build', '--platform', 'linux/amd64,linux/arm64',
+         '--target', 'graph-node-debug',
          '--build-arg', 'COMMIT_SHA=$COMMIT_SHA',
          '--build-arg', 'REPO_NAME=$REPO_NAME',
          '--build-arg', 'BRANCH_NAME=$BRANCH_NAME',


### PR DESCRIPTION
Fix #4643 

Builds ARM64 docker images in additions to the AMD64 that's being deployed.

Reference: [Use Cloud Build to build the image](https://cloud.google.com/dataflow/docs/guides/multi-architecture-container#use-cloud-build)