### PR TITLE
Add `timestamp` support to substreams 

### DIFF
--- a/chain/substreams/proto/codec.proto
+++ b/chain/substreams/proto/codec.proto
@@ -28,8 +28,8 @@ message Value {
     string string = 4;
     bytes bytes = 5;
     bool bool = 6;
-
-    //reserved 7 to 9;  // For future types
+    int64 timestamp = 7;
+    //reserved 8 to 9;  // For future types
 
     Array array = 10;
   }

--- a/chain/substreams/src/mapper.rs
+++ b/chain/substreams/src/mapper.rs
@@ -8,7 +8,7 @@ use graph::blockchain::block_stream::{
     SubstreamsError,
 };
 use graph::blockchain::BlockTime;
-use graph::data::store::scalar::Bytes;
+use graph::data::store::scalar::{Bytes, Timestamp};
 use graph::data::store::IdType;
 use graph::data::value::Word;
 use graph::data_source::CausalityRegion;
@@ -264,6 +264,10 @@ fn decode_value(value: &crate::codec::value::Typed) -> anyhow::Result<Value> {
 
         Typed::Bool(new_value) => Ok(Value::Bool(*new_value)),
 
+        Typed::Timestamp(new_value) => Timestamp::from_microseconds_since_epoch(*new_value)
+            .map(Value::Timestamp)
+            .map_err(|err| anyhow::Error::from(err)),
+
         Typed::Array(arr) => arr
             .value
             .iter()
@@ -282,7 +286,7 @@ mod test {
     use crate::codec::{Array, Value};
     use base64::prelude::*;
     use graph::{
-        data::store::scalar::Bytes,
+        data::store::scalar::{Bytes, Timestamp},
         prelude::{BigDecimal, BigInt, Value as GraphValue},
     };
 
@@ -373,6 +377,13 @@ mod test {
                     typed: Some(Typed::Bool(true)),
                 },
                 expected_value: GraphValue::Bool(true),
+            },
+            Case {
+                name: "timestamp value".to_string(),
+                value: Value {
+                    typed: Some(Typed::Timestamp(1234565789)),
+                },
+                expected_value: GraphValue::Timestamp(Timestamp::from_microseconds_since_epoch(1234565789).unwrap()),
             },
             Case {
                 name: "string array".to_string(),

--- a/chain/substreams/src/protobuf/substreams.entity.v1.rs
+++ b/chain/substreams/src/protobuf/substreams.entity.v1.rs
@@ -68,7 +68,7 @@ pub mod entity_change {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Value {
-    #[prost(oneof = "value::Typed", tags = "1, 2, 3, 4, 5, 6, 10")]
+    #[prost(oneof = "value::Typed", tags = "1, 2, 3, 4, 5, 6, 7, 10")]
     pub typed: ::core::option::Option<value::Typed>,
 }
 /// Nested message and enum types in `Value`.
@@ -88,6 +88,9 @@ pub mod value {
         Bytes(::prost::alloc::vec::Vec<u8>),
         #[prost(bool, tag = "6")]
         Bool(bool),
+        /// reserved 8 to 9;  // For future types
+        #[prost(int64, tag = "7")]
+        Timestamp(i64),
         #[prost(message, tag = "10")]
         Array(super::Array),
     }


### PR DESCRIPTION
Implements #5637

Adds support for `Timestamp` decoding in `EntityChanges`
Needed for aggregation support in substreams-powered subgraphs. 