### PR TITLE
runtime: Fix compiler warning

### DIFF
--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -226,7 +226,7 @@ impl WasmInstanceExt for WasmInstance {
     fn invoke_export1_val_void<V: wasmtime::WasmTy>(&mut self, f: &str, v: V) -> Result<(), Error> {
         let func = self
             .get_func(f)
-            .typed(&self.store.as_context())
+            .typed::<V, ()>(&self.store.as_context())
             .unwrap()
             .clone();
         func.call(&mut self.store.as_context_mut(), v)?;
@@ -525,7 +525,7 @@ async fn run_ipfs_map(
         // Invoke the callback
         let func = instance
             .get_func("ipfsMap")
-            .typed(&instance.store.as_context())
+            .typed::<(u32, u32), ()>(&instance.store.as_context())
             .unwrap()
             .clone();
         func.call(

--- a/runtime/wasm/src/module/instance.rs
+++ b/runtime/wasm/src/module/instance.rs
@@ -92,7 +92,7 @@ impl WasmInstance {
         self.instance
             .get_func(self.store.as_context_mut(), handler_name)
             .with_context(|| format!("function {} not found", handler_name))?
-            .typed(self.store.as_context_mut())?
+            .typed::<(u32, u32), ()>(self.store.as_context_mut())?
             .call(
                 self.store.as_context_mut(),
                 (value?.wasm_ptr(), user_data?.wasm_ptr()),


### PR DESCRIPTION
rustc 1.81 produces a warning (see
https://github.com/rust-lang/rust/issues/123748) in a few places. This change fixes that.

