### PR TITLE
Add json-rpc api support for dropping subgraphs

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -455,6 +455,14 @@ where
         Ok(())
     }
 
+    async fn remove_deployment(&self, id: &DeploymentHash) -> Result<(), SubgraphRegistrarError> {
+        self.store.drop_subgraph(id)?;
+
+        debug!(self.logger, "Removing deployment(s)"; "hash" => id.to_string());
+
+        Ok(())
+    }
+
     /// Reassign a subgraph deployment to a different node.
     ///
     /// Reassigning to a nodeId that does not match any reachable graph-nodes will effectively pause the

--- a/docker/bin/drop
+++ b/docker/bin/drop
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+if [ $# != 1 ]; then
+    echo "usage: drop <ipfs_hash>"
+    exit 1
+fi
+
+api="http://index-node.default/"
+
+echo "Dropping deployment $1"
+data=$(printf '{"jsonrpc": "2.0", "method": "subgraph_drop", "params": {"ipfs_hash":"%s"}, "id":"1"}' "$1")
+curl -s -H "content-type: application/json" --data "$data" "$api"

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -102,6 +102,9 @@ pub trait SubgraphStore: Send + Sync + 'static {
     /// their assignment, but keep the deployments themselves around
     fn remove_subgraph(&self, name: SubgraphName) -> Result<(), StoreError>;
 
+    /// Remove all the subgraph's versions, assignments and data.
+    fn drop_subgraph(&self, name: &DeploymentHash) -> Result<(), StoreError>;
+
     /// Assign the subgraph with `id` to the node `node_id`. If there is no
     /// assignment for the given deployment, report an error.
     fn reassign_subgraph(

--- a/graph/src/components/subgraph/registrar.rs
+++ b/graph/src/components/subgraph/registrar.rs
@@ -48,6 +48,7 @@ pub trait SubgraphRegistrar: Send + Sync + 'static {
     ) -> Result<DeploymentLocator, SubgraphRegistrarError>;
 
     async fn remove_subgraph(&self, name: SubgraphName) -> Result<(), SubgraphRegistrarError>;
+    async fn remove_deployment(&self, hash: &DeploymentHash) -> Result<(), SubgraphRegistrarError>;
 
     async fn reassign_subgraph(
         &self,

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1351,6 +1351,23 @@ impl SubgraphStoreTrait for SubgraphStore {
         })
     }
 
+    fn drop_subgraph(&self, hash: &DeploymentHash) -> Result<(), StoreError> {
+        let deployments = self.subgraphs_for_deployment_hash(hash)?;
+        for (deployment, _) in deployments.into_iter() {
+            self.remove_subgraph(
+                SubgraphName::new(deployment.clone())
+                    .map_err(|_| StoreError::DeploymentNotFound(deployment))?,
+            )?;
+        }
+
+        let locators = self.locators(hash)?;
+        for loc in locators.iter() {
+            self.inner.remove_deployment(loc.id.into())?;
+        }
+
+        Ok(())
+    }
+
     fn reassign_subgraph(
         &self,
         deployment: &DeploymentLocator,


### PR DESCRIPTION
Add json-rpc method for dropping subgraphs. Using this endpoint will remove all the subgraphs for the deployment_id and will delete the underlying data. `docker/bin/drop` is a helper script to use the new endpoint.

Adding some sane defaults as discussed: 

```
 ./docker/bin/drop Qmd3vU6y6pxxXPrvVWRZMN9soNB8AFQCEnqPa9jMSZZDEG
Dropping deployment Qmd3vU6y6pxxXPrvVWRZMN9soNB8AFQCEnqPa9jMSZZDEG
{"jsonrpc":"2.0","error":{"code":1,"message":"subgraph registrar error with store: store error: multiple subgraphs exist fo
r this hash, please remove them before trying to drop"},"id":"1"}
```

```
./docker/bin/remove y
{"jsonrpc":"2.0","result":{"type":"Null"},"id":"1"}
```

```
./docker/bin/drop Qmd3vU6y6pxxXPrvVWRZMN9soNB8AFQCEnqPa9jMSZZDEG
Dropping deployment Qmd3vU6y6pxxXPrvVWRZMN9soNB8AFQCEnqPa9jMSZZDEG
{"jsonrpc":"2.0","result":{"type":"Null"},"id":"1"}%
```