### PR TITLE
Graphman restart: Handle cases where multiple subgraph names reference a deployment ID

### DIFF
--- a/core/graphman/src/commands/deployment/pause.rs
+++ b/core/graphman/src/commands/deployment/pause.rs
@@ -39,12 +39,11 @@ pub fn load_active_deployment(
 ) -> Result<ActiveDeployment, PauseDeploymentError> {
     let mut primary_conn = primary_pool.get().map_err(GraphmanError::from)?;
 
-    let locator = crate::deployment::load_deployment(
+    let locator = crate::deployment::load_deployment_locator(
         &mut primary_conn,
         deployment,
         &DeploymentVersionSelector::All,
-    )?
-    .locator();
+    )?;
 
     let mut catalog_conn = catalog::Connection::new(primary_conn);
 

--- a/core/graphman/src/commands/deployment/resume.rs
+++ b/core/graphman/src/commands/deployment/resume.rs
@@ -39,12 +39,11 @@ pub fn load_paused_deployment(
 ) -> Result<PausedDeployment, ResumeDeploymentError> {
     let mut primary_conn = primary_pool.get().map_err(GraphmanError::from)?;
 
-    let locator = crate::deployment::load_deployment(
+    let locator = crate::deployment::load_deployment_locator(
         &mut primary_conn,
         deployment,
         &DeploymentVersionSelector::All,
-    )?
-    .locator();
+    )?;
 
     let mut catalog_conn = catalog::Connection::new(primary_conn);
 

--- a/core/graphman/src/deployment.rs
+++ b/core/graphman/src/deployment.rs
@@ -127,13 +127,15 @@ pub(crate) fn load_deployments(
     query.load(primary_conn).map_err(Into::into)
 }
 
-pub(crate) fn load_deployment(
+pub(crate) fn load_deployment_locator(
     primary_conn: &mut PgConnection,
     deployment: &DeploymentSelector,
     version: &DeploymentVersionSelector,
-) -> Result<Deployment, GraphmanError> {
-    let deployment = load_deployments(primary_conn, deployment, version)?
+) -> Result<DeploymentLocator, GraphmanError> {
+    let deployment_locator = load_deployments(primary_conn, deployment, version)?
         .into_iter()
+        .map(|deployment| deployment.locator())
+        .unique()
         .exactly_one()
         .map_err(|err| {
             let count = err.into_iter().count();
@@ -142,5 +144,5 @@ pub(crate) fn load_deployment(
             ))
         })?;
 
-    Ok(deployment)
+    Ok(deployment_locator)
 }


### PR DESCRIPTION
There was an issue that prevented `graphman restart` from running if a deployment ID was referenced by multiple subgraph names. This PR fixes that.

Closes #5670