### PR TITLE
Retry IPFS request on Cloudflare 521 Web Server Down

### DIFF
--- a/graph/src/ipfs/error.rs
+++ b/graph/src/ipfs/error.rs
@@ -87,11 +87,14 @@ impl RequestError {
             return true;
         };
 
+        const CLOUDFLARE_WEB_SERVER_DOWN: u16 = 521;
+
         [
             StatusCode::TOO_MANY_REQUESTS,
             StatusCode::INTERNAL_SERVER_ERROR,
             StatusCode::BAD_GATEWAY,
             StatusCode::SERVICE_UNAVAILABLE,
+            StatusCode::from_u16(CLOUDFLARE_WEB_SERVER_DOWN).unwrap(),
         ]
         .into_iter()
         .any(|x| status == x)


### PR DESCRIPTION
In the integration tests, some subgraphs will sync on fraction3, leading to an error as they failed to sync on integer.

Coincidentally, on some runs, fraction3 will also error leading to a _successful_ test; this happens when the subgraph _fails_ to sync due to an HTTP 521 error received when querying the testnet IPFS node. This is a non-deterministic error, and the request can simply be retried.