### PR TITLE
Migrate from `ethabi` to `alloy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,575 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "alloy"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2cc5aeb8dfa1e451a49fac87bc4b86c5de40ebea153ed88e83eb92b8151e74"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-network",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "alloy-transport-http",
+]
+
+[[package]]
+name = "alloy-chains"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a754dbb534198644cb8355b8c23f4aaecf03670fb9409242be1fa1e25897ee9"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "strum",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e32ef5c74bbeb1733c37f4ac7f866f8c8af208b7b4265e21af609dcac5bd5e"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-trie",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa13b7b1e1e3fedc42f0728103bfa3b4d566d3d42b606db449504d88dbdbdcf"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-contract"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6180fb232becdea70fad57c63b6967f01f74ab9595671b870f504116dd29de"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "alloy-transport",
+ "futures 0.3.30",
+ "futures-util",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "alloy-core"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482f377cebceed4bb1fb5e7970f0805e2ab123d06701be9351b67ed6341e74aa"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555896f0b8578adb522b1453b6e6cc6704c3027bd0af20058befdde992cee8e9"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "const-hex",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow 0.7.2",
+]
+
+[[package]]
+name = "alloy-eip2124"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675264c957689f0fd75f5993a73123c2cc3b5c235a38f5b9037fe6c826bfb2c0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabf647eb4650c91a9d38cb6f972bb320009e7e9d61765fb688a86f1563b33e8"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "derive_more 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5591581ca2ab0b3e7226a4047f9a1bfcf431da1d0cce3752fda609fea3c27e37"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 1.0.0",
+ "once_cell",
+ "serde",
+ "sha2",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cded3a2d4bd7173f696458c5d4c98c18a628dfcc9f194385e80a486e412e2e0"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "alloy-trie",
+ "serde",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4012581681b186ba0882007ed873987cc37f86b1b488fe6b91d5efd0b585dc41"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "762414662d793d7aaa36ee3af6928b6be23227df1681ce9c039f6f11daadef64"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-network"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be03f2ebc00cf88bd06d3c6caf387dceaa9c7e6b268216779fa68a9bf8ab4e6"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a00ce618ae2f78369918be0c20f620336381502c83b6ed62c2f7b2db27698b0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478bedf4d24e71ea48428d1bc278553bd7c6ae07c30ca063beb0b09fe58a9e74"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if 1.0.0",
+ "const-hex",
+ "derive_more 1.0.0",
+ "foldhash",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.1",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand",
+ "ruint",
+ "rustc-hash 2.1.1",
+ "serde",
+ "sha3",
+ "tiny-keccak 2.0.2",
+]
+
+[[package]]
+name = "alloy-provider"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbe0a2acff0c4bd1669c71251ce10fc455cbffa1b4d0a817d5ea4ba7e5bb3db7"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "alloy-transport",
+ "alloy-transport-http",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "futures 0.3.30",
+ "futures-utils-wasm",
+ "lru",
+ "parking_lot",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6c1d995bff8d011f7cd6c81820d51825e6e06d6db73914c1630ecf544d83d6"
+dependencies = [
+ "alloy-rlp-derive",
+ "arrayvec 0.7.4",
+ "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40e1ef334153322fd878d07e86af7a529bcb86b2439525920a88eba87bcf943"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b37cc3c7883dc41be1b01460127ad7930466d0a4bb6ba15a02ee34d2745e2d7c"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "alloy-transport-http",
+ "futures 0.3.30",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f18e68a3882f372e045ddc89eb455469347767d17878ca492cfbac81e71a111"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "318ae46dd12456df42527c3b94c1ae9001e1ceb707f7afe2c7807ac4e49ebad9"
+dependencies = [
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4dbee4d82f8a22dde18c28257bed759afeae7ba73da4a1479a039fd1445d04"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-sol-types",
+ "itertools 0.13.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8732058f5ca28c1d53d241e8504620b997ef670315d7c8afab856b3e3b80d945"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f96b3526fdd779a4bd0f37319cfb4172db52a7ac24cdbb8804b72091c18e1701"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve",
+ "k256",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe8f78cd6b7501c7e813a1eb4a087b72d23af51f5bb66d4e948dc840bdd207d8"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2708e27f58d747423ae21d31b7a6625159bd8d867470ddd0256f396a68efa11"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6b7984d7e085dec382d2c5ef022b533fcdb1fe6129200af30ebf5afddb6a361"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck 0.5.0",
+ "indexmap 2.7.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "syn-solidity",
+ "tiny-keccak 2.0.2",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d6a9fc4ed1a3c70bdb2357bec3924551c1a59f24e5a04a74472c755b37f87d"
+dependencies = [
+ "alloy-json-abi",
+ "const-hex",
+ "dunce",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.87",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1b3e9a48a6dd7bb052a111c8d93b5afc7956ed5e2cb4177793dc63bb1d2a36"
+dependencies = [
+ "serde",
+ "winnow 0.7.2",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6044800da35c38118fd4b98e18306bd3b91af5dedeb54c1b768cf1b4fb68f549"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "const-hex",
+ "serde",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a8d762eadce3e9b65eac09879430c6f4fce3736cac3cac123f9b1bf435ddd13"
+dependencies = [
+ "alloy-json-rpc",
+ "base64 0.22.1",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+ "tokio",
+ "tower 0.5.2",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20819c4cb978fb39ce6ac31991ba90f386d595f922f42ef888b4a18be190713e"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "reqwest",
+ "serde_json",
+ "tower 0.5.2",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a94854e420f07e962f7807485856cde359ab99ab6413883e15235ad996e8b"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "arrayvec 0.7.4",
+ "derive_more 1.0.0",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +709,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.0",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint 0.4.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +849,9 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ascii"
@@ -199,7 +895,7 @@ dependencies = [
  "futures-util",
  "handlebars",
  "http 1.1.0",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "mime",
  "multer",
  "num-traits",
@@ -211,7 +907,7 @@ dependencies = [
  "serde_urlencoded",
  "static_assertions_next",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.61",
  "uuid",
 ]
 
@@ -230,7 +926,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.11",
- "tower-service 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.3.3",
 ]
 
 [[package]]
@@ -246,8 +942,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum",
- "syn 2.0.69",
- "thiserror",
+ "syn 2.0.87",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -269,7 +965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef5ec94176a12a8cbe985cd73f2e54dc9c702c88c766bdef12f1f3a67cedbee1"
 dependencies = [
  "bytes",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "serde",
  "serde_json",
 ]
@@ -282,7 +978,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -304,7 +1000,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -315,7 +1011,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -329,6 +1025,17 @@ name = "atomic_refcell"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
+
+[[package]]
+name = "auto_impl"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
 
 [[package]]
 name = "autocfg"
@@ -360,8 +1067,8 @@ dependencies = [
  "serde",
  "sync_wrapper 0.1.2",
  "tower 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-layer 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-layer 0.3.3",
+ "tower-service 0.3.3",
 ]
 
 [[package]]
@@ -396,8 +1103,8 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.21.0",
  "tower 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-layer 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-layer 0.3.3",
+ "tower-service 0.3.3",
  "tracing",
 ]
 
@@ -414,8 +1121,8 @@ dependencies = [
  "http-body 0.4.6",
  "mime",
  "rustversion",
- "tower-layer 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-layer 0.3.3",
+ "tower-service 0.3.3",
 ]
 
 [[package]]
@@ -434,8 +1141,8 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "sync_wrapper 0.1.2",
- "tower-layer 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-layer 0.3.3",
+ "tower-service 0.3.3",
  "tracing",
 ]
 
@@ -459,6 +1166,12 @@ name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -486,6 +1199,12 @@ checksum = "38e2b6c78c06f7288d5e3c3d683bde35a79531127c83b087e5d0d77c974b4b28"
 dependencies = [
  "base64 0.22.1",
 ]
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "beef"
@@ -527,6 +1246,21 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -599,6 +1333,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +1393,21 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "c-kzg"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0307f72feab3300336fb803a57134159f6e20139af1357f36c54cb90d8e8928"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
  "serde",
 ]
 
@@ -731,7 +1492,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -774,6 +1535,25 @@ dependencies = [
  "winapi",
  "winapi-util",
 ]
+
+[[package]]
+name = "const-hex"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
@@ -946,6 +1726,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,6 +1812,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,7 +1885,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1089,7 +1896,21 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1152,6 +1973,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
 
 [[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,8 +2012,29 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
- "syn 2.0.69",
+ "rustc_version 0.4.0",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1215,7 +2067,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1237,7 +2089,7 @@ dependencies = [
  "dsl_auto_type",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1257,7 +2109,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1288,6 +2140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1355,7 +2208,27 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -1363,6 +2236,25 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1451,7 +2343,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "thiserror",
+ "thiserror 1.0.61",
  "uint 0.9.5",
 ]
 
@@ -1462,7 +2354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
 dependencies = [
  "crunchy",
- "fixed-hash",
+ "fixed-hash 0.7.0",
  "impl-rlp",
  "impl-serde",
  "tiny-keccak 2.0.2",
@@ -1475,10 +2367,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
 dependencies = [
  "ethbloom",
- "fixed-hash",
+ "fixed-hash 0.7.0",
  "impl-rlp",
  "impl-serde",
- "primitive-types",
+ "primitive-types 0.11.1",
  "uint 0.9.5",
 ]
 
@@ -1510,6 +2402,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec 0.7.4",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "firestorm"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,6 +2439,18 @@ name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
  "rand",
@@ -1554,6 +2479,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "foreign-types"
@@ -1647,7 +2578,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1688,6 +2619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-utils-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1717,6 +2654,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1737,7 +2675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator 0.3.0",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "stable_deref_trait",
 ]
 
@@ -1765,9 +2703,15 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
  "time",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "globset"
@@ -1787,6 +2731,7 @@ name = "graph"
 version = "0.36.0"
 dependencies = [
  "Inflector",
+ "alloy",
  "anyhow",
  "async-stream",
  "async-trait",
@@ -1804,7 +2749,6 @@ dependencies = [
  "diesel",
  "diesel_derives",
  "envconfig",
- "ethabi",
  "futures 0.1.31",
  "futures 0.3.30",
  "graph_derive",
@@ -1835,7 +2779,7 @@ dependencies = [
  "rand",
  "regex",
  "reqwest",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1850,7 +2794,7 @@ dependencies = [
  "stable-hash 0.3.4",
  "stable-hash 0.4.4",
  "strum_macros",
- "thiserror",
+ "thiserror 1.0.61",
  "tiny-keccak 1.5.0",
  "tokio",
  "tokio-retry",
@@ -1901,7 +2845,7 @@ dependencies = [
  "graph-runtime-wasm",
  "prost 0.12.6",
  "prost-types 0.12.6",
- "semver",
+ "semver 1.0.23",
  "serde",
  "tonic-build",
 ]
@@ -1921,7 +2865,7 @@ dependencies = [
  "jsonrpc-core",
  "prost 0.12.6",
  "prost-types 0.12.6",
- "semver",
+ "semver 1.0.23",
  "serde",
  "tiny-keccak 1.5.0",
  "tonic-build",
@@ -1956,7 +2900,7 @@ dependencies = [
  "lazy_static",
  "prost 0.12.6",
  "prost-types 0.12.6",
- "semver",
+ "semver 1.0.23",
  "serde",
  "tokio",
  "tonic-build",
@@ -2042,7 +2986,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2054,7 +2998,7 @@ dependencies = [
  "graph-runtime-derive",
  "graph-runtime-wasm",
  "rand",
- "semver",
+ "semver 1.0.23",
  "test-store",
  "wasmtime",
 ]
@@ -2066,13 +3010,12 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bs58 0.4.0",
- "ethabi",
  "graph",
  "graph-runtime-derive",
  "hex",
  "never",
  "parity-wasm",
- "semver",
+ "semver 1.0.23",
  "serde_yaml",
  "uuid",
  "wasm-instrument",
@@ -2141,7 +3084,7 @@ dependencies = [
  "blake3 1.5.1",
  "chrono",
  "clap",
- "derive_more",
+ "derive_more 0.99.18",
  "diesel",
  "diesel-derive-enum",
  "diesel-dynamic-schema",
@@ -2200,7 +3143,7 @@ dependencies = [
  "proc-macro-utils",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2213,7 +3156,7 @@ dependencies = [
  "graph-store-postgres",
  "graphman-store",
  "itertools 0.13.0",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
 ]
 
@@ -2237,7 +3180,7 @@ dependencies = [
  "serde_json",
  "slog",
  "test-store",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tower-http",
 ]
@@ -2259,7 +3202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
 dependencies = [
  "combine",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -2276,6 +3219,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2287,7 +3241,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util 0.7.11",
@@ -2306,7 +3260,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util 0.7.11",
@@ -2324,7 +3278,7 @@ dependencies = [
  "pest_derive",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -2349,6 +3303,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -2408,6 +3374,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex-literal"
@@ -2532,7 +3501,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower-service 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.3.3",
  "tracing",
  "want",
 ]
@@ -2573,7 +3542,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
- "tower-service 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.3.3",
 ]
 
 [[package]]
@@ -2601,7 +3570,7 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
- "tower-service 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.3.3",
 ]
 
 [[package]]
@@ -2620,7 +3589,7 @@ dependencies = [
  "socket2",
  "tokio",
  "tower 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.3.3",
  "tracing",
 ]
 
@@ -2743,12 +3712,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -2909,7 +3878,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tracing",
  "unicase",
@@ -2943,8 +3912,21 @@ dependencies = [
  "beef",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.61",
  "tracing",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
 ]
 
 [[package]]
@@ -2954,6 +3936,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
 ]
 
 [[package]]
@@ -3005,6 +3997,15 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+dependencies = [
+ "hashbrown 0.15.2",
+]
 
 [[package]]
 name = "lru_time_cache"
@@ -3266,6 +4267,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "nybbles"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
+dependencies = [
+ "alloy-rlp",
+ "const-hex",
+ "proptest",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3273,7 +4307,7 @@ checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "memchr",
 ]
 
@@ -3351,7 +4385,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3461,7 +4495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.61",
  "ucd-trie",
 ]
 
@@ -3485,7 +4519,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3506,7 +4540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
 ]
 
 [[package]]
@@ -3544,7 +4578,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3558,6 +4592,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -3669,7 +4713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3678,10 +4722,21 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
 dependencies = [
- "fixed-hash",
+ "fixed-hash 0.7.0",
  "impl-codec",
  "impl-rlp",
  "impl-serde",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash 0.8.0",
+ "impl-codec",
  "uint 0.9.5",
 ]
 
@@ -3693,7 +4748,7 @@ checksum = "70c501afe3a2e25c9bd219aa56ec1e04cdb3fcdd763055be268778c13fa82c1f"
 dependencies = [
  "autocfg",
  "equivalent",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
 ]
 
 [[package]]
@@ -3703,6 +4758,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
  "toml_edit 0.21.1",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3739,7 +4816,27 @@ dependencies = [
  "parking_lot",
  "protobuf 2.28.0",
  "reqwest",
- "thiserror",
+ "thiserror 1.0.61",
+]
+
+[[package]]
+name = "proptest"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.6.0",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -3801,7 +4898,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-types 0.12.6",
  "regex",
- "syn 2.0.69",
+ "syn 2.0.87",
  "tempfile",
 ]
 
@@ -3828,7 +4925,7 @@ dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3863,7 +4960,7 @@ checksum = "df67496db1a89596beaced1579212e9b7c53c22dca1d9745de00ead76573d514"
 dependencies = [
  "once_cell",
  "protobuf-support",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -3873,12 +4970,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a16027030d4ec33e423385f73bb559821827e9ec18c50e7874e4d6de5a4e96f"
 dependencies = [
  "anyhow",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "log",
  "protobuf 3.5.0",
  "protobuf-support",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.61",
  "which",
 ]
 
@@ -3888,7 +4985,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e2d30ab1878b2e72d1e2fc23ff5517799c9929e2cf81a8516f9f4dcf2b9cf3"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -3899,6 +4996,12 @@ checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -3922,7 +5025,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 1.1.0",
  "rustls 0.23.10",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "tracing",
 ]
@@ -3936,10 +5039,10 @@ dependencies = [
  "bytes",
  "rand",
  "ring",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.1",
  "rustls 0.23.10",
  "slab",
- "thiserror",
+ "thiserror 1.0.61",
  "tinyvec",
  "tracing",
 ]
@@ -3992,6 +5095,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -4011,6 +5115,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -4065,7 +5178,7 @@ checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -4153,13 +5266,23 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls 0.26.0",
  "tokio-util 0.7.11",
- "tower-service 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.3.3",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -4188,6 +5311,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruint"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "bytes",
+ "fastrlp",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types 0.12.2",
+ "proptest",
+ "rand",
+ "rlp",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4201,9 +5354,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc-hex"
@@ -4213,11 +5366,20 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -4308,6 +5470,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4345,6 +5519,20 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "secp256k1"
@@ -4389,11 +5577,29 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
 ]
 
 [[package]]
@@ -4413,7 +5619,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4502,7 +5708,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4511,7 +5717,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "itoa",
  "ryu",
  "serde",
@@ -4564,6 +5770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "shellexpand"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4579,6 +5795,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core",
 ]
 
 [[package]]
@@ -4675,6 +5901,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snafu"
@@ -4694,7 +5923,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4727,6 +5956,16 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "sptr"
@@ -4825,7 +6064,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4848,7 +6087,7 @@ dependencies = [
  "prost-build 0.11.9",
  "prost-types 0.11.9",
  "substreams-macro",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -4876,7 +6115,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "thiserror",
+ "thiserror 1.0.61",
 ]
 
 [[package]]
@@ -4923,13 +6162,25 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.69"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201fcda3845c23e8212cd466bfebf0bd20694490fc0356ae8e428e0824a915a6"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2de690018098e367beeb793991c7d4dc7270f42c9d2ac4ccc876c1368ca430"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5040,6 +6291,7 @@ dependencies = [
  "lazy_static",
  "pretty_assertions",
  "prost-types 0.12.6",
+ "serde_json",
 ]
 
 [[package]]
@@ -5048,7 +6300,16 @@ version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.61",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -5059,7 +6320,18 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5070,6 +6342,15 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -5173,7 +6454,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5371,7 +6652,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -5382,7 +6663,7 @@ version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f21c7aaf97f1bd9ca9d4f9e73b0a6c74bd5afef56f2bc931943a6e1c37e04e38"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5416,8 +6697,8 @@ dependencies = [
  "tokio-rustls 0.25.0",
  "tokio-stream",
  "tower 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-layer 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-layer 0.3.3",
+ "tower-service 0.3.3",
  "tracing",
 ]
 
@@ -5431,7 +6712,7 @@ dependencies = [
  "proc-macro2",
  "prost-build 0.12.6",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5449,8 +6730,8 @@ dependencies = [
  "slab",
  "tokio",
  "tokio-util 0.7.11",
- "tower-layer 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-layer 0.3.3",
+ "tower-service 0.3.3",
  "tracing",
 ]
 
@@ -5468,9 +6749,23 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "tokio",
  "tokio-util 0.7.11",
- "tower-layer 0.3.2 (git+https://github.com/tower-rs/tower.git)",
- "tower-service 0.3.2 (git+https://github.com/tower-rs/tower.git)",
+ "tower-layer 0.3.2",
+ "tower-service 0.3.2",
  "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.1",
+ "tower-layer 0.3.3",
+ "tower-service 0.3.3",
 ]
 
 [[package]]
@@ -5485,31 +6780,31 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "pin-project-lite",
- "tower-layer 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-layer 0.3.3",
+ "tower-service 0.3.3",
 ]
 
 [[package]]
 name = "tower-layer"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+source = "git+https://github.com/tower-rs/tower.git#39adf5c509a1b2141f679654d8317524ca96b58b"
 
 [[package]]
 name = "tower-layer"
-version = "0.3.2"
-source = "git+https://github.com/tower-rs/tower.git#39adf5c509a1b2141f679654d8317524ca96b58b"
-
-[[package]]
-name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "git+https://github.com/tower-rs/tower.git#39adf5c509a1b2141f679654d8317524ca96b58b"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower-test"
@@ -5520,8 +6815,8 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-test",
- "tower-layer 0.3.2 (git+https://github.com/tower-rs/tower.git)",
- "tower-service 0.3.2 (git+https://github.com/tower-rs/tower.git)",
+ "tower-layer 0.3.2",
+ "tower-service 0.3.2",
 ]
 
 [[package]]
@@ -5544,7 +6839,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5593,7 +6888,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.61",
  "url",
  "utf-8",
 ]
@@ -5612,7 +6907,7 @@ dependencies = [
  "log",
  "rand",
  "sha1",
- "thiserror",
+ "thiserror 1.0.61",
  "utf-8",
 ]
 
@@ -5651,6 +6946,12 @@ dependencies = [
  "hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
@@ -5767,6 +7068,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5783,6 +7090,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -5836,7 +7152,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -5870,7 +7186,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5927,8 +7243,8 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
- "indexmap 2.2.6",
- "semver",
+ "indexmap 2.7.1",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -5937,8 +7253,8 @@ version = "0.118.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77f1154f1ab868e2a01d9834a805faca7bf8b50d041b4ca714d005d0dab1c50c"
 dependencies = [
- "indexmap 2.2.6",
- "semver",
+ "indexmap 2.7.1",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -5953,7 +7269,7 @@ dependencies = [
  "bumpalo",
  "cfg-if 1.0.0",
  "fxprof-processed-profile",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "libc",
  "log",
  "object 0.32.2",
@@ -6016,7 +7332,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser",
@@ -6046,7 +7362,7 @@ dependencies = [
  "log",
  "object 0.32.2",
  "target-lexicon",
- "thiserror",
+ "thiserror 1.0.61",
  "wasmparser 0.116.1",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
@@ -6078,13 +7394,13 @@ dependencies = [
  "anyhow",
  "cranelift-entity",
  "gimli 0.28.1",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "log",
  "object 0.32.2",
  "serde",
  "serde_derive",
  "target-lexicon",
- "thiserror",
+ "thiserror 1.0.61",
  "wasmparser 0.116.1",
  "wasmtime-types",
 ]
@@ -6163,7 +7479,7 @@ dependencies = [
  "anyhow",
  "cc",
  "cfg-if 1.0.0",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "libc",
  "log",
  "mach",
@@ -6192,7 +7508,7 @@ dependencies = [
  "cranelift-entity",
  "serde",
  "serde_derive",
- "thiserror",
+ "thiserror 1.0.61",
  "wasmparser 0.116.1",
 ]
 
@@ -6204,7 +7520,7 @@ checksum = "f50f51f8d79bfd2aa8e9d9a0ae7c2d02b45fe412e62ff1b87c0c81b07c738231"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6215,7 +7531,7 @@ checksum = "4b804dfd3d0c0d6d37aa21026fe7772ba1a769c89ee4f5c4f13b82d91d75216f"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "wit-parser",
 ]
 
@@ -6224,6 +7540,20 @@ name = "wasmtime-wmemcheck"
 version = "15.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6060bc082cc32d9a45587c7640e29e3c7b89ada82677ac25d87850aaccb368"
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0048ad49a55b9deb3953841fa1fc5858f0efbcb7a18868c899a360269fac1b23"
+dependencies = [
+ "futures 0.3.30",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "wast"
@@ -6265,7 +7595,7 @@ dependencies = [
  "arrayvec 0.7.4",
  "base64 0.13.1",
  "bytes",
- "derive_more",
+ "derive_more 0.99.18",
  "ethabi",
  "ethereum-types",
  "futures 0.3.30",
@@ -6299,7 +7629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f6d8d1636b2627fe63518d5a9b38a569405d9c9bc665c43c9c341de57227ebb"
 dependencies = [
  "native-tls",
- "thiserror",
+ "thiserror 1.0.61",
  "tokio",
  "url",
 ]
@@ -6525,6 +7855,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6566,9 +7905,9 @@ checksum = "316b36a9f0005f5aa4b03c39bc3728d045df136f8c13a73b7db4510dec725e08"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.2.6",
+ "indexmap 2.7.1",
  "log",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6613,7 +7952,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6621,6 +7960,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ repository = "https://github.com/graphprotocol/graph-node"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
+alloy = { version = "0.11.1", features = ["dyn-abi", "json-abi"] }
 anyhow = "1.0"
 async-graphql = { version = "7.0.11", features = ["chrono", "uuid"] }
 async-graphql-axum = "7.0.11"

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -1,5 +1,5 @@
 use anyhow::Error;
-use ethabi::{Error as ABIError, ParamType, Token};
+use graph::abi;
 use graph::blockchain::ChainIdentifier;
 use graph::components::subgraph::MappingError;
 use graph::data::store::ethereum::call;
@@ -104,13 +104,12 @@ pub enum EthereumRpcError {
 
 #[derive(Error, Debug)]
 pub enum ContractCallError {
-    #[error("ABI error: {0}")]
-    ABIError(#[from] ABIError),
-    /// `Token` is not of expected `ParamType`
-    #[error("type mismatch, token {0:?} is not of kind {1:?}")]
-    TypeError(Token, ParamType),
-    #[error("error encoding input call data: {0}")]
-    EncodingError(ethabi::Error),
+    #[error("ABI error: {0:#}")]
+    ABIError(anyhow::Error),
+    #[error("type mismatch, decoded value {0:?} is not of kind {1:?}")]
+    TypeError(abi::DynSolValue, abi::DynSolType),
+    #[error("error encoding input call data: {0:#}")]
+    EncodingError(anyhow::Error),
     #[error("call error: {0}")]
     Web3Error(web3::Error),
     #[error("ethereum node took too long to perform call")]
@@ -1165,7 +1164,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         logger: &Logger,
         call: &ContractCall,
         cache: Arc<dyn EthereumCallCache>,
-    ) -> Result<(Option<Vec<Token>>, call::Source), ContractCallError>;
+    ) -> Result<(Option<Vec<abi::DynSolValue>>, call::Source), ContractCallError>;
 
     /// Make multiple contract calls in a single batch. The returned `Vec`
     /// has results in the same order as the calls in `calls` on input. The
@@ -1175,7 +1174,7 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         logger: &Logger,
         calls: &[&ContractCall],
         cache: Arc<dyn EthereumCallCache>,
-    ) -> Result<Vec<(Option<Vec<Token>>, call::Source)>, ContractCallError>;
+    ) -> Result<Vec<(Option<Vec<abi::DynSolValue>>, call::Source)>, ContractCallError>;
 
     fn get_balance(
         &self,
@@ -1204,9 +1203,9 @@ mod tests {
     use graph::blockchain::TriggerFilter as _;
     use graph::firehose::{CallToFilter, CombinedFilter, LogFilter, MultiLogFilter};
     use graph::petgraph::graphmap::GraphMap;
-    use graph::prelude::ethabi::ethereum_types::H256;
     use graph::prelude::web3::types::Address;
     use graph::prelude::web3::types::Bytes;
+    use graph::prelude::web3::types::H256;
     use graph::prelude::EthereumCall;
     use hex::ToHex;
     use itertools::Itertools;

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1,9 +1,11 @@
 use futures03::{future::BoxFuture, stream::FuturesUnordered};
+use graph::abi;
+use graph::abi::DynSolValueExt;
+use graph::abi::FunctionExt;
 use graph::blockchain::client::ChainClient;
 use graph::blockchain::BlockHash;
 use graph::blockchain::ChainIdentifier;
 use graph::blockchain::ExtendedBlockPtr;
-
 use graph::components::transaction_receipt::LightTransactionReceipt;
 use graph::data::store::ethereum::call;
 use graph::data::store::scalar;
@@ -17,8 +19,6 @@ use graph::futures03::future::try_join_all;
 use graph::futures03::{
     self, compat::Future01CompatExt, FutureExt, StreamExt, TryFutureExt, TryStreamExt,
 };
-use graph::prelude::ethabi::ParamType;
-use graph::prelude::ethabi::Token;
 use graph::prelude::tokio::try_join;
 use graph::prelude::web3::types::U256;
 use graph::slog::o;
@@ -28,8 +28,7 @@ use graph::{
     blockchain::{block_stream::BlockWithTriggers, BlockPtr, IngestorError},
     prelude::{
         anyhow::{self, anyhow, bail, ensure, Context},
-        async_trait, debug, error, ethabi, hex, info, retry, serde_json as json, tiny_keccak,
-        trace, warn,
+        async_trait, debug, error, hex, info, retry, serde_json as json, tiny_keccak, trace, warn,
         web3::{
             self,
             types::{
@@ -660,9 +659,10 @@ impl EthereumAdapter {
 
                         match bytes.len() >= 4 && &bytes[..4] == solidity_revert_function_selector {
                             false => None,
-                            true => ethabi::decode(&[ParamType::String], &bytes[4..])
+                            true => abi::DynSolType::String
+                                .abi_decode(&bytes[4..])
                                 .ok()
-                                .and_then(|tokens| tokens[0].clone().into_string()),
+                                .and_then(|val| val.clone().as_str().map(ToOwned::to_owned)),
                         }
                     };
 
@@ -1563,7 +1563,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
         logger: &Logger,
         inp_call: &ContractCall,
         cache: Arc<dyn EthereumCallCache>,
-    ) -> Result<(Option<Vec<Token>>, call::Source), ContractCallError> {
+    ) -> Result<(Option<Vec<abi::DynSolValue>>, call::Source), ContractCallError> {
         let mut result = self.contract_calls(logger, &[inp_call], cache).await?;
         // unwrap: self.contract_calls returns as many results as there were calls
         Ok(result.pop().unwrap())
@@ -1574,20 +1574,26 @@ impl EthereumAdapterTrait for EthereumAdapter {
         logger: &Logger,
         calls: &[&ContractCall],
         cache: Arc<dyn EthereumCallCache>,
-    ) -> Result<Vec<(Option<Vec<Token>>, call::Source)>, ContractCallError> {
+    ) -> Result<Vec<(Option<Vec<abi::DynSolValue>>, call::Source)>, ContractCallError> {
         fn as_req(
             logger: &Logger,
             call: &ContractCall,
             index: u32,
         ) -> Result<call::Request, ContractCallError> {
             // Emit custom error for type mismatches.
-            for (token, kind) in call
+            for (val, kind) in call
                 .args
                 .iter()
-                .zip(call.function.inputs.iter().map(|p| &p.kind))
+                .zip(call.function.inputs.iter().map(|p| p.selector_type()))
             {
-                if !token.type_check(kind) {
-                    return Err(ContractCallError::TypeError(token.clone(), kind.clone()));
+                let kind: abi::DynSolType = kind.parse().map_err(|err| {
+                    ContractCallError::ABIError(anyhow!(
+                        "failed to parse function input type '{kind}': {err}"
+                    ))
+                })?;
+
+                if !val.type_check(&kind) {
+                    return Err(ContractCallError::TypeError(val.clone(), kind.clone()));
                 }
             }
 
@@ -1595,8 +1601,8 @@ impl EthereumAdapterTrait for EthereumAdapter {
             let req = {
                 let encoded_call = call
                     .function
-                    .encode_input(&call.args)
-                    .map_err(ContractCallError::EncodingError)?;
+                    .abi_encode_input(&call.args)
+                    .map_err(|err| ContractCallError::EncodingError(err.into()))?;
                 call::Request::new(call.address, encoded_call, index)
             };
 
@@ -1614,7 +1620,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
             logger: &Logger,
             resp: call::Response,
             call: &ContractCall,
-        ) -> (Option<Vec<Token>>, call::Source) {
+        ) -> (Option<Vec<abi::DynSolValue>>, call::Source) {
             let call::Response {
                 retval,
                 source,
@@ -1622,7 +1628,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
             } = resp;
             use call::Retval::*;
             match retval {
-                Value(output) => match call.function.decode_output(&output) {
+                Value(output) => match call.function.abi_decode_output(&output) {
                     Ok(tokens) => (Some(tokens), source),
                     Err(e) => {
                         // Decode failures are reverts. The reasoning is that if Solidity fails to
@@ -2677,9 +2683,9 @@ mod tests {
         EthereumBlockWithCalls,
     };
     use graph::blockchain::BlockPtr;
-    use graph::prelude::ethabi::ethereum_types::U64;
     use graph::prelude::tokio::{self};
     use graph::prelude::web3::transports::test::TestTransport;
+    use graph::prelude::web3::types::U64;
     use graph::prelude::web3::types::{Address, Block, Bytes, H256};
     use graph::prelude::web3::Web3;
     use graph::prelude::EthereumCall;

--- a/chain/ethereum/src/ingestor.rs
+++ b/chain/ethereum/src/ingestor.rs
@@ -10,8 +10,8 @@ use graph::{
     blockchain::{BlockHash, BlockIngestor, BlockPtr, IngestorError},
     cheap_clone::CheapClone,
     prelude::{
-        async_trait, error, ethabi::ethereum_types::H256, info, tokio, trace, warn, ChainStore,
-        Error, EthereumBlockWithCalls, LogCode, Logger,
+        async_trait, error, info, tokio, trace, warn, web3::types::H256, ChainStore, Error,
+        EthereumBlockWithCalls, LogCode, Logger,
     },
 };
 use std::{sync::Arc, time::Duration};

--- a/chain/ethereum/src/runtime/abi.rs
+++ b/chain/ethereum/src/runtime/abi.rs
@@ -2,9 +2,9 @@ use super::runtime_adapter::UnresolvedContractCall;
 use crate::trigger::{
     EthereumBlockData, EthereumCallData, EthereumEventData, EthereumTransactionData,
 };
+use graph::abi;
 use graph::{
     prelude::{
-        ethabi,
         web3::types::{Log, TransactionReceipt, H256},
         BigInt,
     },
@@ -37,7 +37,7 @@ impl AscType for AscLogParamArray {
     }
 }
 
-impl ToAscObj<AscLogParamArray> for Vec<ethabi::LogParam> {
+impl ToAscObj<AscLogParamArray> for Vec<abi::DynSolParam> {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
@@ -519,7 +519,7 @@ impl ToAscObj<AscEthereumTransaction_0_0_2> for EthereumTransactionData {
             value: asc_new(heap, &BigInt::from_unsigned_u256(&self.value), gas)?,
             gas_limit: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_limit), gas)?,
             gas_price: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_price), gas)?,
-            input: asc_new(heap, &*self.input, gas)?,
+            input: asc_new(heap, &self.input, gas)?,
         })
     }
 }
@@ -541,7 +541,7 @@ impl ToAscObj<AscEthereumTransaction_0_0_6> for EthereumTransactionData {
             value: asc_new(heap, &BigInt::from_unsigned_u256(&self.value), gas)?,
             gas_limit: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_limit), gas)?,
             gas_price: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_price), gas)?,
-            input: asc_new(heap, &*self.input, gas)?,
+            input: asc_new(heap, &self.input, gas)?,
             nonce: asc_new(heap, &BigInt::from_unsigned_u256(&self.nonce), gas)?,
         })
     }
@@ -771,7 +771,7 @@ impl ToAscObj<AscEthereumCall_0_0_3<AscEthereumTransaction_0_0_6, AscEthereumBlo
     }
 }
 
-impl ToAscObj<AscLogParam> for ethabi::LogParam {
+impl ToAscObj<AscLogParam> for abi::DynSolParam {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -7,6 +7,8 @@ use crate::{
 };
 use anyhow::{anyhow, Context, Error};
 use blockchain::HostFn;
+use graph::abi;
+use graph::abi::DynSolValueExt;
 use graph::blockchain::ChainIdentifier;
 use graph::components::subgraph::HostMetrics;
 use graph::data::store::ethereum::call;
@@ -15,6 +17,7 @@ use graph::data::subgraph::API_VERSION_0_0_9;
 use graph::data_source;
 use graph::data_source::common::{ContractCall, MappingABI};
 use graph::futures03::compat::Future01CompatExt;
+use graph::prelude::web3::types::Address;
 use graph::prelude::web3::types::H160;
 use graph::runtime::gas::Gas;
 use graph::runtime::{AscIndexId, IndexForAscTypeId};
@@ -22,10 +25,7 @@ use graph::slog::debug;
 use graph::{
     blockchain::{self, BlockPtr, HostFnCtx},
     cheap_clone::CheapClone,
-    prelude::{
-        ethabi::{self, Address, Token},
-        EthereumCallCache,
-    },
+    prelude::EthereumCallCache,
     runtime::{asc_get, asc_new, AscPtr, HostExportError},
     semver::Version,
     slog::Logger,
@@ -292,20 +292,7 @@ fn eth_call(
     abis: &[Arc<MappingABI>],
     eth_call_gas: Option<u32>,
     metrics: Arc<HostMetrics>,
-) -> Result<Option<Vec<Token>>, HostExportError> {
-    // Helpers to log the result of the call at the end
-    fn tokens_as_string(tokens: &[Token]) -> String {
-        tokens.iter().map(|arg| arg.to_string()).join(", ")
-    }
-
-    fn result_as_string(result: &Result<Option<Vec<Token>>, HostExportError>) -> String {
-        match result {
-            Ok(Some(tokens)) => format!("({})", tokens_as_string(&tokens)),
-            Ok(None) => "none".to_string(),
-            Err(_) => "error".to_string(),
-        }
-    }
-
+) -> Result<Option<Vec<abi::DynSolValue>>, HostExportError> {
     let start_time = Instant::now();
 
     // Obtain the path to the contract ABI
@@ -384,16 +371,26 @@ fn eth_call(
         );
     }
 
-    debug!(logger, "Contract call finished";
-              "address" => format!("0x{:x}", &unresolved_call.contract_address),
-              "contract" => &unresolved_call.contract_name,
-              "signature" => &unresolved_call.function_signature,
-              "args" => format!("[{}]", tokens_as_string(&unresolved_call.function_args)),
-              "time_ms" => format!("{}ms", elapsed.as_millis()),
-              "result" => result_as_string(&result),
-              "block_hash" => block_ptr.hash_hex(),
-              "block_number" => block_ptr.block_number(),
-              "source" => source.to_string());
+    let args_as_string = format!("[{}]", values_to_string(&unresolved_call.function_args));
+
+    let result_as_string = match &result {
+        Ok(Some(values)) => format!("({})", values_to_string(values)),
+        Ok(None) => "none".to_owned(),
+        Err(_err) => "error".to_owned(),
+    };
+
+    debug!(
+        logger, "Contract call finished";
+        "address" => format!("0x{:x}", &unresolved_call.contract_address),
+        "contract" => &unresolved_call.contract_name,
+        "signature" => &unresolved_call.function_signature,
+        "args" => args_as_string,
+        "time_ms" => format!("{}ms", elapsed.as_millis()),
+        "result" => result_as_string,
+        "block_hash" => block_ptr.hash_hex(),
+        "block_number" => block_ptr.block_number(),
+        "source" => source.to_string(),
+    );
 
     result
 }
@@ -404,9 +401,18 @@ pub struct UnresolvedContractCall {
     pub contract_address: Address,
     pub function_name: String,
     pub function_signature: Option<String>,
-    pub function_args: Vec<ethabi::Token>,
+    pub function_args: Vec<abi::DynSolValue>,
 }
 
 impl AscIndexId for AscUnresolvedContractCall {
     const INDEX_ASC_TYPE_ID: IndexForAscTypeId = IndexForAscTypeId::SmartContractCall;
+}
+
+#[inline]
+fn values_to_string(values: &[abi::DynSolValue]) -> String {
+    values
+        .iter()
+        .map(|x| x.to_string())
+        .collect_vec()
+        .join(", ")
 }

--- a/chain/ethereum/src/trigger.rs
+++ b/chain/ethereum/src/trigger.rs
@@ -1,21 +1,21 @@
+use graph::abi;
 use graph::blockchain::MappingTriggerTrait;
 use graph::blockchain::TriggerData;
 use graph::data::subgraph::API_VERSION_0_0_2;
 use graph::data::subgraph::API_VERSION_0_0_6;
 use graph::data::subgraph::API_VERSION_0_0_7;
 use graph::data_source::common::DeclaredCall;
-use graph::prelude::ethabi::ethereum_types::H160;
-use graph::prelude::ethabi::ethereum_types::H256;
-use graph::prelude::ethabi::ethereum_types::U128;
-use graph::prelude::ethabi::ethereum_types::U256;
-use graph::prelude::ethabi::ethereum_types::U64;
-use graph::prelude::ethabi::Address;
-use graph::prelude::ethabi::Bytes;
-use graph::prelude::ethabi::LogParam;
+use graph::prelude::web3::types::Address;
 use graph::prelude::web3::types::Block;
+use graph::prelude::web3::types::Bytes;
 use graph::prelude::web3::types::Log;
 use graph::prelude::web3::types::Transaction;
 use graph::prelude::web3::types::TransactionReceipt;
+use graph::prelude::web3::types::H160;
+use graph::prelude::web3::types::H256;
+use graph::prelude::web3::types::U128;
+use graph::prelude::web3::types::U256;
+use graph::prelude::web3::types::U64;
 use graph::prelude::BlockNumber;
 use graph::prelude::BlockPtr;
 use graph::prelude::{CheapClone, EthereumCall};
@@ -47,7 +47,7 @@ pub enum MappingTrigger {
         block: Arc<LightEthereumBlock>,
         transaction: Arc<Transaction>,
         log: Arc<Log>,
-        params: Vec<LogParam>,
+        params: Vec<abi::DynSolParam>,
         receipt: Option<Arc<TransactionReceipt>>,
         calls: Vec<DeclaredCall>,
     },
@@ -55,8 +55,8 @@ pub enum MappingTrigger {
         block: Arc<LightEthereumBlock>,
         transaction: Arc<Transaction>,
         call: Arc<EthereumCall>,
-        inputs: Vec<LogParam>,
-        outputs: Vec<LogParam>,
+        inputs: Vec<abi::DynSolParam>,
+        outputs: Vec<abi::DynSolParam>,
     },
     Block {
         block: Arc<LightEthereumBlock>,
@@ -64,7 +64,7 @@ pub enum MappingTrigger {
 }
 
 impl MappingTriggerTrait for MappingTrigger {
-    fn error_context(&self) -> std::string::String {
+    fn error_context(&self) -> String {
         let transaction_id = match self {
             MappingTrigger::Log { log, .. } => log.transaction_hash,
             MappingTrigger::Call { call, .. } => call.transaction_hash,
@@ -86,13 +86,13 @@ impl std::fmt::Debug for MappingTrigger {
             Log {
                 _transaction: Arc<Transaction>,
                 _log: Arc<Log>,
-                _params: Vec<LogParam>,
+                _params: Vec<abi::DynSolParam>,
             },
             Call {
                 _transaction: Arc<Transaction>,
                 _call: Arc<EthereumCall>,
-                _inputs: Vec<LogParam>,
-                _outputs: Vec<LogParam>,
+                _inputs: Vec<abi::DynSolParam>,
+                _outputs: Vec<abi::DynSolParam>,
             },
             Block,
         }
@@ -488,7 +488,7 @@ impl From<&'_ Transaction> for EthereumTransactionData {
             value: tx.value,
             gas_limit: tx.gas,
             gas_price: tx.gas_price.unwrap_or(U256::zero()), // EIP-1559 made this optional.
-            input: tx.input.0.clone(),
+            input: tx.input.clone(),
             nonce: tx.nonce,
         }
     }
@@ -503,7 +503,7 @@ pub struct EthereumEventData {
     pub log_type: Option<String>,
     pub block: EthereumBlockData,
     pub transaction: EthereumTransactionData,
-    pub params: Vec<LogParam>,
+    pub params: Vec<abi::DynSolParam>,
 }
 
 /// An Ethereum call executed within a transaction within a block to a contract address.
@@ -513,6 +513,6 @@ pub struct EthereumCallData {
     pub to: Address,
     pub block: EthereumBlockData,
     pub transaction: EthereumTransactionData,
-    pub inputs: Vec<LogParam>,
-    pub outputs: Vec<LogParam>,
+    pub inputs: Vec<abi::DynSolParam>,
+    pub outputs: Vec<abi::DynSolParam>,
 }

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+alloy = { workspace = true }
 base64 = "=0.21.7"
 anyhow = "1.0"
 async-trait = "0.1.74"
@@ -25,7 +26,6 @@ envconfig = "0.10.0"
 Inflector = "0.11.3"
 isatty = "0.1.9"
 reqwest = { version = "0.12.5", features = ["json", "stream", "multipart"] }
-ethabi = "17.2"
 hex = "0.4.3"
 http0 = { version = "0", package = "http" }
 http = "1"

--- a/graph/src/abi/event_ext.rs
+++ b/graph/src/abi/event_ext.rs
@@ -1,0 +1,142 @@
+use alloy::json_abi::Event;
+use alloy::primitives::LogData;
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
+use itertools::Itertools;
+use web3::types::Log;
+
+use crate::abi::DynSolParam;
+
+pub trait EventExt {
+    fn decode_log(&self, log: &Log) -> Result<Vec<DynSolParam>>;
+}
+
+impl EventExt for Event {
+    fn decode_log(&self, log: &Log) -> Result<Vec<DynSolParam>> {
+        let log_data = log_to_log_data(log)?;
+        let decoded_event = alloy::dyn_abi::EventExt::decode_log(self, &log_data, true)?;
+
+        if self.inputs.len() != decoded_event.indexed.len() + decoded_event.body.len() {
+            return Err(anyhow!(
+                "unexpected number of decoded event inputs; expected {}, got {}",
+                self.inputs.len(),
+                decoded_event.indexed.len() + decoded_event.body.len(),
+            ));
+        }
+
+        let decoded_params = decoded_event
+            .indexed
+            .into_iter()
+            .chain(decoded_event.body.into_iter())
+            .enumerate()
+            .map(|(i, value)| DynSolParam {
+                name: self.inputs[i].name.clone(),
+                value,
+            })
+            .collect();
+
+        Ok(decoded_params)
+    }
+}
+
+fn log_to_log_data(log: &Log) -> Result<LogData> {
+    let topics = log
+        .topics
+        .iter()
+        .map(|x| x.to_fixed_bytes().into())
+        .collect_vec();
+
+    let data = log.data.0.clone().into();
+
+    LogData::new(topics, data).context("log has an invalid number of topics")
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::dyn_abi::DynSolValue;
+    use alloy::primitives::U256;
+
+    use super::*;
+
+    fn make_log(topics: &[[u8; 32]], data: Vec<u8>) -> Log {
+        Log {
+            address: [1; 20].into(),
+            topics: topics.iter().map(Into::into).collect(),
+            data: data.into(),
+            block_hash: None,
+            block_number: None,
+            transaction_hash: None,
+            transaction_index: None,
+            log_index: None,
+            transaction_log_index: None,
+            log_type: None,
+            removed: None,
+        }
+    }
+
+    #[test]
+    fn decode_log_no_topic_0() {
+        let event = Event::parse("event X(uint256 indexed a, bytes32 b)").unwrap();
+        let a = U256::from(10).to_be_bytes::<32>();
+        let b = DynSolValue::FixedBytes([10; 32].into(), 32).abi_encode();
+
+        let log = make_log(&[a], b);
+        let err = event.decode_log(&log).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "invalid log topic list length: expected 2 topics, got 1",
+        );
+    }
+
+    #[test]
+    fn decode_log_invalid_topic_0() {
+        let event = Event::parse("event X(uint256 indexed a, bytes32 b)").unwrap();
+        let a = U256::from(10).to_be_bytes::<32>();
+        let b = DynSolValue::FixedBytes([10; 32].into(), 32).abi_encode();
+
+        let log = make_log(&[[0; 32], a], b);
+        let err = event.decode_log(&log).unwrap_err();
+
+        assert!(err.to_string().starts_with("invalid event signature:"));
+    }
+
+    #[test]
+    fn decode_log_success() {
+        let event = Event::parse("event X(uint256 indexed a, bytes32 b)").unwrap();
+        let topic_0 = event.selector().0;
+        let a = U256::from(10).to_be_bytes::<32>();
+        let b = DynSolValue::FixedBytes([10; 32].into(), 32).abi_encode();
+
+        let log = make_log(&[topic_0, a], b);
+        let resp = event.decode_log(&log).unwrap();
+
+        assert_eq!(
+            resp,
+            vec![
+                DynSolParam {
+                    name: "a".to_owned(),
+                    value: DynSolValue::Uint(U256::from(10), 256),
+                },
+                DynSolParam {
+                    name: "b".to_owned(),
+                    value: DynSolValue::FixedBytes([10; 32].into(), 32),
+                }
+            ],
+        );
+    }
+
+    #[test]
+    fn decode_log_too_many_topics() {
+        let event = Event::parse("event X(uint256 indexed a, bytes32 b)").unwrap();
+        let topic_0 = event.selector().0;
+        let a = U256::from(10).to_be_bytes::<32>();
+        let b = DynSolValue::FixedBytes([10; 32].into(), 32).abi_encode();
+
+        let log = make_log(&[topic_0, a, a, a, a], b);
+        let err = event.decode_log(&log).unwrap_err();
+
+        assert_eq!(err.to_string(), "log has an invalid number of topics");
+    }
+}

--- a/graph/src/abi/function_ext.rs
+++ b/graph/src/abi/function_ext.rs
@@ -1,0 +1,303 @@
+use std::borrow::Cow;
+
+use alloy::dyn_abi::DynSolType;
+use alloy::dyn_abi::DynSolValue;
+use alloy::dyn_abi::Specifier;
+use alloy::json_abi::Function;
+use alloy::json_abi::Param;
+use anyhow::anyhow;
+use anyhow::Result;
+use itertools::Itertools;
+
+use crate::abi::DynSolValueExt;
+
+pub trait FunctionExt {
+    /// Returns the signature of this function in the following formats:
+    /// - if the function has no outputs: `$name($($inputs),*)`
+    /// - if the function has outputs: `$name($($inputs),*):($(outputs),*)`
+    ///
+    /// Examples:
+    /// - `functionName()`
+    /// - `functionName():(uint256)`
+    /// - `functionName(bool):(uint256,string)`
+    /// - `functionName(uint256,bytes32):(string,uint256)`
+    fn signature_compat(&self) -> String;
+
+    /// ABI-decodes the given data according to the function's input types.
+    fn abi_decode_input(&self, data: &[u8]) -> Result<Vec<DynSolValue>>;
+
+    /// ABI-decodes the given data according to the function's output types.
+    fn abi_decode_output(&self, data: &[u8]) -> Result<Vec<DynSolValue>>;
+
+    /// ABI-encodes the given values, prefixed by the function's selector, if any.
+    ///
+    /// This behaviour is to ensure consistency with `ethabi`.
+    fn abi_encode_input(&self, values: &[DynSolValue]) -> Result<Vec<u8>>;
+}
+
+impl FunctionExt for Function {
+    fn signature_compat(&self) -> String {
+        let name = &self.name;
+        let inputs = &self.inputs;
+        let outputs = &self.outputs;
+
+        // This is what `alloy` uses internally when creating signatures.
+        const MAX_SOL_TYPE_LEN: usize = 32;
+
+        let mut sig_cap = name.len() + 1 + inputs.len() * MAX_SOL_TYPE_LEN + 1;
+
+        if !outputs.is_empty() {
+            sig_cap = sig_cap + 2 + outputs.len() * MAX_SOL_TYPE_LEN + 1;
+        }
+
+        let mut sig = String::with_capacity(sig_cap);
+
+        sig.push_str(&name);
+        signature_part(&inputs, &mut sig);
+
+        if !outputs.is_empty() {
+            sig.push(':');
+            signature_part(&outputs, &mut sig);
+        }
+
+        sig
+    }
+
+    fn abi_decode_input(&self, data: &[u8]) -> Result<Vec<DynSolValue>> {
+        (self as &dyn alloy::dyn_abi::FunctionExt)
+            .abi_decode_input(data, true)
+            .map_err(Into::into)
+    }
+
+    fn abi_decode_output(&self, data: &[u8]) -> Result<Vec<DynSolValue>> {
+        (self as &dyn alloy::dyn_abi::FunctionExt)
+            .abi_decode_output(data, true)
+            .map_err(Into::into)
+    }
+
+    fn abi_encode_input(&self, values: &[DynSolValue]) -> Result<Vec<u8>> {
+        let inputs = &self.inputs;
+
+        if inputs.len() != values.len() {
+            return Err(anyhow!(
+                "unexpected number of values; expected {}, got {}",
+                inputs.len(),
+                values.len(),
+            ));
+        }
+
+        let mut fixed_values = Vec::with_capacity(values.len());
+
+        for (i, input) in inputs.iter().enumerate() {
+            let ty = input.resolve()?;
+            let val = &values[i];
+
+            fixed_values.push(fix_type_size(&ty, val)?);
+        }
+
+        if fixed_values.iter().all(|x| matches!(x, Cow::Borrowed(_))) {
+            return (self as &dyn alloy::dyn_abi::JsonAbiExt)
+                .abi_encode_input(values)
+                .map_err(Into::into);
+        }
+
+        // Required because of `alloy::dyn_abi::JsonAbiExt::abi_encode_input` API;
+        let owned_fixed_values = fixed_values
+            .into_iter()
+            .map(|x| x.into_owned())
+            .collect_vec();
+
+        (self as &dyn alloy::dyn_abi::JsonAbiExt)
+            .abi_encode_input(&owned_fixed_values)
+            .map_err(Into::into)
+    }
+}
+
+// An efficient way to compute a part of the signature without new allocations.
+fn signature_part(params: &[Param], out: &mut String) {
+    out.push('(');
+
+    match params.len() {
+        0 => {}
+        1 => {
+            params[0].selector_type_raw(out);
+        }
+        n => {
+            params[0].selector_type_raw(out);
+
+            for i in 1..n {
+                out.push(',');
+                params[i].selector_type_raw(out);
+            }
+        }
+    }
+
+    out.push(')');
+}
+
+// Alloy is stricter in type checking than `ehtabi` and requires that the decoded values have
+// exactly the same number of bits / bytes as the type used for checking.
+//
+// This is a problem because in some ASC conversions we lose the original number of bits / bytes
+// if the actual data takes less memory.
+//
+// This method fixes that in a simple but not very cheap way, by encoding the value and trying
+// to decode it again using the given type. The result fixes the number of bits / bytes in the
+// decoded values, so we can use `alloy` methods that have strict type checking internally.
+fn fix_type_size<'a>(ty: &DynSolType, val: &'a DynSolValue) -> Result<Cow<'a, DynSolValue>> {
+    if val.matches(ty) {
+        return Ok(Cow::Borrowed(val));
+    }
+
+    if !val.type_check(ty) {
+        return Err(anyhow!(
+            "invalid value type; expected '{}', got '{:?}'",
+            ty.sol_type_name(),
+            val.sol_type_name(),
+        ));
+    }
+
+    let bytes = val.abi_encode();
+    let new_val = ty.abi_decode(&bytes)?;
+
+    Ok(Cow::Owned(new_val))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::I256;
+    use alloy::primitives::U256;
+
+    use super::*;
+
+    fn s(f: &str) -> String {
+        Function::parse(f).unwrap().signature_compat()
+    }
+
+    fn u256(u: u64) -> U256 {
+        U256::from(u)
+    }
+
+    fn i256(i: i32) -> I256 {
+        I256::try_from(i).unwrap()
+    }
+
+    #[test]
+    fn signature_compat_no_inputs_no_outputs() {
+        assert_eq!(s("x()"), "x()");
+    }
+
+    #[test]
+    fn signature_compat_one_input_no_outputs() {
+        assert_eq!(s("x(uint256 a)"), "x(uint256)");
+    }
+
+    #[test]
+    fn signature_compat_multiple_inputs_no_outputs() {
+        assert_eq!(s("x(uint256 a, bytes32 b)"), "x(uint256,bytes32)");
+    }
+
+    #[test]
+    fn signature_compat_no_inputs_one_output() {
+        assert_eq!(s("x() returns (uint256)"), "x():(uint256)");
+    }
+
+    #[test]
+    fn signature_compat_no_inputs_multiple_outputs() {
+        assert_eq!(s("x() returns (uint256, bytes32)"), "x():(uint256,bytes32)");
+    }
+
+    #[test]
+    fn signature_compat_multiple_inputs_multiple_outputs() {
+        assert_eq!(
+            s("x(bytes32 a, uint256 b) returns (uint256, bytes32)"),
+            "x(bytes32,uint256):(uint256,bytes32)",
+        );
+    }
+
+    #[test]
+    fn abi_decode_input() {
+        use DynSolValue::{Int, Tuple, Uint};
+
+        let f = Function::parse("x(uint256 a, int256 b)").unwrap();
+        let data = Tuple(vec![Uint(u256(10), 256), Int(i256(-10), 256)]).abi_encode_params();
+        let inputs = f.abi_decode_input(&data).unwrap();
+
+        assert_eq!(inputs, vec![Uint(u256(10), 256), Int(i256(-10), 256)]);
+    }
+
+    #[test]
+    fn abi_decode_output() {
+        use DynSolValue::{Int, Tuple, Uint};
+
+        let f = Function::parse("x() returns (uint256 a, int256 b)").unwrap();
+        let data = Tuple(vec![Uint(u256(10), 256), Int(i256(-10), 256)]).abi_encode_params();
+        let outputs = f.abi_decode_output(&data).unwrap();
+
+        assert_eq!(outputs, vec![Uint(u256(10), 256), Int(i256(-10), 256)]);
+    }
+
+    #[test]
+    fn abi_encode_input_no_values() {
+        let f = Function::parse("x(uint256 a, int256 b)").unwrap();
+        let err = f.abi_encode_input(&[]).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "unexpected number of values; expected 2, got 0",
+        );
+    }
+
+    #[test]
+    fn abi_encode_input_too_many_values() {
+        use DynSolValue::Bool;
+
+        let f = Function::parse("x(uint256 a, int256 b)").unwrap();
+
+        let err = f
+            .abi_encode_input(&[Bool(true), Bool(false), Bool(true)])
+            .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "unexpected number of values; expected 2, got 3",
+        );
+    }
+
+    #[test]
+    fn abi_encode_input_invalid_types() {
+        use DynSolValue::Bool;
+
+        let f = Function::parse("x(uint256 a, int256 b)").unwrap();
+        let err = f.abi_encode_input(&[Bool(true), Bool(false)]).unwrap_err();
+        assert!(err.to_string().starts_with("invalid value type;"));
+    }
+
+    #[test]
+    fn abi_encode_success() {
+        use DynSolValue::{Bool, Uint};
+
+        let f = Function::parse("x(uint256 a, bool b)").unwrap();
+        let a = Uint(u256(10), 256);
+        let b = Bool(true);
+
+        let data = f.abi_encode_input(&[a.clone(), b.clone()]).unwrap();
+        let inputs = f.abi_decode_input(&data[4..]).unwrap();
+
+        assert_eq!(inputs, vec![a, b]);
+    }
+
+    #[test]
+    fn abi_encode_success_with_size_fix() {
+        use DynSolValue::{Int, Uint};
+
+        let f = Function::parse("x(uint256 a, int256 b)").unwrap();
+        let a = Uint(u256(10), 32);
+        let b = Int(i256(-10), 32);
+
+        let data = f.abi_encode_input(&[a, b]).unwrap();
+        let inputs = f.abi_decode_input(&data[4..]).unwrap();
+
+        assert_eq!(inputs, vec![Uint(u256(10), 256), Int(i256(-10), 256)]);
+    }
+}

--- a/graph/src/abi/mod.rs
+++ b/graph/src/abi/mod.rs
@@ -1,0 +1,20 @@
+mod event_ext;
+mod function_ext;
+mod param;
+mod value_ext;
+
+pub use alloy::dyn_abi::DynSolType;
+pub use alloy::dyn_abi::DynSolValue;
+
+pub use alloy::json_abi::Event;
+pub use alloy::json_abi::Function;
+pub use alloy::json_abi::JsonAbi;
+pub use alloy::json_abi::StateMutability;
+
+pub use alloy::primitives::I256;
+pub use alloy::primitives::U256;
+
+pub use self::event_ext::EventExt;
+pub use self::function_ext::FunctionExt;
+pub use self::param::DynSolParam;
+pub use self::value_ext::DynSolValueExt;

--- a/graph/src/abi/param.rs
+++ b/graph/src/abi/param.rs
@@ -1,0 +1,7 @@
+use alloy::dyn_abi::DynSolValue;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DynSolParam {
+    pub name: String,
+    pub value: DynSolValue,
+}

--- a/graph/src/abi/value_ext.rs
+++ b/graph/src/abi/value_ext.rs
@@ -1,0 +1,277 @@
+use alloy::dyn_abi::DynSolType;
+use alloy::dyn_abi::DynSolValue;
+use anyhow::anyhow;
+use anyhow::Result;
+use itertools::Itertools;
+
+pub trait DynSolValueExt {
+    /// Creates a fixed-byte decoded value from a slice.
+    ///
+    /// Fails if the source slice exceeds 32 bytes.
+    fn fixed_bytes_from_slice(s: &[u8]) -> Result<DynSolValue>;
+
+    /// Returns the decoded value as a string.
+    ///
+    /// The resulting string contains no type information.
+    fn to_string(&self) -> String;
+
+    /// Checks whether the value is of the specified type.
+    ///
+    /// For types with additional size information, returns true if the size of the value is less
+    /// than or equal to the size of the specified type.
+    #[must_use]
+    fn type_check(&self, ty: &DynSolType) -> bool;
+}
+
+impl DynSolValueExt for DynSolValue {
+    fn fixed_bytes_from_slice(s: &[u8]) -> Result<Self> {
+        let num_bytes = s.len();
+
+        if num_bytes > 32 {
+            return Err(anyhow!(
+                "input slice must contain a maximum of 32 bytes, got {num_bytes}"
+            ));
+        }
+
+        let mut bytes = [0u8; 32];
+
+        // Access: If `x` is of type `bytesI`, then `x[k]` for `0 <= k < I` returns the `k`th byte.
+        // Ref: <https://docs.soliditylang.org/en/v0.8.28/types.html#fixed-size-byte-arrays>
+        bytes[..num_bytes].copy_from_slice(s);
+
+        Ok(Self::FixedBytes(bytes.into(), num_bytes))
+    }
+
+    fn to_string(&self) -> String {
+        let s = |v: &[Self]| v.iter().map(|x| x.to_string()).collect_vec().join(",");
+
+        // Output format is taken from `ethabi`;
+        // See: <https://docs.rs/ethabi/18.0.0/ethabi/enum.Token.html#impl-Display-for-Token>
+        match self {
+            Self::Bool(v) => v.to_string(),
+            Self::Int(v, _) => format!("{v:x}"),
+            Self::Uint(v, _) => format!("{v:x}"),
+            Self::FixedBytes(v, _) => hex::encode(v),
+            Self::Address(v) => format!("{v:x}"),
+            Self::Function(v) => format!("{v:x}"),
+            Self::Bytes(v) => hex::encode(v),
+            Self::String(v) => v.to_owned(),
+            Self::Array(v) => format!("[{}]", s(v)),
+            Self::FixedArray(v) => format!("[{}]", s(v)),
+            Self::Tuple(v) => format!("({})", s(v)),
+        }
+    }
+
+    fn type_check(&self, ty: &DynSolType) -> bool {
+        match self {
+            Self::Bool(_) => *ty == DynSolType::Bool,
+            Self::Int(_, a) => {
+                if let DynSolType::Int(b) = ty {
+                    b >= a
+                } else {
+                    false
+                }
+            }
+            Self::Uint(_, a) => {
+                if let DynSolType::Uint(b) = ty {
+                    b >= a
+                } else {
+                    false
+                }
+            }
+            Self::FixedBytes(_, a) => {
+                if let DynSolType::FixedBytes(b) = ty {
+                    b >= a
+                } else {
+                    false
+                }
+            }
+            Self::Address(_) => *ty == DynSolType::Address,
+            Self::Function(_) => *ty == DynSolType::Function,
+            Self::Bytes(_) => *ty == DynSolType::Bytes,
+            Self::String(_) => *ty == DynSolType::String,
+            Self::Array(values) => {
+                if let DynSolType::Array(ty) = ty {
+                    values.iter().all(|x| x.type_check(ty))
+                } else {
+                    false
+                }
+            }
+            Self::FixedArray(values) => {
+                if let DynSolType::FixedArray(ty, size) = ty {
+                    *size == values.len() && values.iter().all(|x| x.type_check(ty))
+                } else {
+                    false
+                }
+            }
+            Self::Tuple(values) => {
+                if let DynSolType::Tuple(types) = ty {
+                    types.len() == values.len()
+                        && values
+                            .iter()
+                            .enumerate()
+                            .all(|(i, x)| x.type_check(&types[i]))
+                } else {
+                    false
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::I256;
+    use alloy::primitives::U256;
+
+    use super::*;
+
+    #[test]
+    fn fixed_bytes_from_slice_empty_slice() {
+        let val = DynSolValue::fixed_bytes_from_slice(&[]).unwrap();
+        let bytes = [0; 32];
+
+        assert_eq!(val, DynSolValue::FixedBytes(bytes.into(), 0));
+    }
+
+    #[test]
+    fn fixed_bytes_from_slice_one_byte() {
+        let val = DynSolValue::fixed_bytes_from_slice(&[10]).unwrap();
+        let mut bytes = [0; 32];
+        bytes[0] = 10;
+
+        assert_eq!(val, DynSolValue::FixedBytes(bytes.into(), 1));
+    }
+
+    #[test]
+    fn fixed_bytes_from_slice_multiple_bytes() {
+        let val = DynSolValue::fixed_bytes_from_slice(&[10, 20, 30]).unwrap();
+        let mut bytes = [0; 32];
+        bytes[0] = 10;
+        bytes[1] = 20;
+        bytes[2] = 30;
+
+        assert_eq!(val, DynSolValue::FixedBytes(bytes.into(), 3));
+    }
+
+    #[test]
+    fn fixed_bytes_from_slice_max_bytes() {
+        let val = DynSolValue::fixed_bytes_from_slice(&[10; 32]).unwrap();
+        let bytes = [10; 32];
+
+        assert_eq!(val, DynSolValue::FixedBytes(bytes.into(), 32));
+    }
+
+    #[test]
+    fn fixed_bytes_from_slice_too_many_bytes() {
+        DynSolValue::fixed_bytes_from_slice(&[10; 33]).unwrap_err();
+    }
+
+    #[test]
+    fn to_string() {
+        use DynSolValue::*;
+
+        assert_eq!(Bool(false).to_string(), "false");
+        assert_eq!(Bool(true).to_string(), "true");
+
+        assert_eq!(
+            Int(I256::try_from(-10).unwrap(), 256).to_string(),
+            "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6",
+        );
+
+        assert_eq!(Uint(U256::from(10), 256).to_string(), "a");
+
+        assert_eq!(
+            FixedBytes([10; 32].into(), 32).to_string(),
+            "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a",
+        );
+
+        assert_eq!(
+            Address([10; 20].into()).to_string(),
+            "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a",
+        );
+
+        assert_eq!(
+            Function([10; 24].into()).to_string(),
+            "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a",
+        );
+
+        assert_eq!(Bytes(vec![10, 20, 30]).to_string(), "0a141e");
+
+        assert_eq!(
+            String("one two three".to_owned()).to_string(),
+            "one two three"
+        );
+
+        assert_eq!(
+            Array(vec![String("one".to_owned()), String("two".to_owned())]).to_string(),
+            "[one,two]",
+        );
+
+        assert_eq!(
+            FixedArray(vec![String("one".to_owned()), String("two".to_owned())]).to_string(),
+            "[one,two]"
+        );
+
+        assert_eq!(
+            Tuple(vec![String("one".to_owned()), String("two".to_owned())]).to_string(),
+            "(one,two)"
+        );
+    }
+
+    #[test]
+    fn type_check() {
+        use DynSolType as T;
+        use DynSolValue::*;
+
+        assert!(Bool(true).type_check(&T::Bool));
+        assert!(!Bool(true).type_check(&T::Int(256)));
+
+        assert!(!Int(I256::try_from(-10).unwrap(), 32).type_check(&T::Int(24)));
+        assert!(Int(I256::try_from(-10).unwrap(), 32).type_check(&T::Int(32)));
+        assert!(Int(I256::try_from(-10).unwrap(), 32).type_check(&T::Int(256)));
+        assert!(!Int(I256::try_from(-10).unwrap(), 32).type_check(&T::Uint(256)));
+
+        assert!(!Uint(U256::from(10), 32).type_check(&T::Uint(24)));
+        assert!(Uint(U256::from(10), 32).type_check(&T::Uint(32)));
+        assert!(Uint(U256::from(10), 32).type_check(&T::Uint(256)));
+        assert!(!Uint(U256::from(10), 32).type_check(&T::FixedBytes(32)));
+
+        assert!(!FixedBytes([0; 32].into(), 16).type_check(&T::FixedBytes(8)));
+        assert!(FixedBytes([0; 32].into(), 16).type_check(&T::FixedBytes(16)));
+        assert!(FixedBytes([0; 32].into(), 16).type_check(&T::FixedBytes(32)));
+        assert!(!FixedBytes([0; 32].into(), 32).type_check(&T::Address));
+
+        assert!(Address([0; 20].into()).type_check(&T::Address));
+        assert!(!Address([0; 20].into()).type_check(&T::Function));
+
+        assert!(Function([0; 24].into()).type_check(&T::Function));
+        assert!(!Function([0; 24].into()).type_check(&T::Bytes));
+
+        assert!(Bytes(vec![0, 0, 0]).type_check(&T::Bytes));
+        assert!(!Bytes(vec![0, 0, 0]).type_check(&T::String));
+
+        assert!(String("".to_owned()).type_check(&T::String));
+        assert!(!String("".to_owned()).type_check(&T::Array(Box::new(T::Bool))));
+
+        assert!(Array(vec![Bool(true)]).type_check(&T::Array(Box::new(T::Bool))));
+        assert!(!Array(vec![Bool(true)]).type_check(&T::Array(Box::new(T::String))));
+        assert!(!Array(vec![Bool(true)]).type_check(&T::FixedArray(Box::new(T::Bool), 1)));
+
+        assert!(!FixedArray(vec![String("".to_owned())])
+            .type_check(&T::FixedArray(Box::new(T::Bool), 1)));
+        assert!(!FixedArray(vec![Bool(true), Bool(false)])
+            .type_check(&T::FixedArray(Box::new(T::Bool), 1)));
+        assert!(FixedArray(vec![Bool(true), Bool(false)])
+            .type_check(&T::FixedArray(Box::new(T::Bool), 2)));
+        assert!(!FixedArray(vec![Bool(true), Bool(false)])
+            .type_check(&T::FixedArray(Box::new(T::Bool), 3)));
+        assert!(!FixedArray(vec![Bool(true), Bool(false)])
+            .type_check(&T::Tuple(vec![T::Bool, T::Bool])));
+
+        assert!(!Tuple(vec![Bool(true), Bool(false)]).type_check(&T::Tuple(vec![T::Bool])));
+        assert!(Tuple(vec![Bool(true), Bool(false)]).type_check(&T::Tuple(vec![T::Bool, T::Bool])));
+        assert!(!Tuple(vec![Bool(true)]).type_check(&T::Tuple(vec![T::Bool, T::Bool])));
+        assert!(!Tuple(vec![Bool(true)]).type_check(&T::Bool));
+    }
+}

--- a/graph/src/cheap_clone.rs
+++ b/graph/src/cheap_clone.rs
@@ -118,4 +118,4 @@ cheap_clone_is_copy!(
     &'static str,
     std::time::Duration
 );
-cheap_clone_is_copy!(ethabi::Address);
+cheap_clone_is_copy!(web3::types::Address);

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -1262,7 +1262,7 @@ pub struct CachedEthereumCall {
     pub block_ptr: BlockPtr,
 
     /// The address to the called contract.
-    pub contract_address: ethabi::Address,
+    pub contract_address: web3::types::Address,
 
     /// The encoded return value of this call.
     pub return_value: Vec<u8>,

--- a/graph/src/data/store/ethereum.rs
+++ b/graph/src/data/store/ethereum.rs
@@ -104,7 +104,7 @@ pub mod call {
     /// on the call's return value
     #[derive(Debug, Clone, CheapClone)]
     pub struct Request {
-        pub address: ethabi::Address,
+        pub address: web3::types::Address,
         pub encoded_call: Arc<Bytes>,
         /// The index is set by the caller and is used to identify the
         /// request in related data structures that the caller might have
@@ -112,7 +112,7 @@ pub mod call {
     }
 
     impl Request {
-        pub fn new(address: ethabi::Address, encoded_call: Vec<u8>, index: u32) -> Self {
+        pub fn new(address: web3::types::Address, encoded_call: Vec<u8>, index: u32) -> Self {
             Request {
                 address,
                 encoded_call: Arc::new(Bytes::from(encoded_call)),

--- a/graph/src/data_source/common.rs
+++ b/graph/src/data_source/common.rs
@@ -1,8 +1,10 @@
+use crate::abi;
+use crate::abi::DynSolValueExt;
+use crate::abi::FunctionExt;
 use crate::blockchain::block_stream::EntitySourceOperation;
 use crate::prelude::{BlockPtr, Value};
 use crate::{components::link_resolver::LinkResolver, data::value::Word, prelude::Link};
 use anyhow::{anyhow, Context, Error};
-use ethabi::{Address, Contract, Function, LogParam, ParamType, Token};
 use graph_derive::CheapClone;
 use lazy_static::lazy_static;
 use num_bigint::Sign;
@@ -11,12 +13,13 @@ use serde::de;
 use serde::Deserialize;
 use slog::Logger;
 use std::{str::FromStr, sync::Arc};
+use web3::types::Address;
 use web3::types::{Log, H160};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct MappingABI {
     pub name: String,
-    pub contract: Contract,
+    pub contract: abi::JsonAbi,
 }
 
 impl MappingABI {
@@ -25,24 +28,27 @@ impl MappingABI {
         contract_name: &str,
         name: &str,
         signature: Option<&str>,
-    ) -> Result<&Function, Error> {
+    ) -> Result<&abi::Function, Error> {
         let contract = &self.contract;
         let function = match signature {
             // Behavior for apiVersion < 0.0.4: look up function by name; for overloaded
             // functions this always picks the same overloaded variant, which is incorrect
             // and may lead to encoding/decoding errors
-            None => contract.function(name).with_context(|| {
-                format!(
-                    "Unknown function \"{}::{}\" called from WASM runtime",
-                    contract_name, name
-                )
-            })?,
+            None => contract
+                .function(name)
+                .and_then(|matches| matches.first())
+                .with_context(|| {
+                    format!(
+                        "Unknown function \"{}::{}\" called from WASM runtime",
+                        contract_name, name
+                    )
+                })?,
 
             // Behavior for apiVersion >= 0.0.04: look up function by signature of
             // the form `functionName(uint256,string) returns (bytes32,string)`; this
             // correctly picks the correct variant of an overloaded function
             Some(ref signature) => contract
-                .functions_by_name(name)
+                .function(name)
                 .with_context(|| {
                     format!(
                         "Unknown function \"{}::{}\" called from WASM runtime",
@@ -50,7 +56,7 @@ impl MappingABI {
                     )
                 })?
                 .iter()
-                .find(|f| signature == &f.signature())
+                .find(|f| signature == &f.signature_compat())
                 .with_context(|| {
                     format!(
                         "Unknown function \"{}::{}\" with signature `{}` \
@@ -81,7 +87,7 @@ impl UnresolvedMappingABI {
                 self.name, self.file.link
             )
         })?;
-        let contract = Contract::load(&*contract_bytes)?;
+        let contract = serde_json::from_slice(&*contract_bytes)?;
         Ok(MappingABI {
             name: self.name,
             contract,
@@ -122,21 +128,23 @@ impl CallDecl {
         self.expr.validate_args()
     }
 
-    pub fn address_for_log(&self, log: &Log, params: &[LogParam]) -> Result<H160, Error> {
+    pub fn address_for_log(&self, log: &Log, params: &[abi::DynSolParam]) -> Result<H160, Error> {
         let address = match &self.expr.address {
             CallArg::HexAddress(address) => *address,
             CallArg::Ethereum(arg) => match arg {
                 EthereumArg::Address => log.address,
                 EthereumArg::Param(name) => {
-                    let value = params
+                    let value = &params
                         .iter()
                         .find(|param| &param.name == name.as_str())
-                        .ok_or_else(|| anyhow!("unknown param {name}"))?
-                        .value
-                        .clone();
-                    value
-                        .into_address()
-                        .ok_or_else(|| anyhow!("param {name} is not an address"))?
+                        .ok_or_else(|| anyhow!("unknown param '{name}'"))?
+                        .value;
+
+                    let address = value
+                        .as_address()
+                        .ok_or_else(|| anyhow!("param '{name}' is not an address"))?;
+
+                    Address::from(address.into_array())
                 }
             },
             CallArg::Subgraph(_) => {
@@ -148,14 +156,24 @@ impl CallDecl {
         Ok(address)
     }
 
-    pub fn args_for_log(&self, log: &Log, params: &[LogParam]) -> Result<Vec<Token>, Error> {
+    pub fn args_for_log(
+        &self,
+        log: &Log,
+        params: &[abi::DynSolParam],
+    ) -> Result<Vec<abi::DynSolValue>, Error> {
+        use abi::DynSolValue;
+
         self.expr
             .args
             .iter()
             .map(|arg| match arg {
-                CallArg::HexAddress(address) => Ok(Token::Address(*address)),
+                CallArg::HexAddress(address) => {
+                    Ok(DynSolValue::Address(address.to_fixed_bytes().into()))
+                }
                 CallArg::Ethereum(arg) => match arg {
-                    EthereumArg::Address => Ok(Token::Address(log.address)),
+                    EthereumArg::Address => {
+                        Ok(DynSolValue::Address(log.address.to_fixed_bytes().into()))
+                    }
                     EthereumArg::Param(name) => {
                         let value = params
                             .iter()
@@ -173,7 +191,10 @@ impl CallDecl {
             .collect()
     }
 
-    pub fn get_function(&self, mapping: &dyn FindMappingABI) -> Result<Function, anyhow::Error> {
+    pub fn get_function(
+        &self,
+        mapping: &dyn FindMappingABI,
+    ) -> Result<abi::Function, anyhow::Error> {
         let contract_name = self.expr.abi.to_string();
         let function_name = self.expr.func.as_str();
         let abi = mapping.find_abi(&contract_name)?;
@@ -184,6 +205,7 @@ impl CallDecl {
         // and may lead to encoding/decoding errors
         abi.contract
             .function(function_name)
+            .and_then(|matches| matches.first())
             .cloned()
             .with_context(|| {
                 format!(
@@ -231,8 +253,8 @@ impl CallDecl {
     pub fn args_for_entity_handler(
         &self,
         entity: &EntitySourceOperation,
-        param_types: Vec<ParamType>,
-    ) -> Result<Vec<Token>, Error> {
+        param_types: Vec<abi::DynSolType>,
+    ) -> Result<Vec<abi::DynSolValue>, Error> {
         self.validate_entity_handler_args(&param_types)?;
 
         self.expr
@@ -246,7 +268,7 @@ impl CallDecl {
     }
 
     /// Validates that the number of provided arguments matches the expected parameter types.
-    fn validate_entity_handler_args(&self, param_types: &[ParamType]) -> Result<(), Error> {
+    fn validate_entity_handler_args(&self, param_types: &[abi::DynSolType]) -> Result<(), Error> {
         if self.expr.args.len() != param_types.len() {
             return Err(anyhow!(
                 "mismatched number of arguments: expected {}, got {}",
@@ -262,9 +284,9 @@ impl CallDecl {
     fn process_entity_handler_arg(
         &self,
         arg: &CallArg,
-        expected_type: &ParamType,
+        expected_type: &abi::DynSolType,
         entity: &EntitySourceOperation,
-    ) -> Result<Token, Error> {
+    ) -> Result<abi::DynSolValue, Error> {
         match arg {
             CallArg::HexAddress(address) => self.process_hex_address(*address, expected_type),
             CallArg::Ethereum(_) => Err(anyhow!(
@@ -280,10 +302,12 @@ impl CallDecl {
     fn process_hex_address(
         &self,
         address: H160,
-        expected_type: &ParamType,
-    ) -> Result<Token, Error> {
+        expected_type: &abi::DynSolType,
+    ) -> Result<abi::DynSolValue, Error> {
         match expected_type {
-            ParamType::Address => Ok(Token::Address(address)),
+            abi::DynSolType::Address => {
+                Ok(abi::DynSolValue::Address(address.to_fixed_bytes().into()))
+            }
             _ => Err(anyhow!(
                 "type mismatch: hex address provided for non-address parameter"
             )),
@@ -294,9 +318,9 @@ impl CallDecl {
     fn process_entity_param(
         &self,
         name: &str,
-        expected_type: &ParamType,
+        expected_type: &abi::DynSolType,
         entity: &EntitySourceOperation,
-    ) -> Result<Token, Error> {
+    ) -> Result<abi::DynSolValue, Error> {
         let value = entity
             .entity
             .get(name)
@@ -310,27 +334,43 @@ impl CallDecl {
     fn convert_entity_value_to_token(
         &self,
         value: &Value,
-        expected_type: &ParamType,
+        expected_type: &abi::DynSolType,
         param_name: &str,
-    ) -> Result<Token, Error> {
+    ) -> Result<abi::DynSolValue, Error> {
+        use abi::DynSolType;
+        use abi::DynSolValue;
+
         match (expected_type, value) {
-            (ParamType::Address, Value::Bytes(b)) => {
-                Ok(Token::Address(H160::from_slice(b.as_slice())))
+            (DynSolType::Address, Value::Bytes(b)) => {
+                Ok(DynSolValue::Address(b.as_slice().try_into()?))
             }
-            (ParamType::Bytes, Value::Bytes(b)) => Ok(Token::Bytes(b.as_ref().to_vec())),
-            (ParamType::FixedBytes(size), Value::Bytes(b)) if b.len() == *size => {
-                Ok(Token::FixedBytes(b.as_ref().to_vec()))
+            (DynSolType::Bytes, Value::Bytes(b)) => Ok(DynSolValue::Bytes(b.as_ref().to_vec())),
+            (DynSolType::FixedBytes(size), Value::Bytes(b)) if b.len() == *size => {
+                DynSolValue::fixed_bytes_from_slice(b.as_ref())
             }
-            (ParamType::String, Value::String(s)) => Ok(Token::String(s.to_string())),
-            (ParamType::Bool, Value::Bool(b)) => Ok(Token::Bool(*b)),
-            (ParamType::Int(_), Value::Int(i)) => Ok(Token::Int((*i).into())),
-            (ParamType::Int(_), Value::Int8(i)) => Ok(Token::Int((*i).into())),
-            (ParamType::Int(_), Value::BigInt(i)) => Ok(Token::Int(i.to_signed_u256())),
-            (ParamType::Uint(_), Value::Int(i)) if *i >= 0 => Ok(Token::Uint((*i).into())),
-            (ParamType::Uint(_), Value::BigInt(i)) if i.sign() == Sign::Plus => {
-                Ok(Token::Uint(i.to_unsigned_u256()))
+            (DynSolType::String, Value::String(s)) => Ok(DynSolValue::String(s.to_string())),
+            (DynSolType::Bool, Value::Bool(b)) => Ok(DynSolValue::Bool(*b)),
+            (DynSolType::Int(_), Value::Int(i)) => {
+                let x = abi::I256::try_from(*i)?;
+                Ok(DynSolValue::Int(x, x.bits() as usize))
             }
-            (ParamType::Array(inner_type), Value::List(values)) => {
+            (DynSolType::Int(_), Value::Int8(i)) => {
+                let x = abi::I256::try_from(*i)?;
+                Ok(DynSolValue::Int(x, x.bits() as usize))
+            }
+            (DynSolType::Int(_), Value::BigInt(i)) => {
+                let x = abi::I256::from_limbs(i.to_signed_u256().0);
+                Ok(DynSolValue::Int(x, x.bits() as usize))
+            }
+            (DynSolType::Uint(_), Value::Int(i)) if *i >= 0 => {
+                let x = abi::U256::try_from(*i)?;
+                Ok(DynSolValue::Uint(x, x.bit_len()))
+            }
+            (DynSolType::Uint(_), Value::BigInt(i)) if i.sign() == Sign::Plus => {
+                let x = abi::U256::from_limbs(i.to_unsigned_u256().0);
+                Ok(DynSolValue::Uint(x, x.bit_len()))
+            }
+            (DynSolType::Array(inner_type), Value::List(values)) => {
                 self.process_entity_array_values(values, inner_type.as_ref(), param_name)
             }
             _ => Err(anyhow!(
@@ -344,17 +384,17 @@ impl CallDecl {
     fn process_entity_array_values(
         &self,
         values: &[Value],
-        inner_type: &ParamType,
+        inner_type: &abi::DynSolType,
         param_name: &str,
-    ) -> Result<Token, Error> {
-        let tokens: Result<Vec<Token>, Error> = values
+    ) -> Result<abi::DynSolValue, Error> {
+        let tokens: Result<Vec<abi::DynSolValue>, Error> = values
             .iter()
             .enumerate()
             .map(|(idx, v)| {
                 self.convert_entity_value_to_token(v, inner_type, &format!("{param_name}[{idx}]"))
             })
             .collect();
-        Ok(Token::Array(tokens?))
+        Ok(abi::DynSolValue::Array(tokens?))
     }
 }
 
@@ -530,8 +570,8 @@ pub struct DeclaredCall {
     label: String,
     contract_name: String,
     address: Address,
-    function: Function,
-    args: Vec<Token>,
+    function: abi::Function,
+    args: Vec<abi::DynSolValue>,
 }
 
 impl DeclaredCall {
@@ -539,8 +579,8 @@ impl DeclaredCall {
         mapping: &dyn FindMappingABI,
         call_decls: &CallDecls,
         log: &Log,
-        params: &[LogParam],
-    ) -> Result<Vec<DeclaredCall>, anyhow::Error> {
+        params: &[abi::DynSolParam],
+    ) -> Result<Vec<DeclaredCall>, Error> {
         Self::create_calls(mapping, call_decls, |decl, _| {
             Ok((
                 decl.address_for_log(log, params)?,
@@ -553,13 +593,13 @@ impl DeclaredCall {
         mapping: &dyn FindMappingABI,
         call_decls: &CallDecls,
         entity: &EntitySourceOperation,
-    ) -> Result<Vec<DeclaredCall>, anyhow::Error> {
+    ) -> Result<Vec<DeclaredCall>, Error> {
         Self::create_calls(mapping, call_decls, |decl, function| {
             let param_types = function
                 .inputs
                 .iter()
-                .map(|param| param.kind.clone())
-                .collect::<Vec<_>>();
+                .map(|param| param.selector_type().parse())
+                .collect::<Result<Vec<_>, _>>()?;
 
             Ok((
                 decl.address_for_entity_handler(entity)?,
@@ -579,7 +619,7 @@ impl DeclaredCall {
         get_address_and_args: F,
     ) -> Result<Vec<DeclaredCall>, anyhow::Error>
     where
-        F: Fn(&CallDecl, &Function) -> Result<(Address, Vec<Token>), anyhow::Error>,
+        F: Fn(&CallDecl, &abi::Function) -> Result<(Address, Vec<abi::DynSolValue>), anyhow::Error>,
     {
         let mut calls = Vec::new();
         for decl in call_decls.decls.iter() {
@@ -617,8 +657,8 @@ pub struct ContractCall {
     pub contract_name: String,
     pub address: Address,
     pub block_ptr: BlockPtr,
-    pub function: Function,
-    pub args: Vec<Token>,
+    pub function: abi::Function,
+    pub args: Vec<abi::DynSolValue>,
     pub gas: Option<u32>,
 }
 

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -37,8 +37,11 @@ pub mod env;
 
 pub mod ipfs;
 
+pub mod abi;
+
 /// Wrapper for spawning tasks that abort on panic, which is our default.
 mod task_spawn;
+
 pub use task_spawn::{
     block_on, spawn, spawn_allow_panic, spawn_blocking, spawn_blocking_allow_panic, spawn_thread,
 };
@@ -81,7 +84,6 @@ pub mod prelude {
     pub use chrono;
     pub use diesel;
     pub use envconfig;
-    pub use ethabi;
     pub use hex;
     pub use isatty;
     pub use lazy_static::lazy_static;

--- a/runtime/test/src/common.rs
+++ b/runtime/test/src/common.rs
@@ -1,4 +1,3 @@
-use ethabi::Contract;
 use graph::blockchain::BlockTime;
 use graph::components::store::DeploymentLocator;
 use graph::data::subgraph::*;
@@ -81,7 +80,7 @@ fn mock_host_exports(
 fn mock_abi() -> MappingABI {
     MappingABI {
         name: "mock_abi".to_string(),
-        contract: Contract::load(
+        contract: serde_json::from_str(
             r#"[
             {
                 "inputs": [
@@ -92,8 +91,7 @@ fn mock_abi() -> MappingABI {
                 ],
                 "type": "constructor"
             }
-        ]"#
-            .as_bytes(),
+        ]"#,
         )
         .unwrap(),
     }

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 
 [dependencies]
 async-trait = "0.1.50"
-ethabi = "17.2"
 hex = "0.4.3"
 graph = { path = "../../graph" }
 bs58 = "0.4.0"

--- a/runtime/wasm/src/asc_abi/class.rs
+++ b/runtime/wasm/src/asc_abi/class.rs
@@ -1,5 +1,4 @@
-use ethabi;
-
+use graph::abi;
 use graph::{
     data::store::{self, scalar::Timestamp},
     runtime::{
@@ -535,21 +534,25 @@ pub enum EthereumValueKind {
     FixedArray,
     Array,
     Tuple,
+    Function,
 }
 
 impl EthereumValueKind {
-    pub(crate) fn get_kind(token: &ethabi::Token) -> Self {
-        match token {
-            ethabi::Token::Address(_) => EthereumValueKind::Address,
-            ethabi::Token::FixedBytes(_) => EthereumValueKind::FixedBytes,
-            ethabi::Token::Bytes(_) => EthereumValueKind::Bytes,
-            ethabi::Token::Int(_) => EthereumValueKind::Int,
-            ethabi::Token::Uint(_) => EthereumValueKind::Uint,
-            ethabi::Token::Bool(_) => EthereumValueKind::Bool,
-            ethabi::Token::String(_) => EthereumValueKind::String,
-            ethabi::Token::FixedArray(_) => EthereumValueKind::FixedArray,
-            ethabi::Token::Array(_) => EthereumValueKind::Array,
-            ethabi::Token::Tuple(_) => EthereumValueKind::Tuple,
+    pub(crate) fn get_kind(value: &abi::DynSolValue) -> Self {
+        use graph::abi::DynSolValue;
+
+        match value {
+            DynSolValue::Bool(_) => Self::Bool,
+            DynSolValue::Int(_, _) => Self::Int,
+            DynSolValue::Uint(_, _) => Self::Uint,
+            DynSolValue::FixedBytes(_, _) => Self::FixedBytes,
+            DynSolValue::Address(_) => Self::Address,
+            DynSolValue::Function(_) => Self::Function,
+            DynSolValue::Bytes(_) => Self::Bytes,
+            DynSolValue::String(_) => Self::String,
+            DynSolValue::Array(_) => Self::Array,
+            DynSolValue::FixedArray(_) => Self::FixedArray,
+            DynSolValue::Tuple(_) => Self::Tuple,
         }
     }
 }

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -12,6 +12,7 @@ use never::Never;
 use semver::Version;
 use web3::types::H160;
 
+use graph::abi;
 use graph::blockchain::BlockTime;
 use graph::blockchain::Blockchain;
 use graph::components::store::{EnsLookup, GetScope, LoadRelatedRequest};
@@ -21,8 +22,6 @@ use graph::components::subgraph::{
 use graph::data::store::{self};
 use graph::data_source::{CausalityRegion, DataSource, EntityTypeAccess};
 use graph::ensure;
-use graph::prelude::ethabi::param_type::Reader;
-use graph::prelude::ethabi::{decode, encode, Token};
 use graph::prelude::serde_json;
 use graph::prelude::{slog::b, slog::record_static, *};
 use graph::runtime::gas::{self, complexity, Gas, GasCounter};
@@ -1196,11 +1195,11 @@ impl HostExports {
 
     pub(crate) fn ethereum_encode(
         &self,
-        token: Token,
+        value: abi::DynSolValue,
         gas: &GasCounter,
         state: &mut BlockState,
     ) -> Result<Vec<u8>, DeterministicHostError> {
-        let encoded = encode(&[token]);
+        let encoded = value.abi_encode();
 
         Self::track_gas_and_ops(
             gas,
@@ -1218,7 +1217,7 @@ impl HostExports {
         data: Vec<u8>,
         gas: &GasCounter,
         state: &mut BlockState,
-    ) -> Result<Token, anyhow::Error> {
+    ) -> Result<abi::DynSolValue, anyhow::Error> {
         Self::track_gas_and_ops(
             gas,
             state,
@@ -1226,15 +1225,9 @@ impl HostExports {
             "ethereum_decode",
         )?;
 
-        let param_types =
-            Reader::read(&types).map_err(|e| anyhow::anyhow!("Failed to read types: {}", e))?;
+        let ty: abi::DynSolType = types.parse().context("Failed to read types")?;
 
-        decode(&[param_types], &data)
-            // The `.pop().unwrap()` here is ok because we're always only passing one
-            // `param_types` to `decode`, so the returned `Vec` has always size of one.
-            // We can't do `tokens[0]` because the value can't be moved out of the `Vec`.
-            .map(|mut tokens| tokens.pop().unwrap())
-            .context("Failed to decode")
+        ty.abi_decode(&data).context("Failed to decode")
     }
 
     pub(crate) fn yaml_from_bytes(

--- a/runtime/wasm/src/to_from/external.rs
+++ b/runtime/wasm/src/to_from/external.rs
@@ -1,5 +1,5 @@
-use ethabi;
-
+use graph::abi;
+use graph::abi::DynSolValueExt;
 use graph::blockchain::block_stream::{EntityOperationKind, EntitySourceOperation};
 use graph::data::store::scalar::Timestamp;
 use graph::data::value::Word;
@@ -165,32 +165,42 @@ impl ToAscObj<Array<AscPtr<AscString>>> for Vec<String> {
     }
 }
 
-impl ToAscObj<AscEnum<EthereumValueKind>> for ethabi::Token {
+impl ToAscObj<AscEnum<EthereumValueKind>> for abi::DynSolValue {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
         gas: &GasCounter,
     ) -> Result<AscEnum<EthereumValueKind>, HostExportError> {
-        use ethabi::Token::*;
-
         let kind = EthereumValueKind::get_kind(self);
+
         let payload = match self {
-            Address(address) => asc_new::<AscAddress, _, _>(heap, address, gas)?.to_payload(),
-            FixedBytes(bytes) | Bytes(bytes) => {
-                asc_new::<Uint8Array, _, _>(heap, &**bytes, gas)?.to_payload()
-            }
-            Int(uint) => {
-                let n = BigInt::from_signed_u256(uint);
+            Self::Bool(val) => *val as u64,
+            Self::Int(val, _) => {
+                let bytes = val.to_le_bytes::<32>();
+                let n = BigInt::from_signed_bytes_le(&bytes)?;
+
                 asc_new(heap, &n, gas)?.to_payload()
             }
-            Uint(uint) => {
-                let n = BigInt::from_unsigned_u256(uint);
+            Self::Uint(val, _) => {
+                let bytes = val.to_le_bytes::<32>();
+                let n = BigInt::from_unsigned_bytes_le(&bytes)?;
+
                 asc_new(heap, &n, gas)?.to_payload()
             }
-            Bool(b) => *b as u64,
-            String(string) => asc_new(heap, &**string, gas)?.to_payload(),
-            FixedArray(tokens) | Array(tokens) => asc_new(heap, &**tokens, gas)?.to_payload(),
-            Tuple(tokens) => asc_new(heap, &**tokens, gas)?.to_payload(),
+            Self::FixedBytes(val, _) => {
+                asc_new::<Uint8Array, _, _>(heap, val.as_slice(), gas)?.to_payload()
+            }
+            Self::Address(val) => {
+                asc_new::<AscAddress, _, _>(heap, val.as_slice(), gas)?.to_payload()
+            }
+            Self::Function(val) => {
+                asc_new::<Uint8Array, _, _>(heap, val.as_slice(), gas)?.to_payload()
+            }
+            Self::Bytes(val) => asc_new::<Uint8Array, _, _>(heap, &**val, gas)?.to_payload(),
+            Self::String(val) => asc_new(heap, &**val, gas)?.to_payload(),
+            Self::Array(values) => asc_new(heap, &**values, gas)?.to_payload(),
+            Self::FixedArray(values) => asc_new(heap, &**values, gas)?.to_payload(),
+            Self::Tuple(values) => asc_new(heap, &**values, gas)?.to_payload(),
         };
 
         Ok(AscEnum {
@@ -201,57 +211,78 @@ impl ToAscObj<AscEnum<EthereumValueKind>> for ethabi::Token {
     }
 }
 
-impl FromAscObj<AscEnum<EthereumValueKind>> for ethabi::Token {
+impl FromAscObj<AscEnum<EthereumValueKind>> for abi::DynSolValue {
     fn from_asc_obj<H: AscHeap + ?Sized>(
         asc_enum: AscEnum<EthereumValueKind>,
         heap: &H,
         gas: &GasCounter,
         depth: usize,
     ) -> Result<Self, DeterministicHostError> {
-        use ethabi::Token;
-
         let payload = asc_enum.payload;
-        Ok(match asc_enum.kind {
-            EthereumValueKind::Bool => Token::Bool(bool::from(payload)),
+
+        let value = match asc_enum.kind {
             EthereumValueKind::Address => {
                 let ptr: AscPtr<AscAddress> = AscPtr::from(payload);
-                Token::Address(asc_get(heap, ptr, gas, depth)?)
+                let bytes: [u8; 20] = asc_get(heap, ptr, gas, depth)?;
+
+                Self::Address(bytes.into())
             }
             EthereumValueKind::FixedBytes => {
                 let ptr: AscPtr<Uint8Array> = AscPtr::from(payload);
-                Token::FixedBytes(asc_get(heap, ptr, gas, depth)?)
+                let bytes: Vec<u8> = asc_get(heap, ptr, gas, depth)?;
+
+                Self::fixed_bytes_from_slice(&bytes)?
             }
             EthereumValueKind::Bytes => {
                 let ptr: AscPtr<Uint8Array> = AscPtr::from(payload);
-                Token::Bytes(asc_get(heap, ptr, gas, depth)?)
+                let bytes: Vec<u8> = asc_get(heap, ptr, gas, depth)?;
+
+                Self::Bytes(bytes)
             }
             EthereumValueKind::Int => {
                 let ptr: AscPtr<AscBigInt> = AscPtr::from(payload);
                 let n: BigInt = asc_get(heap, ptr, gas, depth)?;
-                Token::Int(n.to_signed_u256())
+                let x = abi::I256::from_limbs(n.to_signed_u256().0);
+
+                Self::Int(x, x.bits() as usize)
             }
             EthereumValueKind::Uint => {
                 let ptr: AscPtr<AscBigInt> = AscPtr::from(payload);
                 let n: BigInt = asc_get(heap, ptr, gas, depth)?;
-                Token::Uint(n.to_unsigned_u256())
+                let x = abi::U256::from_limbs(n.to_unsigned_u256().0);
+
+                Self::Uint(x, x.bit_len())
             }
+            EthereumValueKind::Bool => Self::Bool(bool::from(payload)),
             EthereumValueKind::String => {
                 let ptr: AscPtr<AscString> = AscPtr::from(payload);
-                Token::String(asc_get(heap, ptr, gas, depth)?)
+
+                Self::String(asc_get(heap, ptr, gas, depth)?)
             }
             EthereumValueKind::FixedArray => {
                 let ptr: AscEnumArray<EthereumValueKind> = AscPtr::from(payload);
-                Token::FixedArray(asc_get(heap, ptr, gas, depth)?)
+
+                Self::FixedArray(asc_get(heap, ptr, gas, depth)?)
             }
             EthereumValueKind::Array => {
                 let ptr: AscEnumArray<EthereumValueKind> = AscPtr::from(payload);
-                Token::Array(asc_get(heap, ptr, gas, depth)?)
+
+                Self::Array(asc_get(heap, ptr, gas, depth)?)
             }
             EthereumValueKind::Tuple => {
                 let ptr: AscEnumArray<EthereumValueKind> = AscPtr::from(payload);
-                Token::Tuple(asc_get(heap, ptr, gas, depth)?)
+
+                Self::Tuple(asc_get(heap, ptr, gas, depth)?)
             }
-        })
+            EthereumValueKind::Function => {
+                let ptr: AscPtr<Uint8Array> = AscPtr::from(payload);
+                let bytes: [u8; 24] = asc_get(heap, ptr, gas, depth)?;
+
+                Self::Function(bytes.into())
+            }
+        };
+
+        Ok(value)
     }
 }
 

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -100,8 +100,8 @@ mod data {
     use graph::blockchain::{Block, BlockHash};
     use graph::constraint_violation;
     use graph::data::store::scalar::Bytes;
-    use graph::prelude::ethabi::ethereum_types::H160;
     use graph::prelude::transaction_receipt::LightTransactionReceipt;
+    use graph::prelude::web3::types::H160;
     use graph::prelude::web3::types::H256;
     use graph::prelude::{
         serde_json as json, BlockNumber, BlockPtr, CachedEthereumCall, Error, StoreError,

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -19,3 +19,4 @@ prost-types = { workspace = true }
 [dev-dependencies]
 hex = "0.4.3"
 pretty_assertions = "1.4.0"
+serde_json = { workspace = true }

--- a/store/test-store/tests/postgres/store.rs
+++ b/store/test-store/tests/postgres/store.rs
@@ -23,7 +23,6 @@ use graph::{
         BlockStore as _, EntityFilter, EntityOrder, EntityQuery, StatusStore,
         SubscriptionManager as _,
     },
-    prelude::ethabi::Contract,
 };
 use graph::{data::store::scalar, semver::Version};
 use graph::{entity, prelude::*};
@@ -1158,19 +1157,18 @@ fn mock_data_source() -> graph_chain_ethereum::DataSource {
 fn mock_abi() -> MappingABI {
     MappingABI {
         name: "mock_abi".to_string(),
-        contract: Contract::load(
+        contract: serde_json::from_str(
             r#"[
-            {
-                "inputs": [
-                    {
-                        "name": "a",
-                        "type": "address"
-                    }
-                ],
-                "type": "constructor"
-            }
-        ]"#
-            .as_bytes(),
+                {
+                    "inputs": [
+                        {
+                            "name": "a",
+                            "type": "address"
+                        }
+                    ],
+                    "type": "constructor"
+                }
+            ]"#,
         )
         .unwrap(),
     }

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -34,8 +34,8 @@ use graph::http_body_util::Full;
 use graph::hyper::body::Bytes;
 use graph::hyper::Request;
 use graph::ipfs::IpfsClient;
-use graph::prelude::ethabi::ethereum_types::H256;
 use graph::prelude::serde_json::{self, json};
+use graph::prelude::web3::types::H256;
 use graph::prelude::{
     async_trait, lazy_static, q, r, ApiVersion, BigInt, BlockNumber, DeploymentHash,
     GraphQlRunner as _, IpfsResolver, LoggerFactory, NodeId, QueryError,

--- a/tests/tests/runner_tests.rs
+++ b/tests/tests/runner_tests.rs
@@ -16,8 +16,8 @@ use graph::env::EnvVars;
 use graph::ipfs;
 use graph::ipfs::test_utils::add_files_to_local_ipfs_node_for_testing;
 use graph::object;
-use graph::prelude::ethabi::ethereum_types::H256;
 use graph::prelude::web3::types::Address;
+use graph::prelude::web3::types::H256;
 use graph::prelude::{
     hex, CheapClone, DeploymentHash, SubgraphAssignmentProvider, SubgraphName, SubgraphStore,
 };


### PR DESCRIPTION
This PR removes the deprecated [`ethabi`](https://crates.io/crates/ethabi) dependency and migrates the codebase to [`alloy`](https://crates.io/crates/alloy).

Closes #5669

#### ⚠️ Requires attention:

The [`ethabi::Token`](https://docs.rs/ethabi/latest/ethabi/enum.Token.html) enum has fewer variants than [`alloy_dyn_abi::DynSolValue`](https://docs.rs/alloy-dyn-abi/latest/alloy_dyn_abi/enum.DynSolValue.html), so the [EthereumValueKind](https://github.com/graphprotocol/graph-node/blob/b9e1c5f6010d2ecfca0c052a058ca356c6ca49bc/runtime/wasm/src/asc_abi/class.rs#L512) enum was extended to support function pointer kind.

### Todos

- [x] Make sure all tests pass
- [ ] Make sure that the existing functionality has not been changed in any way