### PR TITLE
Subgraph composition : TriggersAdapter wrapper

### DIFF
--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -1109,6 +1109,13 @@ pub trait EthereumAdapter: Send + Sync + 'static {
         block_hash: H256,
     ) -> Box<dyn Future<Item = LightEthereumBlock, Error = Error> + Send>;
 
+    async fn load_blocks_by_numbers(
+        &self,
+        _logger: Logger,
+        _chain_store: Arc<dyn ChainStore>,
+        _block_numbers: HashSet<BlockNumber>,
+    ) -> Box<dyn Stream<Item = Arc<LightEthereumBlock>, Error = Error> + Send>;
+
     /// Load Ethereum blocks in bulk, returning results as they come back as a Stream.
     /// May use the `chain_store` as a cache.
     async fn load_blocks(

--- a/chain/ethereum/src/tests.rs
+++ b/chain/ethereum/src/tests.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use graph::{
-    blockchain::{block_stream::BlockWithTriggers, BlockPtr},
+    blockchain::{block_stream::BlockWithTriggers, BlockPtr, Trigger},
     prelude::{
         web3::types::{Address, Bytes, Log, H160, H256, U64},
         EthereumCall, LightEthereumBlock,
@@ -107,10 +107,12 @@ fn test_trigger_ordering() {
         &logger,
     );
 
-    assert_eq!(
-        block_with_triggers.trigger_data,
-        vec![log1, log2, call1, log3, call2, call4, call3, block2, block1]
-    );
+    let expected = vec![log1, log2, call1, log3, call2, call4, call3, block2, block1]
+        .into_iter()
+        .map(|t| Trigger::Chain(t))
+        .collect::<Vec<_>>();
+
+    assert_eq!(block_with_triggers.trigger_data, expected);
 }
 
 #[test]
@@ -203,8 +205,10 @@ fn test_trigger_dedup() {
         &logger,
     );
 
-    assert_eq!(
-        block_with_triggers.trigger_data,
-        vec![log1, log2, call1, log3, call2, call3, block2, block1]
-    );
+    let expected = vec![log1, log2, call1, log3, call2, call3, block2, block1]
+        .into_iter()
+        .map(|t| Trigger::Chain(t))
+        .collect::<Vec<_>>();
+
+    assert_eq!(block_with_triggers.trigger_data, expected);
 }

--- a/chain/substreams/src/block_stream.rs
+++ b/chain/substreams/src/block_stream.rs
@@ -7,11 +7,11 @@ use graph::{
             BlockStream, BlockStreamBuilder as BlockStreamBuilderTrait, FirehoseCursor,
         },
         substreams_block_stream::SubstreamsBlockStream,
-        Blockchain,
+        Blockchain, TriggerFilterWrapper,
     },
-    components::store::DeploymentLocator,
+    components::store::{DeploymentLocator, ReadStore},
     data::subgraph::UnifiedMappingApiVersion,
-    prelude::{async_trait, BlockNumber, BlockPtr},
+    prelude::{async_trait, BlockNumber, BlockPtr, DeploymentHash},
     schema::InputSchema,
     slog::o,
 };
@@ -104,8 +104,9 @@ impl BlockStreamBuilderTrait<Chain> for BlockStreamBuilder {
         _chain: &Chain,
         _deployment: DeploymentLocator,
         _start_blocks: Vec<BlockNumber>,
+        _source_subgraph_stores: Vec<(DeploymentHash, Arc<dyn ReadStore>)>,
         _subgraph_current_block: Option<BlockPtr>,
-        _filter: Arc<TriggerFilter>,
+        _filter: Arc<TriggerFilterWrapper<Chain>>,
         _unified_api_version: UnifiedMappingApiVersion,
     ) -> Result<Box<dyn BlockStream<Chain>>> {
         unimplemented!("polling block stream is not support for substreams")

--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -16,7 +16,7 @@ use graph::{
 };
 use graph_runtime_wasm::module::ToAscPtr;
 use lazy_static::__Deref;
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use crate::{Block, Chain, NoopDataSourceTemplate, ParsedChanges};
 
@@ -133,6 +133,18 @@ impl blockchain::TriggersAdapter<Chain> for TriggersAdapter {
         _offset: BlockNumber,
         _root: Option<BlockHash>,
     ) -> Result<Option<Block>, Error> {
+        unimplemented!()
+    }
+
+    async fn load_blocks_by_numbers(
+        &self,
+        _logger: Logger,
+        _block_numbers: HashSet<BlockNumber>,
+    ) -> Result<Vec<Block>, Error> {
+        unimplemented!()
+    }
+
+    async fn chain_head_ptr(&self) -> Result<Option<BlockPtr>, Error> {
         unimplemented!()
     }
 

--- a/core/src/subgraph/context/instance/hosts.rs
+++ b/core/src/subgraph/context/instance/hosts.rs
@@ -57,7 +57,7 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> OnchainHosts<C, T> {
     }
 
     pub fn push(&mut self, host: Arc<T::Host>) {
-        assert!(host.data_source().as_onchain().is_some());
+        assert!(host.data_source().is_chain_based());
 
         self.hosts.push(host.cheap_clone());
         let idx = self.hosts.len() - 1;

--- a/core/src/subgraph/context/mod.rs
+++ b/core/src/subgraph/context/mod.rs
@@ -6,7 +6,7 @@ use crate::polling_monitor::{
 use anyhow::{self, Error};
 use bytes::Bytes;
 use graph::{
-    blockchain::{BlockTime, Blockchain},
+    blockchain::{BlockTime, Blockchain, TriggerFilterWrapper},
     components::{
         store::{DeploymentId, SubgraphFork},
         subgraph::{HostMetrics, MappingError, RuntimeHost as _, SharedProofOfIndexing},
@@ -77,7 +77,7 @@ where
     pub(crate) instance: SubgraphInstance<C, T>,
     pub instances: SubgraphKeepAlive,
     pub offchain_monitor: OffchainMonitor,
-    pub filter: Option<C::TriggerFilter>,
+    pub filter: Option<TriggerFilterWrapper<C>>,
     pub(crate) trigger_processor: Box<dyn TriggerProcessor<C, T>>,
     pub(crate) decoder: Box<Decoder<C, T>>,
 }

--- a/core/src/subgraph/inputs.rs
+++ b/core/src/subgraph/inputs.rs
@@ -1,12 +1,12 @@
 use graph::{
-    blockchain::{Blockchain, TriggersAdapter},
+    blockchain::{block_stream::TriggersAdapterWrapper, Blockchain},
     components::{
-        store::{DeploymentLocator, SubgraphFork, WritableStore},
+        store::{DeploymentLocator, ReadStore, SubgraphFork, WritableStore},
         subgraph::ProofOfIndexingVersion,
     },
     data::subgraph::{SubgraphFeature, UnifiedMappingApiVersion},
     data_source::DataSourceTemplate,
-    prelude::BlockNumber,
+    prelude::{BlockNumber, DeploymentHash},
 };
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -16,11 +16,12 @@ pub struct IndexingInputs<C: Blockchain> {
     pub features: BTreeSet<SubgraphFeature>,
     pub start_blocks: Vec<BlockNumber>,
     pub end_blocks: BTreeSet<BlockNumber>,
+    pub source_subgraph_stores: Vec<(DeploymentHash, Arc<dyn ReadStore>)>,
     pub stop_block: Option<BlockNumber>,
     pub max_end_block: Option<BlockNumber>,
     pub store: Arc<dyn WritableStore>,
     pub debug_fork: Option<Arc<dyn SubgraphFork>>,
-    pub triggers_adapter: Arc<dyn TriggersAdapter<C>>,
+    pub triggers_adapter: Arc<TriggersAdapterWrapper<C>>,
     pub chain: Arc<C>,
     pub templates: Arc<Vec<DataSourceTemplate<C>>>,
     pub unified_api_version: UnifiedMappingApiVersion,
@@ -40,6 +41,7 @@ impl<C: Blockchain> IndexingInputs<C> {
             features,
             start_blocks,
             end_blocks,
+            source_subgraph_stores,
             stop_block,
             max_end_block,
             store: _,
@@ -58,6 +60,7 @@ impl<C: Blockchain> IndexingInputs<C> {
             features: features.clone(),
             start_blocks: start_blocks.clone(),
             end_blocks: end_blocks.clone(),
+            source_subgraph_stores: source_subgraph_stores.clone(),
             stop_block: stop_block.clone(),
             max_end_block: max_end_block.clone(),
             store,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -611,7 +611,6 @@ async fn create_subgraph_version<C: Blockchain, S: SubgraphStore>(
     )
     .map_err(SubgraphRegistrarError::ResolveError)
     .await?;
-
     // Determine if the graft_base should be validated.
     // Validate the graft_base if there is a pending graft, ensuring its presence.
     // If the subgraph is new (indicated by DeploymentNotFound), the graft_base should be validated.

--- a/core/src/subgraph/stream.rs
+++ b/core/src/subgraph/stream.rs
@@ -1,13 +1,13 @@
 use crate::subgraph::inputs::IndexingInputs;
 use anyhow::bail;
 use graph::blockchain::block_stream::{BlockStream, BufferedBlockStream};
-use graph::blockchain::Blockchain;
+use graph::blockchain::{Blockchain, TriggerFilterWrapper};
 use graph::prelude::{CheapClone, Error, SubgraphInstanceMetrics};
 use std::sync::Arc;
 
 pub async fn new_block_stream<C: Blockchain>(
     inputs: &IndexingInputs<C>,
-    filter: &C::TriggerFilter,
+    filter: TriggerFilterWrapper<C>,
     metrics: &SubgraphInstanceMetrics,
 ) -> Result<Box<dyn BlockStream<C>>, Error> {
     let is_firehose = inputs.chain.chain_client().is_firehose();
@@ -18,6 +18,7 @@ pub async fn new_block_stream<C: Blockchain>(
             inputs.deployment.clone(),
             inputs.store.cheap_clone(),
             inputs.start_blocks.clone(),
+            inputs.source_subgraph_stores.clone(),
             Arc::new(filter.clone()),
             inputs.unified_api_version.clone(),
         )

--- a/graph/src/blockchain/polling_block_stream.rs
+++ b/graph/src/blockchain/polling_block_stream.rs
@@ -9,9 +9,9 @@ use std::time::Duration;
 
 use super::block_stream::{
     BlockStream, BlockStreamError, BlockStreamEvent, BlockWithTriggers, ChainHeadUpdateStream,
-    FirehoseCursor, TriggersAdapter, BUFFERED_BLOCK_STREAM_SIZE,
+    FirehoseCursor, TriggersAdapterWrapper, BUFFERED_BLOCK_STREAM_SIZE,
 };
-use super::{Block, BlockPtr, Blockchain};
+use super::{Block, BlockPtr, Blockchain, TriggerFilterWrapper};
 
 use crate::components::store::BlockNumber;
 use crate::data::subgraph::UnifiedMappingApiVersion;
@@ -79,13 +79,13 @@ where
     C: Blockchain,
 {
     chain_store: Arc<dyn ChainStore>,
-    adapter: Arc<dyn TriggersAdapter<C>>,
+    adapter: Arc<TriggersAdapterWrapper<C>>,
     node_id: NodeId,
     subgraph_id: DeploymentHash,
     // This is not really a block number, but the (unsigned) difference
     // between two block numbers
     reorg_threshold: BlockNumber,
-    filter: Arc<C::TriggerFilter>,
+    filter: Arc<TriggerFilterWrapper<C>>,
     start_blocks: Vec<BlockNumber>,
     logger: Logger,
     previous_triggers_per_block: f64,
@@ -146,10 +146,10 @@ where
     pub fn new(
         chain_store: Arc<dyn ChainStore>,
         chain_head_update_stream: ChainHeadUpdateStream,
-        adapter: Arc<dyn TriggersAdapter<C>>,
+        adapter: Arc<TriggersAdapterWrapper<C>>,
         node_id: NodeId,
         subgraph_id: DeploymentHash,
-        filter: Arc<C::TriggerFilter>,
+        filter: Arc<TriggerFilterWrapper<C>>,
         start_blocks: Vec<BlockNumber>,
         reorg_threshold: BlockNumber,
         logger: Logger,
@@ -218,7 +218,7 @@ where
         let max_block_range_size = self.max_block_range_size;
 
         // Get pointers from database for comparison
-        let head_ptr_opt = ctx.chain_store.chain_head_ptr().await?;
+        let head_ptr_opt = ctx.adapter.chain_head_ptr().await?;
         let subgraph_ptr = self.current_block.clone();
 
         // If chain head ptr is not set yet
@@ -469,7 +469,11 @@ where
                         // Note that head_ancestor is a child of subgraph_ptr.
                         let block = self
                             .adapter
-                            .triggers_in_block(&self.logger, head_ancestor, &self.filter)
+                            .triggers_in_block(
+                                &self.logger,
+                                head_ancestor,
+                                &self.filter.chain_filter.clone(),
+                            )
                             .await?;
                         Ok(ReconciliationStep::ProcessDescendantBlocks(vec![block], 1))
                     } else {

--- a/graph/src/blockchain/types.rs
+++ b/graph/src/blockchain/types.rs
@@ -31,6 +31,10 @@ impl BlockHash {
         &self.0
     }
 
+    pub fn as_h256(&self) -> H256 {
+        H256::from_slice(self.as_slice())
+    }
+
     /// Encodes the block hash into a hexadecimal string **without** a "0x"
     /// prefix. Hashes are stored in the database in this format when the
     /// schema uses `text` columns, which is a legacy and such columns

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -185,6 +185,13 @@ pub trait SubgraphStore: Send + Sync + 'static {
         manifest_idx_and_name: Arc<Vec<(u32, String)>>,
     ) -> Result<Arc<dyn WritableStore>, StoreError>;
 
+    async fn readable(
+        self: Arc<Self>,
+        logger: Logger,
+        deployment: DeploymentId,
+        manifest_idx_and_name: Arc<Vec<(u32, String)>>,
+    ) -> Result<Arc<dyn ReadStore>, StoreError>;
+
     /// Initiate a graceful shutdown of the writable that a previous call to
     /// `writable` might have started
     async fn stop_subgraph(&self, deployment: &DeploymentLocator) -> Result<(), StoreError>;

--- a/graph/src/components/subgraph/instance.rs
+++ b/graph/src/components/subgraph/instance.rs
@@ -20,6 +20,7 @@ impl<C: Blockchain> From<&DataSourceTemplate<C>> for InstanceDSTemplate {
         match value {
             DataSourceTemplate::Onchain(ds) => Self::Onchain(ds.info()),
             DataSourceTemplate::Offchain(ds) => Self::Offchain(ds.clone()),
+            DataSourceTemplate::Subgraph(_) => todo!(), // TODO(krishna)
         }
     }
 }

--- a/graph/src/components/subgraph/proof_of_indexing/online.rs
+++ b/graph/src/components/subgraph/proof_of_indexing/online.rs
@@ -146,8 +146,8 @@ impl BlockEventStream {
     fn write(&mut self, event: &ProofOfIndexingEvent<'_>) {
         let children = &[
             1,                // kvp -> v
-            0,                // PoICausalityRegion.blocks: Vec<Block>
-            self.block_index, // Vec<Block> -> [i]
+            0,                // PoICausalityRegion.blocks: Result<Vec<Block>>
+            self.block_index, // Result<Vec<Block>> -> [i]
             0,                // Block.events -> Vec<ProofOfIndexingEvent>
             self.vec_length,
         ];

--- a/graph/src/data/subgraph/api_version.rs
+++ b/graph/src/data/subgraph/api_version.rs
@@ -54,6 +54,9 @@ pub const SPEC_VERSION_1_1_0: Version = Version::new(1, 1, 0);
 // Enables eth call declarations and indexed arguments(topics) filtering in manifest
 pub const SPEC_VERSION_1_2_0: Version = Version::new(1, 2, 0);
 
+// Enables subgraphs as datasource
+pub const SPEC_VERSION_1_3_0: Version = Version::new(1, 3, 0);
+
 // The latest spec version available
 pub const LATEST_VERSION: &Version = &SPEC_VERSION_1_2_0;
 

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -33,7 +33,7 @@ use web3::types::Address;
 
 use crate::{
     bail,
-    blockchain::{BlockPtr, Blockchain, DataSource as _},
+    blockchain::{BlockPtr, Blockchain},
     components::{
         link_resolver::LinkResolver,
         store::{StoreError, SubgraphStore},
@@ -139,6 +139,10 @@ impl DeploymentHash {
         Link {
             link: format!("/ipfs/{}", self),
         }
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.as_bytes().to_vec()
     }
 }
 
@@ -713,7 +717,7 @@ impl<C: Blockchain> UnvalidatedSubgraphManifest<C> {
             .0
             .data_sources
             .iter()
-            .filter_map(|d| Some(d.as_onchain()?.network()?.to_string()))
+            .filter_map(|d| Some(d.network()?.to_string()))
             .collect::<Vec<String>>();
         networks.sort();
         networks.dedup();
@@ -759,11 +763,9 @@ impl<C: Blockchain> SubgraphManifest<C> {
         max_spec_version: semver::Version,
     ) -> Result<Self, SubgraphManifestResolveError> {
         let unresolved = UnresolvedSubgraphManifest::parse(id, raw)?;
-
         let resolved = unresolved
             .resolve(resolver, logger, max_spec_version)
             .await?;
-
         Ok(resolved)
     }
 
@@ -771,14 +773,14 @@ impl<C: Blockchain> SubgraphManifest<C> {
         // Assume the manifest has been validated, ensuring network names are homogenous
         self.data_sources
             .iter()
-            .find_map(|d| Some(d.as_onchain()?.network()?.to_string()))
+            .find_map(|d| Some(d.network()?.to_string()))
             .expect("Validated manifest does not have a network defined on any datasource")
     }
 
     pub fn start_blocks(&self) -> Vec<BlockNumber> {
         self.data_sources
             .iter()
-            .filter_map(|d| Some(d.as_onchain()?.start_block()))
+            .filter_map(|d| d.start_block())
             .collect()
     }
 

--- a/graph/src/data_source/mod.rs
+++ b/graph/src/data_source/mod.rs
@@ -1,6 +1,8 @@
 pub mod causality_region;
 pub mod offchain;
+pub mod subgraph;
 
+pub use self::DataSource as DataSourceEnum;
 pub use causality_region::CausalityRegion;
 
 #[cfg(test)]
@@ -17,6 +19,7 @@ use crate::{
         store::{BlockNumber, StoredDynamicDataSource},
     },
     data_source::offchain::OFFCHAIN_KINDS,
+    data_source::subgraph::SUBGRAPH_DS_KIND,
     prelude::{CheapClone as _, DataSourceContext},
     schema::{EntityType, InputSchema},
 };
@@ -35,6 +38,7 @@ use thiserror::Error;
 pub enum DataSource<C: Blockchain> {
     Onchain(C::DataSource),
     Offchain(offchain::DataSource),
+    Subgraph(subgraph::DataSource),
 }
 
 #[derive(Error, Debug)]
@@ -89,6 +93,23 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(ds) => Some(ds),
             Self::Offchain(_) => None,
+            Self::Subgraph(_) => None,
+        }
+    }
+
+    pub fn as_subgraph(&self) -> Option<&subgraph::DataSource> {
+        match self {
+            Self::Onchain(_) => None,
+            Self::Offchain(_) => None,
+            Self::Subgraph(ds) => Some(ds),
+        }
+    }
+
+    pub fn is_chain_based(&self) -> bool {
+        match self {
+            Self::Onchain(_) => true,
+            Self::Offchain(_) => false,
+            Self::Subgraph(_) => true,
         }
     }
 
@@ -96,6 +117,23 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(_) => None,
             Self::Offchain(ds) => Some(ds),
+            Self::Subgraph(_) => None,
+        }
+    }
+
+    pub fn network(&self) -> Option<&str> {
+        match self {
+            DataSourceEnum::Onchain(ds) => ds.network(),
+            DataSourceEnum::Offchain(_) => None,
+            DataSourceEnum::Subgraph(ds) => ds.network(),
+        }
+    }
+
+    pub fn start_block(&self) -> Option<BlockNumber> {
+        match self {
+            DataSourceEnum::Onchain(ds) => Some(ds.start_block()),
+            DataSourceEnum::Offchain(_) => None,
+            DataSourceEnum::Subgraph(ds) => Some(ds.source.start_block),
         }
     }
 
@@ -111,6 +149,7 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(ds) => ds.address().map(ToOwned::to_owned),
             Self::Offchain(ds) => ds.address(),
+            Self::Subgraph(ds) => ds.address(),
         }
     }
 
@@ -118,6 +157,7 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(ds) => ds.name(),
             Self::Offchain(ds) => &ds.name,
+            Self::Subgraph(ds) => &ds.name,
         }
     }
 
@@ -125,6 +165,7 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(ds) => ds.kind().to_owned(),
             Self::Offchain(ds) => ds.kind.to_string(),
+            Self::Subgraph(ds) => ds.kind.clone(),
         }
     }
 
@@ -132,6 +173,7 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(ds) => ds.min_spec_version(),
             Self::Offchain(ds) => ds.min_spec_version(),
+            Self::Subgraph(ds) => ds.min_spec_version(),
         }
     }
 
@@ -139,6 +181,7 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(ds) => ds.end_block(),
             Self::Offchain(_) => None,
+            Self::Subgraph(_) => None,
         }
     }
 
@@ -146,6 +189,7 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(ds) => ds.creation_block(),
             Self::Offchain(ds) => ds.creation_block,
+            Self::Subgraph(ds) => ds.creation_block,
         }
     }
 
@@ -153,6 +197,7 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(ds) => ds.context(),
             Self::Offchain(ds) => ds.context.clone(),
+            Self::Subgraph(ds) => ds.context.clone(),
         }
     }
 
@@ -160,6 +205,7 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(ds) => ds.api_version(),
             Self::Offchain(ds) => ds.mapping.api_version.clone(),
+            Self::Subgraph(ds) => ds.mapping.api_version.clone(),
         }
     }
 
@@ -167,6 +213,7 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(ds) => ds.runtime(),
             Self::Offchain(ds) => Some(ds.mapping.runtime.cheap_clone()),
+            Self::Subgraph(ds) => Some(ds.mapping.runtime.cheap_clone()),
         }
     }
 
@@ -176,6 +223,7 @@ impl<C: Blockchain> DataSource<C> {
             // been enforced.
             Self::Onchain(_) => EntityTypeAccess::Any,
             Self::Offchain(ds) => EntityTypeAccess::Restriced(ds.mapping.entities.clone()),
+            Self::Subgraph(_) => EntityTypeAccess::Any,
         }
     }
 
@@ -183,6 +231,7 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(ds) => ds.handler_kinds(),
             Self::Offchain(ds) => vec![ds.handler_kind()].into_iter().collect(),
+            Self::Subgraph(ds) => vec![ds.handler_kind()].into_iter().collect(),
         }
     }
 
@@ -190,6 +239,7 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(ds) => ds.has_declared_calls(),
             Self::Offchain(_) => false,
+            Self::Subgraph(_) => false,
         }
     }
 
@@ -207,8 +257,15 @@ impl<C: Blockchain> DataSource<C> {
             (Self::Offchain(ds), TriggerData::Offchain(trigger)) => {
                 Ok(ds.match_and_decode(trigger))
             }
+            (Self::Subgraph(ds), TriggerData::Subgraph(trigger)) => {
+                Ok(ds.match_and_decode(block, trigger))
+            }
             (Self::Onchain(_), TriggerData::Offchain(_))
-            | (Self::Offchain(_), TriggerData::Onchain(_)) => Ok(None),
+            | (Self::Offchain(_), TriggerData::Onchain(_))
+            | (Self::Onchain(_), TriggerData::Subgraph(_))
+            | (Self::Offchain(_), TriggerData::Subgraph(_))
+            | (Self::Subgraph(_), TriggerData::Onchain(_))
+            | (Self::Subgraph(_), TriggerData::Offchain(_)) => Ok(None),
         }
     }
 
@@ -224,6 +281,7 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(ds) => ds.as_stored_dynamic_data_source(),
             Self::Offchain(ds) => ds.as_stored_dynamic_data_source(),
+            Self::Subgraph(_) => todo!(), // TODO(krishna)
         }
     }
 
@@ -240,6 +298,7 @@ impl<C: Blockchain> DataSource<C> {
                 offchain::DataSource::from_stored_dynamic_data_source(template, stored)
                     .map(DataSource::Offchain)
             }
+            DataSourceTemplate::Subgraph(_) => todo!(), // TODO(krishna)
         }
     }
 
@@ -247,6 +306,7 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(ds) => ds.validate(spec_version),
             Self::Offchain(_) => vec![],
+            Self::Subgraph(_) => vec![], // TODO(krishna)
         }
     }
 
@@ -254,6 +314,7 @@ impl<C: Blockchain> DataSource<C> {
         match self {
             Self::Onchain(_) => CausalityRegion::ONCHAIN,
             Self::Offchain(ds) => ds.causality_region,
+            Self::Subgraph(_) => CausalityRegion::ONCHAIN,
         }
     }
 }
@@ -262,6 +323,7 @@ impl<C: Blockchain> DataSource<C> {
 pub enum UnresolvedDataSource<C: Blockchain> {
     Onchain(C::UnresolvedDataSource),
     Offchain(offchain::UnresolvedDataSource),
+    Subgraph(subgraph::UnresolvedDataSource),
 }
 
 impl<C: Blockchain> UnresolvedDataSource<C> {
@@ -276,6 +338,10 @@ impl<C: Blockchain> UnresolvedDataSource<C> {
                 .resolve(resolver, logger, manifest_idx)
                 .await
                 .map(DataSource::Onchain),
+            Self::Subgraph(unresolved) => unresolved
+                .resolve(resolver, logger, manifest_idx)
+                .await
+                .map(DataSource::Subgraph),
             Self::Offchain(_unresolved) => {
                 anyhow::bail!(
                     "static file data sources are not yet supported, \\
@@ -299,6 +365,7 @@ pub struct DataSourceTemplateInfo {
 pub enum DataSourceTemplate<C: Blockchain> {
     Onchain(C::DataSourceTemplate),
     Offchain(offchain::DataSourceTemplate),
+    Subgraph(subgraph::DataSourceTemplate),
 }
 
 impl<C: Blockchain> DataSourceTemplate<C> {
@@ -306,6 +373,7 @@ impl<C: Blockchain> DataSourceTemplate<C> {
         match self {
             DataSourceTemplate::Onchain(template) => template.info(),
             DataSourceTemplate::Offchain(template) => template.clone().into(),
+            DataSourceTemplate::Subgraph(template) => template.clone().into(),
         }
     }
 
@@ -313,6 +381,7 @@ impl<C: Blockchain> DataSourceTemplate<C> {
         match self {
             Self::Onchain(ds) => Some(ds),
             Self::Offchain(_) => None,
+            Self::Subgraph(_) => todo!(), // TODO(krishna)
         }
     }
 
@@ -320,6 +389,7 @@ impl<C: Blockchain> DataSourceTemplate<C> {
         match self {
             Self::Onchain(_) => None,
             Self::Offchain(t) => Some(t),
+            Self::Subgraph(_) => todo!(), // TODO(krishna)
         }
     }
 
@@ -327,6 +397,7 @@ impl<C: Blockchain> DataSourceTemplate<C> {
         match self {
             Self::Onchain(ds) => Some(ds),
             Self::Offchain(_) => None,
+            Self::Subgraph(_) => todo!(), // TODO(krishna)
         }
     }
 
@@ -334,6 +405,7 @@ impl<C: Blockchain> DataSourceTemplate<C> {
         match self {
             Self::Onchain(ds) => &ds.name(),
             Self::Offchain(ds) => &ds.name,
+            Self::Subgraph(ds) => &ds.name,
         }
     }
 
@@ -341,6 +413,7 @@ impl<C: Blockchain> DataSourceTemplate<C> {
         match self {
             Self::Onchain(ds) => ds.api_version(),
             Self::Offchain(ds) => ds.mapping.api_version.clone(),
+            Self::Subgraph(ds) => ds.mapping.api_version.clone(),
         }
     }
 
@@ -348,6 +421,7 @@ impl<C: Blockchain> DataSourceTemplate<C> {
         match self {
             Self::Onchain(ds) => ds.runtime(),
             Self::Offchain(ds) => Some(ds.mapping.runtime.clone()),
+            Self::Subgraph(ds) => Some(ds.mapping.runtime.clone()),
         }
     }
 
@@ -355,6 +429,7 @@ impl<C: Blockchain> DataSourceTemplate<C> {
         match self {
             Self::Onchain(ds) => ds.manifest_idx(),
             Self::Offchain(ds) => ds.manifest_idx,
+            Self::Subgraph(ds) => ds.manifest_idx,
         }
     }
 
@@ -362,6 +437,7 @@ impl<C: Blockchain> DataSourceTemplate<C> {
         match self {
             Self::Onchain(ds) => ds.kind().to_string(),
             Self::Offchain(ds) => ds.kind.to_string(),
+            Self::Subgraph(ds) => ds.kind.clone(),
         }
     }
 }
@@ -370,6 +446,7 @@ impl<C: Blockchain> DataSourceTemplate<C> {
 pub enum UnresolvedDataSourceTemplate<C: Blockchain> {
     Onchain(C::UnresolvedDataSourceTemplate),
     Offchain(offchain::UnresolvedDataSourceTemplate),
+    Subgraph(subgraph::UnresolvedDataSourceTemplate),
 }
 
 impl<C: Blockchain> Default for UnresolvedDataSourceTemplate<C> {
@@ -395,6 +472,10 @@ impl<C: Blockchain> UnresolvedDataSourceTemplate<C> {
                 .resolve(resolver, logger, manifest_idx, schema)
                 .await
                 .map(DataSourceTemplate::Offchain),
+            Self::Subgraph(ds) => ds
+                .resolve(resolver, logger, manifest_idx)
+                .await
+                .map(DataSourceTemplate::Subgraph),
         }
     }
 }
@@ -475,6 +556,7 @@ impl<T> TriggerWithHandler<T> {
 pub enum TriggerData<C: Blockchain> {
     Onchain(C::TriggerData),
     Offchain(offchain::TriggerData),
+    Subgraph(subgraph::TriggerData),
 }
 
 impl<C: Blockchain> TriggerData<C> {
@@ -482,6 +564,7 @@ impl<C: Blockchain> TriggerData<C> {
         match self {
             Self::Onchain(trigger) => trigger.error_context(),
             Self::Offchain(trigger) => format!("{:?}", trigger.source),
+            Self::Subgraph(trigger) => format!("{:?}", trigger.source),
         }
     }
 }
@@ -490,6 +573,7 @@ impl<C: Blockchain> TriggerData<C> {
 pub enum MappingTrigger<C: Blockchain> {
     Onchain(C::MappingTrigger),
     Offchain(offchain::TriggerData),
+    Subgraph(subgraph::TriggerData),
 }
 
 impl<C: Blockchain> MappingTrigger<C> {
@@ -497,6 +581,7 @@ impl<C: Blockchain> MappingTrigger<C> {
         match self {
             Self::Onchain(trigger) => Some(trigger.error_context()),
             Self::Offchain(_) => None, // TODO: Add error context for offchain triggers
+            Self::Subgraph(_) => None, // TODO(krishna)
         }
     }
 
@@ -504,6 +589,7 @@ impl<C: Blockchain> MappingTrigger<C> {
         match self {
             Self::Onchain(trigger) => Some(trigger),
             Self::Offchain(_) => None,
+            Self::Subgraph(_) => None, // TODO(krishna)
         }
     }
 }
@@ -515,6 +601,7 @@ macro_rules! clone_data_source {
                 match self {
                     Self::Onchain(ds) => Self::Onchain(ds.clone()),
                     Self::Offchain(ds) => Self::Offchain(ds.clone()),
+                    Self::Subgraph(ds) => Self::Subgraph(ds.clone()),
                 }
             }
         }
@@ -541,6 +628,10 @@ macro_rules! deserialize_data_source {
                     offchain::$t::deserialize(map.into_deserializer())
                         .map_err(serde::de::Error::custom)
                         .map($t::Offchain)
+                } else if SUBGRAPH_DS_KIND == kind {
+                    subgraph::$t::deserialize(map.into_deserializer())
+                        .map_err(serde::de::Error::custom)
+                        .map($t::Subgraph)
                 } else if (&C::KIND.to_string() == kind) || C::ALIASES.contains(&kind) {
                     C::$t::deserialize(map.into_deserializer())
                         .map_err(serde::de::Error::custom)

--- a/graph/src/data_source/subgraph.rs
+++ b/graph/src/data_source/subgraph.rs
@@ -1,0 +1,305 @@
+use crate::{
+    blockchain::{Block, Blockchain},
+    components::{
+        link_resolver::LinkResolver,
+        store::{BlockNumber, Entity},
+    },
+    data::{subgraph::SPEC_VERSION_1_3_0, value::Word},
+    data_source,
+    prelude::{DataSourceContext, DeploymentHash, Link},
+};
+use anyhow::{Context, Error};
+use serde::Deserialize;
+use slog::{info, Logger};
+use std::{fmt, sync::Arc};
+
+use super::{DataSourceTemplateInfo, TriggerWithHandler};
+
+pub const SUBGRAPH_DS_KIND: &str = "subgraph";
+
+const ENTITY_HANDLER_KINDS: &str = "entity";
+
+#[derive(Debug, Clone)]
+pub struct DataSource {
+    pub kind: String,
+    pub name: String,
+    pub network: String,
+    pub manifest_idx: u32,
+    pub source: Source,
+    pub mapping: Mapping,
+    pub context: Arc<Option<DataSourceContext>>,
+    pub creation_block: Option<BlockNumber>,
+}
+
+impl DataSource {
+    pub fn new(
+        kind: String,
+        name: String,
+        network: String,
+        manifest_idx: u32,
+        source: Source,
+        mapping: Mapping,
+        context: Arc<Option<DataSourceContext>>,
+        creation_block: Option<BlockNumber>,
+    ) -> Self {
+        Self {
+            kind,
+            name,
+            network,
+            manifest_idx,
+            source,
+            mapping,
+            context,
+            creation_block,
+        }
+    }
+
+    pub fn min_spec_version(&self) -> semver::Version {
+        SPEC_VERSION_1_3_0
+    }
+
+    pub fn handler_kind(&self) -> &str {
+        ENTITY_HANDLER_KINDS
+    }
+
+    pub fn network(&self) -> Option<&str> {
+        Some(&self.network)
+    }
+
+    pub fn match_and_decode<C: Blockchain>(
+        &self,
+        block: &Arc<C::Block>,
+        trigger: &TriggerData,
+    ) -> Option<TriggerWithHandler<super::MappingTrigger<C>>> {
+        if self.source.address != trigger.source {
+            return None;
+        }
+
+        let trigger_ref = self.mapping.handlers.iter().find_map(|handler| {
+            if handler.entity != trigger.entity_type {
+                return None;
+            }
+
+            Some(TriggerWithHandler::new(
+                data_source::MappingTrigger::Subgraph(trigger.clone()),
+                handler.handler.clone(),
+                block.ptr(),
+                block.timestamp(),
+            ))
+        });
+
+        return trigger_ref;
+    }
+
+    pub fn address(&self) -> Option<Vec<u8>> {
+        Some(self.source.address().to_bytes())
+    }
+
+    pub fn source_subgraph(&self) -> DeploymentHash {
+        self.source.address()
+    }
+}
+
+pub type Base64 = Word;
+
+#[derive(Clone, Debug, Default, Hash, Eq, PartialEq, Deserialize)]
+pub struct Source {
+    pub address: DeploymentHash,
+    #[serde(default)]
+    pub start_block: BlockNumber,
+}
+
+impl Source {
+    /// The concept of an address may or not make sense for a subgraph data source, but graph node
+    /// will use this in a few places where some sort of not necessarily unique id is useful:
+    /// 1. This is used as the value to be returned to mappings from the `dataSource.address()` host
+    ///    function, so changing this is a breaking change.
+    /// 2. This is used to match with triggers with hosts in `fn hosts_for_trigger`, so make sure
+    ///    the `source` of the data source is equal the `source` of the `TriggerData`.
+    pub fn address(&self) -> DeploymentHash {
+        self.address.clone()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Mapping {
+    pub language: String,
+    pub api_version: semver::Version,
+    pub entities: Vec<String>,
+    pub handlers: Vec<EntityHandler>,
+    pub runtime: Arc<Vec<u8>>,
+    pub link: Link,
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Deserialize)]
+pub struct EntityHandler {
+    pub handler: String,
+    pub entity: String,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize)]
+pub struct UnresolvedDataSource {
+    pub kind: String,
+    pub name: String,
+    pub network: String,
+    pub source: UnresolvedSource,
+    pub mapping: UnresolvedMapping,
+}
+
+#[derive(Clone, Debug, Default, Hash, Eq, PartialEq, Deserialize)]
+pub struct UnresolvedSource {
+    address: DeploymentHash,
+    #[serde(default)]
+    start_block: BlockNumber,
+}
+
+#[derive(Clone, Debug, Default, Hash, Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnresolvedMapping {
+    pub api_version: String,
+    pub language: String,
+    pub file: Link,
+    pub handlers: Vec<EntityHandler>,
+    pub entities: Vec<String>,
+}
+
+impl UnresolvedDataSource {
+    #[allow(dead_code)]
+    pub(super) async fn resolve(
+        self,
+        resolver: &Arc<dyn LinkResolver>,
+        logger: &Logger,
+        manifest_idx: u32,
+    ) -> Result<DataSource, Error> {
+        info!(logger, "Resolve subgraph data source";
+            "name" => &self.name,
+            "kind" => &self.kind,
+            "source" => format_args!("{:?}", &self.source),
+        );
+
+        let kind = self.kind;
+        let source = Source {
+            address: self.source.address,
+            start_block: self.source.start_block,
+        };
+
+        Ok(DataSource {
+            manifest_idx,
+            kind,
+            name: self.name,
+            network: self.network,
+            source,
+            mapping: self.mapping.resolve(resolver, logger).await?,
+            context: Arc::new(None),
+            creation_block: None,
+        })
+    }
+}
+
+impl UnresolvedMapping {
+    pub async fn resolve(
+        self,
+        resolver: &Arc<dyn LinkResolver>,
+        logger: &Logger,
+    ) -> Result<Mapping, Error> {
+        info!(logger, "Resolve subgraph ds mapping"; "link" => &self.file.link);
+
+        Ok(Mapping {
+            language: self.language,
+            api_version: semver::Version::parse(&self.api_version)?,
+            entities: self.entities,
+            handlers: self.handlers,
+            runtime: Arc::new(resolver.cat(logger, &self.file).await?),
+            link: self.file,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct UnresolvedDataSourceTemplate {
+    pub kind: String,
+    pub network: Option<String>,
+    pub name: String,
+    pub mapping: UnresolvedMapping,
+}
+
+#[derive(Clone, Debug)]
+pub struct DataSourceTemplate {
+    pub kind: String,
+    pub network: Option<String>,
+    pub name: String,
+    pub manifest_idx: u32,
+    pub mapping: Mapping,
+}
+
+impl Into<DataSourceTemplateInfo> for DataSourceTemplate {
+    fn into(self) -> DataSourceTemplateInfo {
+        let DataSourceTemplate {
+            kind,
+            network: _,
+            name,
+            manifest_idx,
+            mapping,
+        } = self;
+
+        DataSourceTemplateInfo {
+            api_version: mapping.api_version.clone(),
+            runtime: Some(mapping.runtime),
+            name,
+            manifest_idx: Some(manifest_idx),
+            kind: kind.to_string(),
+        }
+    }
+}
+
+impl UnresolvedDataSourceTemplate {
+    pub async fn resolve(
+        self,
+        resolver: &Arc<dyn LinkResolver>,
+        logger: &Logger,
+        manifest_idx: u32,
+    ) -> Result<DataSourceTemplate, Error> {
+        let kind = self.kind;
+
+        let mapping = self
+            .mapping
+            .resolve(resolver, logger)
+            .await
+            .with_context(|| format!("failed to resolve data source template {}", self.name))?;
+
+        Ok(DataSourceTemplate {
+            kind,
+            network: self.network,
+            name: self.name,
+            manifest_idx,
+            mapping,
+        })
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct TriggerData {
+    pub source: DeploymentHash,
+    pub entity: Entity,
+    pub entity_type: String,
+}
+
+impl TriggerData {
+    pub fn new(source: DeploymentHash, entity: Entity, entity_type: String) -> Self {
+        Self {
+            source,
+            entity,
+            entity_type,
+        }
+    }
+}
+
+impl fmt::Debug for TriggerData {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "TriggerData {{ source: {:?}, entity: {:?} }}",
+            self.source, self.entity,
+        )
+    }
+}

--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -390,7 +390,7 @@ struct Inner {
         default = "false"
     )]
     allow_non_deterministic_fulltext_search: EnvVarBoolean,
-    #[envconfig(from = "GRAPH_MAX_SPEC_VERSION", default = "1.2.0")]
+    #[envconfig(from = "GRAPH_MAX_SPEC_VERSION", default = "1.3.0")]
     max_spec_version: Version,
     #[envconfig(from = "GRAPH_LOAD_WINDOW_SIZE", default = "300")]
     load_window_size_in_secs: u64,

--- a/runtime/wasm/src/host.rs
+++ b/runtime/wasm/src/host.rs
@@ -366,6 +366,7 @@ impl<C: Blockchain> RuntimeHostTrait<C> for RuntimeHost<C> {
         match self.data_source() {
             DataSource::Onchain(_) => None,
             DataSource::Offchain(ds) => ds.done_at(),
+            DataSource::Subgraph(_) => None,
         }
     }
 
@@ -373,6 +374,7 @@ impl<C: Blockchain> RuntimeHostTrait<C> for RuntimeHost<C> {
         match self.data_source() {
             DataSource::Onchain(_) => {}
             DataSource::Offchain(ds) => ds.set_done_at(block),
+            DataSource::Subgraph(_) => {}
         }
     }
 

--- a/runtime/wasm/src/module/mod.rs
+++ b/runtime/wasm/src/module/mod.rs
@@ -4,6 +4,7 @@ use std::mem::MaybeUninit;
 use anyhow::anyhow;
 use anyhow::Error;
 use graph::blockchain::Blockchain;
+use graph::data_source::subgraph;
 use graph::util::mem::init_slice;
 use semver::Version;
 use wasmtime::AsContext;
@@ -69,6 +70,16 @@ impl ToAscPtr for offchain::TriggerData {
     }
 }
 
+impl ToAscPtr for subgraph::TriggerData {
+    fn to_asc_ptr<H: AscHeap>(
+        self,
+        heap: &mut H,
+        gas: &GasCounter,
+    ) -> Result<AscPtr<()>, HostExportError> {
+        asc_new(heap, &self.entity.sorted_ref(), gas).map(|ptr| ptr.erase())
+    }
+}
+
 impl<C: Blockchain> ToAscPtr for MappingTrigger<C>
 where
     C::MappingTrigger: ToAscPtr,
@@ -81,6 +92,7 @@ where
         match self {
             MappingTrigger::Onchain(trigger) => trigger.to_asc_ptr(heap, gas),
             MappingTrigger::Offchain(trigger) => trigger.to_asc_ptr(heap, gas),
+            MappingTrigger::Subgraph(trigger) => trigger.to_asc_ptr(heap, gas),
         }
     }
 }

--- a/store/test-store/tests/chain/ethereum/manifest.rs
+++ b/store/test-store/tests/chain/ethereum/manifest.rs
@@ -11,10 +11,10 @@ use graph::data::store::Value;
 use graph::data::subgraph::schema::SubgraphError;
 use graph::data::subgraph::{
     Prune, LATEST_VERSION, SPEC_VERSION_0_0_4, SPEC_VERSION_0_0_7, SPEC_VERSION_0_0_8,
-    SPEC_VERSION_0_0_9, SPEC_VERSION_1_0_0, SPEC_VERSION_1_2_0,
+    SPEC_VERSION_0_0_9, SPEC_VERSION_1_0_0, SPEC_VERSION_1_2_0, SPEC_VERSION_1_3_0,
 };
 use graph::data_source::offchain::OffchainDataSourceKind;
-use graph::data_source::DataSourceTemplate;
+use graph::data_source::{DataSourceEnum, DataSourceTemplate};
 use graph::entity;
 use graph::env::ENV_VARS;
 use graph::prelude::web3::types::H256;
@@ -166,8 +166,50 @@ specVersion: 0.0.7
     let data_source = match &manifest.templates[0] {
         DataSourceTemplate::Offchain(ds) => ds,
         DataSourceTemplate::Onchain(_) => unreachable!(),
+        DataSourceTemplate::Subgraph(_) => unreachable!(),
     };
     assert_eq!(data_source.kind, OffchainDataSourceKind::Ipfs);
+}
+
+#[tokio::test]
+async fn subgraph_ds_manifest() {
+    let yaml = "
+schema:
+  file:
+    /: /ipfs/Qmschema
+dataSources:
+  - name: SubgraphSource
+    kind: subgraph
+    entities:
+        - Gravatar
+    network: mainnet
+    source: 
+      address: 'QmUVaWpdKgcxBov1jHEa8dr46d2rkVzfHuZFu4fXJ4sFse'
+      startBlock: 0
+    mapping:
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - TestEntity
+      file:
+        /: /ipfs/Qmmapping
+      handlers:
+        - handler: handleEntity
+          entity: User
+specVersion: 1.3.0
+";
+
+    let manifest = resolve_manifest(yaml, SPEC_VERSION_1_3_0).await;
+
+    assert_eq!("Qmmanifest", manifest.id.as_str());
+    assert_eq!(manifest.data_sources.len(), 1);
+    let data_source = &manifest.data_sources[0];
+    match data_source {
+        DataSourceEnum::Subgraph(ds) => {
+            assert_eq!(ds.name, "SubgraphSource");
+        }
+        _ => panic!("Expected a subgraph data source"),
+    }
 }
 
 #[tokio::test]

--- a/tests/runner-tests/subgraph-data-sources/abis/Contract.abi
+++ b/tests/runner-tests/subgraph-data-sources/abis/Contract.abi
@@ -1,0 +1,15 @@
+[
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "string",
+                "name": "testCommand",
+                "type": "string"
+            }
+        ],
+        "name": "TestEvent",
+        "type": "event"
+    }
+]

--- a/tests/runner-tests/subgraph-data-sources/package.json
+++ b/tests/runner-tests/subgraph-data-sources/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "subgraph-data-sources",
+  "version": "0.1.0",
+  "scripts": {
+    "codegen": "graph codegen --skip-migrations",
+    "create:test": "graph create test/subgraph-data-sources --node $GRAPH_NODE_ADMIN_URI",
+    "deploy:test": "graph deploy test/subgraph-data-sources --version-label v0.0.1 --ipfs $IPFS_URI --node $GRAPH_NODE_ADMIN_URI"
+  },
+  "devDependencies": {
+    "@graphprotocol/graph-cli": "0.79.0-alpha-20240711124603-49edf22",
+    "@graphprotocol/graph-ts": "0.31.0"
+  }
+}

--- a/tests/runner-tests/subgraph-data-sources/schema.graphql
+++ b/tests/runner-tests/subgraph-data-sources/schema.graphql
@@ -1,0 +1,6 @@
+type Data @entity {
+  id: ID!
+  foo: String
+  bar: Int
+  isTest: Boolean
+}

--- a/tests/runner-tests/subgraph-data-sources/src/mapping.ts
+++ b/tests/runner-tests/subgraph-data-sources/src/mapping.ts
@@ -1,0 +1,6 @@
+import { Entity, log } from '@graphprotocol/graph-ts';
+
+export function handleBlock(content: Entity): void {
+  let stringContent = content.getString('val');
+  log.info('Content: {}', [stringContent]);
+}

--- a/tests/runner-tests/subgraph-data-sources/subgraph.yaml
+++ b/tests/runner-tests/subgraph-data-sources/subgraph.yaml
@@ -1,0 +1,19 @@
+specVersion: 1.3.0
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: subgraph
+    name: Contract
+    network: test
+    source:
+      address: 'QmRFXhvyvbm4z5Lo7z2mN9Ckmo623uuB2jJYbRmAXgYKXJ'
+      startBlock: 6082461
+    mapping:
+      apiVersion: 0.0.7
+      language: wasm/assemblyscript
+      entities:
+        - Gravatar
+      handlers:
+        - handler: handleBlock
+          entity: User
+      file: ./src/mapping.ts

--- a/tests/runner-tests/yarn.lock
+++ b/tests/runner-tests/yarn.lock
@@ -349,6 +349,40 @@
     which "2.0.2"
     yaml "1.10.2"
 
+"@graphprotocol/graph-cli@0.79.0-alpha-20240711124603-49edf22":
+  version "0.79.0-alpha-20240711124603-49edf22"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.79.0-alpha-20240711124603-49edf22.tgz#4e3f6201932a0b68ce64d6badd8432cf2bead3c2"
+  integrity sha512-fZrdPiFbbbBVMnvsjfKA+j48WzzquaHQIpozBqnUKRPCV1n1NenIaq2nH16mlMwovRIS7AAIVCpa0QYQuPzw7Q==
+  dependencies:
+    "@float-capital/float-subgraph-uncrashable" "^0.0.0-alpha.4"
+    "@oclif/core" "2.8.6"
+    "@oclif/plugin-autocomplete" "^2.3.6"
+    "@oclif/plugin-not-found" "^2.4.0"
+    "@whatwg-node/fetch" "^0.8.4"
+    assemblyscript "0.19.23"
+    binary-install-raw "0.0.13"
+    chalk "3.0.0"
+    chokidar "3.5.3"
+    debug "4.3.4"
+    docker-compose "0.23.19"
+    dockerode "2.5.8"
+    fs-extra "9.1.0"
+    glob "9.3.5"
+    gluegun "5.1.6"
+    graphql "15.5.0"
+    immutable "4.2.1"
+    ipfs-http-client "55.0.0"
+    jayson "4.0.0"
+    js-yaml "3.14.1"
+    open "8.4.2"
+    prettier "3.0.3"
+    semver "7.4.0"
+    sync-request "6.1.0"
+    tmp-promise "3.0.3"
+    web3-eth-abi "1.7.0"
+    which "2.0.2"
+    yaml "1.10.2"
+
 "@graphprotocol/graph-ts@0.30.0":
   version "0.30.0"
   resolved "https://registry.npmjs.org/@graphprotocol/graph-ts/-/graph-ts-0.30.0.tgz"
@@ -1473,6 +1507,11 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
 delay@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz"
@@ -1544,6 +1583,13 @@ ejs@3.1.6:
   integrity sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==
   dependencies:
     jake "^10.6.1"
+
+ejs@3.1.8:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.8.tgz#758d32910c78047585c7ef1f92f9ee041c1c190b"
+  integrity sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==
+  dependencies:
+    jake "^10.8.5"
 
 ejs@^3.1.8:
   version "3.1.9"
@@ -1996,6 +2042,42 @@ gluegun@5.1.2:
     which "2.0.2"
     yargs-parser "^21.0.0"
 
+gluegun@5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/gluegun/-/gluegun-5.1.6.tgz#74ec13193913dc610f5c1a4039972c70c96a7bad"
+  integrity sha512-9zbi4EQWIVvSOftJWquWzr9gLX2kaDgPkNR5dYWbM53eVvCI3iKuxLlnKoHC0v4uPoq+Kr/+F569tjoFbA4DSA==
+  dependencies:
+    apisauce "^2.1.5"
+    app-module-path "^2.2.0"
+    cli-table3 "0.6.0"
+    colors "1.4.0"
+    cosmiconfig "7.0.1"
+    cross-spawn "7.0.3"
+    ejs "3.1.8"
+    enquirer "2.3.6"
+    execa "5.1.1"
+    fs-jetpack "4.3.1"
+    lodash.camelcase "^4.3.0"
+    lodash.kebabcase "^4.1.1"
+    lodash.lowercase "^4.3.0"
+    lodash.lowerfirst "^4.3.1"
+    lodash.pad "^4.5.1"
+    lodash.padend "^4.6.1"
+    lodash.padstart "^4.6.1"
+    lodash.repeat "^4.1.0"
+    lodash.snakecase "^4.1.1"
+    lodash.startcase "^4.4.0"
+    lodash.trim "^4.5.1"
+    lodash.trimend "^4.5.1"
+    lodash.trimstart "^4.5.1"
+    lodash.uppercase "^4.3.0"
+    lodash.upperfirst "^4.3.1"
+    ora "4.0.2"
+    pluralize "^8.0.0"
+    semver "7.3.5"
+    which "2.0.2"
+    yargs-parser "^21.0.0"
+
 graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
@@ -2282,7 +2364,7 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-docker@^2.0.0:
+is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
   resolved "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
@@ -2922,6 +3004,15 @@ onetime@^5.1.0, onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
+open@8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
+  integrity sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
+
 ora@4.0.2:
   version "4.0.2"
   resolved "https://registry.npmjs.org/ora/-/ora-4.0.2.tgz"
@@ -3041,6 +3132,11 @@ prettier@1.19.1:
   version "1.19.1"
   resolved "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
+  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
This PR introduces a wrapper around the TriggersAdapter to support subgraph triggers from other subgraphs. Previously, the TriggersAdapter was chain-specific, handling triggers only for individual chains. With subgraph data sources, we need a higher-level adapter to fetch entity triggers from source subgraphs without depending on any specific chain.

This PR lays the groundwork for enabling the new subgraph data source type. The changes include:

Allow subgraph datasource in manifest
A wrapper for TriggersAdapter
A wrapper for TriggerFilter
A new trigger type specific to subgraph data sources