### PR TITLE
Optimize IPFS retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,6 +1988,7 @@ dependencies = [
  "tower 0.4.13 (git+https://github.com/tower-rs/tower.git)",
  "tower-test",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,3 +26,4 @@ anyhow = "1.0"
 [dev-dependencies]
 tower-test = { git = "https://github.com/tower-rs/tower.git" }
 uuid = { version = "1.9.1", features = ["v4"] }
+wiremock = "0.6.1"

--- a/core/src/polling_monitor/ipfs_service.rs
+++ b/core/src/polling_monitor/ipfs_service.rs
@@ -101,9 +101,14 @@ mod test {
     use graph::ipfs::test_utils::add_files_to_local_ipfs_node_for_testing;
     use graph::ipfs::IpfsRpcClient;
     use graph::ipfs::ServerAddress;
+    use graph::log::discard;
     use graph::tokio;
     use tower::ServiceExt;
     use uuid::Uuid;
+    use wiremock::matchers as m;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
 
     use super::*;
 
@@ -142,5 +147,35 @@ mod test {
             {"name":"Arloader NFT #1","description":"Super dope, one of a kind NFT","collection":{"name":"Arloader NFT","family":"We AR"},"attributes":[{"trait_type":"cx","value":-0.4042198883730073},{"trait_type":"cy","value":0.5641681708263335},{"trait_type":"iters","value":44}],"properties":{"category":"image","files":[{"uri":"https://arweave.net/7gWCr96zc0QQCXOsn5Vk9ROVGFbMaA9-cYpzZI8ZMDs","type":"image/png"},{"uri":"https://arweave.net/URwQtoqrbYlc5183STNy3ZPwSCRY4o8goaF7MJay3xY/1.png","type":"image/png"}]},"image":"https://arweave.net/URwQtoqrbYlc5183STNy3ZPwSCRY4o8goaF7MJay3xY/1.png"}
         "#.trim_start().trim_end();
         assert_eq!(expected, body);
+    }
+
+    #[tokio::test]
+    async fn no_client_retries_to_allow_polling_monitor_to_handle_retries_internally() {
+        const CID: &str = "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn";
+
+        let server = MockServer::start().await;
+        let ipfs_client = IpfsRpcClient::new_unchecked(server.uri(), &discard()).unwrap();
+        let ipfs_service = ipfs_service(Arc::new(ipfs_client), 10, Duration::from_secs(1), 1);
+        let path = ContentPath::new(CID).unwrap();
+
+        Mock::given(m::method("POST"))
+            .and(m::path("/api/v0/cat"))
+            .and(m::query_param("arg", CID))
+            .respond_with(ResponseTemplate::new(500))
+            .up_to_n_times(1)
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        Mock::given(m::method("POST"))
+            .and(m::path("/api/v0/cat"))
+            .and(m::query_param("arg", CID))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(..=1)
+            .mount(&server)
+            .await;
+
+        // This means that we never reached the successful response.
+        ipfs_service.oneshot(path).await.unwrap_err();
     }
 }

--- a/graph/src/ipfs/client.rs
+++ b/graph/src/ipfs/client.rs
@@ -1,0 +1,186 @@
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use bytes::BytesMut;
+use futures03::stream::BoxStream;
+use futures03::StreamExt;
+use futures03::TryStreamExt;
+use slog::Logger;
+
+use crate::ipfs::ContentPath;
+use crate::ipfs::IpfsError;
+use crate::ipfs::IpfsResult;
+use crate::ipfs::RetryPolicy;
+
+/// A read-only connection to an IPFS server.
+#[async_trait]
+pub trait IpfsClient: Send + Sync + 'static {
+    /// Returns the logger associated with the client.
+    fn logger(&self) -> &Logger;
+
+    /// Sends a request to the IPFS server and returns a raw response.
+    async fn call(self: Arc<Self>, req: IpfsRequest) -> IpfsResult<IpfsResponse>;
+
+    /// Streams data from the specified content path.
+    ///
+    /// If a timeout is specified, the execution will be aborted if the IPFS server
+    /// does not return a response within the specified amount of time.
+    ///
+    /// The timeout is not propagated to the resulting stream.
+    async fn cat_stream(
+        self: Arc<Self>,
+        path: &ContentPath,
+        timeout: Option<Duration>,
+        retry_policy: RetryPolicy,
+    ) -> IpfsResult<BoxStream<'static, IpfsResult<Bytes>>> {
+        let fut = retry_policy.create("IPFS.cat_stream", self.logger()).run({
+            let path = path.to_owned();
+
+            move || {
+                let path = path.clone();
+                let client = self.clone();
+
+                async move { client.call(IpfsRequest::Cat(path)).await }
+            }
+        });
+
+        let resp = run_with_optional_timeout(path, fut, timeout).await?;
+
+        Ok(resp.bytes_stream())
+    }
+
+    /// Downloads data from the specified content path.
+    ///
+    /// If a timeout is specified, the execution will be aborted if the IPFS server
+    /// does not return a response within the specified amount of time.
+    async fn cat(
+        self: Arc<Self>,
+        path: &ContentPath,
+        max_size: usize,
+        timeout: Option<Duration>,
+        retry_policy: RetryPolicy,
+    ) -> IpfsResult<Bytes> {
+        let fut = retry_policy.create("IPFS.cat", self.logger()).run({
+            let path = path.to_owned();
+
+            move || {
+                let path = path.clone();
+                let client = self.clone();
+
+                async move {
+                    client
+                        .call(IpfsRequest::Cat(path))
+                        .await?
+                        .bytes(Some(max_size))
+                        .await
+                }
+            }
+        });
+
+        run_with_optional_timeout(path, fut, timeout).await
+    }
+
+    /// Downloads an IPFS block in raw format.
+    ///
+    /// If a timeout is specified, the execution will be aborted if the IPFS server
+    /// does not return a response within the specified amount of time.
+    async fn get_block(
+        self: Arc<Self>,
+        path: &ContentPath,
+        timeout: Option<Duration>,
+        retry_policy: RetryPolicy,
+    ) -> IpfsResult<Bytes> {
+        let fut = retry_policy.create("IPFS.get_block", self.logger()).run({
+            let path = path.to_owned();
+
+            move || {
+                let path = path.clone();
+                let client = self.clone();
+
+                async move {
+                    client
+                        .call(IpfsRequest::GetBlock(path))
+                        .await?
+                        .bytes(None)
+                        .await
+                }
+            }
+        });
+
+        run_with_optional_timeout(path, fut, timeout).await
+    }
+}
+
+/// Describes a request to an IPFS server.
+#[derive(Clone, Debug)]
+pub enum IpfsRequest {
+    Cat(ContentPath),
+    GetBlock(ContentPath),
+}
+
+/// Contains a raw, successful IPFS response.
+#[derive(Debug)]
+pub struct IpfsResponse {
+    pub(super) path: ContentPath,
+    pub(super) response: reqwest::Response,
+}
+
+impl IpfsResponse {
+    /// Reads and returns the response body.
+    ///
+    /// If the max size is specified and the response body is larger than the max size,
+    /// execution will result in an error.
+    pub async fn bytes(self, max_size: Option<usize>) -> IpfsResult<Bytes> {
+        let Some(max_size) = max_size else {
+            return self.response.bytes().await.map_err(Into::into);
+        };
+
+        let bytes = self
+            .response
+            .bytes_stream()
+            .err_into()
+            .try_fold(BytesMut::new(), |mut acc, chunk| async {
+                acc.extend(chunk);
+
+                if acc.len() > max_size {
+                    return Err(IpfsError::ContentTooLarge {
+                        path: self.path.clone(),
+                        max_size,
+                    });
+                }
+
+                Ok(acc)
+            })
+            .await?;
+
+        Ok(bytes.into())
+    }
+
+    /// Converts the response into a stream of bytes from the body.
+    pub fn bytes_stream(self) -> BoxStream<'static, IpfsResult<Bytes>> {
+        self.response.bytes_stream().err_into().boxed()
+    }
+}
+
+async fn run_with_optional_timeout<F, O>(
+    path: &ContentPath,
+    fut: F,
+    timeout: Option<Duration>,
+) -> IpfsResult<O>
+where
+    F: Future<Output = IpfsResult<O>>,
+{
+    match timeout {
+        Some(timeout) => {
+            tokio::time::timeout(timeout, fut)
+                .await
+                .map_err(|_| IpfsError::RequestTimeout {
+                    path: path.to_owned(),
+                })?
+        }
+        None => fut.await,
+    }
+}

--- a/graph/src/ipfs/content_path.rs
+++ b/graph/src/ipfs/content_path.rs
@@ -4,8 +4,8 @@ use cid::Cid;
 use crate::ipfs::IpfsError;
 use crate::ipfs::IpfsResult;
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Represents a path to some data on IPFS.
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ContentPath {
     cid: Cid,
     path: Option<String>,

--- a/graph/src/ipfs/pool.rs
+++ b/graph/src/ipfs/pool.rs
@@ -1,124 +1,79 @@
-use std::time::Duration;
+use std::sync::Arc;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
-use bytes::Bytes;
-use futures03::stream::BoxStream;
 use futures03::stream::FuturesUnordered;
 use futures03::stream::StreamExt;
+use slog::Logger;
 
-use crate::ipfs::CanProvide;
-use crate::ipfs::Cat;
-use crate::ipfs::CatStream;
-use crate::ipfs::ContentPath;
-use crate::ipfs::GetBlock;
 use crate::ipfs::IpfsClient;
 use crate::ipfs::IpfsError;
+use crate::ipfs::IpfsRequest;
+use crate::ipfs::IpfsResponse;
 use crate::ipfs::IpfsResult;
 
 /// Contains a list of IPFS clients and, for each read request, selects the fastest IPFS client
-/// that can provide the content and forwards the request to that client.
+/// that can provide the content and streams the response from that client.
 ///
 /// This can significantly improve performance when using multiple IPFS gateways,
 /// as some of them may already have the content cached.
-///
-/// Note: It should remain an implementation detail and not be used directly.
-pub(super) struct IpfsClientPool {
-    inner: Vec<Box<dyn IpfsClient>>,
+pub struct IpfsClientPool {
+    clients: Vec<Arc<dyn IpfsClient>>,
+    logger: Logger,
 }
 
 impl IpfsClientPool {
-    pub(super) fn with_clients(clients: Vec<Box<dyn IpfsClient>>) -> Self {
-        Self { inner: clients }
-    }
-
-    pub(super) fn into_boxed(self) -> Box<dyn IpfsClient> {
-        Box::new(self)
-    }
-}
-
-#[async_trait]
-impl CanProvide for IpfsClientPool {
-    async fn can_provide(&self, path: &ContentPath, timeout: Option<Duration>) -> IpfsResult<bool> {
-        select_fastest_ipfs_client(&self.inner, path, timeout)
-            .await
-            .map(|_client| true)
+    /// Creates a new IPFS client pool from the specified clients.
+    pub fn new(clients: Vec<Arc<dyn IpfsClient>>, logger: &Logger) -> Self {
+        Self {
+            clients,
+            logger: logger.to_owned(),
+        }
     }
 }
 
 #[async_trait]
-impl CatStream for IpfsClientPool {
-    async fn cat_stream(
-        &self,
-        path: &ContentPath,
-        timeout: Option<Duration>,
-    ) -> IpfsResult<BoxStream<'static, IpfsResult<Bytes>>> {
-        let client = select_fastest_ipfs_client(&self.inner, path, timeout).await?;
-
-        client.cat_stream(path, timeout).await
+impl IpfsClient for IpfsClientPool {
+    fn logger(&self) -> &Logger {
+        &self.logger
     }
-}
 
-#[async_trait]
-impl Cat for IpfsClientPool {
-    async fn cat(
-        &self,
-        path: &ContentPath,
-        max_size: usize,
-        timeout: Option<Duration>,
-    ) -> IpfsResult<Bytes> {
-        let client = select_fastest_ipfs_client(&self.inner, path, timeout).await?;
+    async fn call(self: Arc<Self>, req: IpfsRequest) -> IpfsResult<IpfsResponse> {
+        let mut futs = self
+            .clients
+            .iter()
+            .map(|client| client.clone().call(req.clone()))
+            .collect::<FuturesUnordered<_>>();
 
-        client.cat(path, max_size, timeout).await
-    }
-}
+        let mut last_err = None;
 
-#[async_trait]
-impl GetBlock for IpfsClientPool {
-    async fn get_block(&self, path: &ContentPath, timeout: Option<Duration>) -> IpfsResult<Bytes> {
-        let client = select_fastest_ipfs_client(&self.inner, path, timeout).await?;
+        while let Some(result) = futs.next().await {
+            match result {
+                Ok(resp) => return Ok(resp),
+                Err(err) => last_err = Some(err),
+            };
+        }
 
-        client.get_block(path, timeout).await
-    }
-}
-
-/// Returns the first IPFS client that can provide the content from the specified path.
-async fn select_fastest_ipfs_client<'a>(
-    clients: &'a [Box<dyn IpfsClient>],
-    path: &ContentPath,
-    timeout: Option<Duration>,
-) -> IpfsResult<&'a dyn IpfsClient> {
-    let mut futs = clients
-        .iter()
-        .enumerate()
-        .map(|(i, client)| async move {
-            client
-                .can_provide(path, timeout)
-                .await
-                .map(|ok| ok.then_some(i))
-        })
-        .collect::<FuturesUnordered<_>>();
-
-    let mut last_err = None;
-
-    while let Some(result) = futs.next().await {
-        match result {
-            Ok(Some(i)) => return Ok(clients[i].as_ref()),
-            Ok(None) => continue,
-            Err(err) => last_err = Some(err),
+        let path = match req {
+            IpfsRequest::Cat(path) => path,
+            IpfsRequest::GetBlock(path) => path,
         };
+
+        let err = last_err.unwrap_or_else(|| IpfsError::ContentNotAvailable {
+            path,
+            reason: anyhow!("no clients can provide the content"),
+        });
+
+        Err(err)
     }
-
-    let err = last_err.unwrap_or_else(|| IpfsError::ContentNotAvailable {
-        path: path.to_owned(),
-        reason: anyhow!("no clients can provide the content"),
-    });
-
-    Err(err)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use bytes::BytesMut;
+    use futures03::TryStreamExt;
     use http::StatusCode;
     use wiremock::matchers as m;
     use wiremock::Mock;
@@ -127,24 +82,22 @@ mod tests {
     use wiremock::ResponseTemplate;
 
     use super::*;
+    use crate::ipfs::ContentPath;
     use crate::ipfs::IpfsGatewayClient;
+    use crate::ipfs::RetryPolicy;
     use crate::log::discard;
 
     const PATH: &str = "/ipfs/QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn";
-
-    fn mock_head() -> MockBuilder {
-        Mock::given(m::method("HEAD")).and(m::path(PATH))
-    }
 
     fn mock_get() -> MockBuilder {
         Mock::given(m::method("GET")).and(m::path(PATH))
     }
 
-    async fn make_client() -> (MockServer, IpfsGatewayClient) {
+    async fn make_client() -> (MockServer, Arc<IpfsGatewayClient>) {
         let server = MockServer::start().await;
         let client = IpfsGatewayClient::new_unchecked(server.uri(), &discard()).unwrap();
 
-        (server, client)
+        (server, Arc::new(client))
     }
 
     fn make_path() -> ContentPath {
@@ -156,116 +109,149 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn can_provide_returns_true_if_any_client_can_provide_the_content() {
+    async fn cat_stream_streams_the_response_from_the_fastest_client() {
         let (server_1, client_1) = make_client().await;
         let (server_2, client_2) = make_client().await;
+        let (server_3, client_3) = make_client().await;
 
-        mock_head()
+        mock_get()
             .respond_with(
-                ResponseTemplate::new(StatusCode::INTERNAL_SERVER_ERROR).set_delay(ms(100)),
+                ResponseTemplate::new(StatusCode::OK)
+                    .set_body_bytes(b"server_1")
+                    .set_delay(ms(300)),
             )
-            .expect(1..)
-            .mount(&server_1)
-            .await;
-
-        mock_head()
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_delay(ms(200)))
-            .expect(1)
-            .mount(&server_2)
-            .await;
-
-        let clients = vec![client_1.into_boxed(), client_2.into_boxed()];
-        let pool = IpfsClientPool::with_clients(clients);
-        let ok = pool.can_provide(&make_path(), None).await.unwrap();
-
-        assert!(ok);
-    }
-
-    #[tokio::test]
-    async fn cat_stream_forwards_the_request_to_the_fastest_client_that_can_provide_the_content() {
-        let (server_1, client_1) = make_client().await;
-        let (server_2, client_2) = make_client().await;
-
-        mock_head()
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_delay(ms(200)))
             .expect(1)
             .mount(&server_1)
             .await;
 
-        mock_head()
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_delay(ms(100)))
+        mock_get()
+            .respond_with(
+                ResponseTemplate::new(StatusCode::OK)
+                    .set_body_bytes(b"server_2")
+                    .set_delay(ms(200)),
+            )
             .expect(1)
             .mount(&server_2)
             .await;
 
         mock_get()
-            .respond_with(ResponseTemplate::new(StatusCode::OK))
+            .respond_with(
+                ResponseTemplate::new(StatusCode::OK)
+                    .set_body_bytes(b"server_3")
+                    .set_delay(ms(100)),
+            )
             .expect(1)
-            .mount(&server_2)
+            .mount(&server_3)
             .await;
 
-        let clients = vec![client_1.into_boxed(), client_2.into_boxed()];
-        let pool = IpfsClientPool::with_clients(clients);
-        let _stream = pool.cat_stream(&make_path(), None).await.unwrap();
+        let clients: Vec<Arc<dyn IpfsClient>> = vec![client_1, client_2, client_3];
+        let pool = Arc::new(IpfsClientPool::new(clients, &discard()));
+
+        let bytes = pool
+            .cat_stream(&make_path(), None, RetryPolicy::None)
+            .await
+            .unwrap()
+            .try_fold(BytesMut::new(), |mut acc, chunk| async {
+                acc.extend(chunk);
+                Ok(acc)
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(bytes.as_ref(), b"server_3");
     }
 
     #[tokio::test]
-    async fn cat_forwards_the_request_to_the_fastest_client_that_can_provide_the_content() {
+    async fn cat_streams_the_response_from_the_fastest_client() {
         let (server_1, client_1) = make_client().await;
         let (server_2, client_2) = make_client().await;
+        let (server_3, client_3) = make_client().await;
 
-        mock_head()
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_delay(ms(200)))
+        mock_get()
+            .respond_with(
+                ResponseTemplate::new(StatusCode::OK)
+                    .set_body_bytes(b"server_1")
+                    .set_delay(ms(300)),
+            )
             .expect(1)
             .mount(&server_1)
             .await;
 
-        mock_head()
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_delay(ms(100)))
+        mock_get()
+            .respond_with(
+                ResponseTemplate::new(StatusCode::OK)
+                    .set_body_bytes(b"server_2")
+                    .set_delay(ms(200)),
+            )
             .expect(1)
             .mount(&server_2)
             .await;
 
         mock_get()
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_body_bytes(b"some data"))
+            .respond_with(
+                ResponseTemplate::new(StatusCode::OK)
+                    .set_body_bytes(b"server_3")
+                    .set_delay(ms(100)),
+            )
             .expect(1)
-            .mount(&server_2)
+            .mount(&server_3)
             .await;
 
-        let clients = vec![client_1.into_boxed(), client_2.into_boxed()];
-        let pool = IpfsClientPool::with_clients(clients);
-        let content = pool.cat(&make_path(), usize::MAX, None).await.unwrap();
+        let clients: Vec<Arc<dyn IpfsClient>> = vec![client_1, client_2, client_3];
+        let pool = Arc::new(IpfsClientPool::new(clients, &discard()));
 
-        assert_eq!(content.as_ref(), b"some data")
+        let bytes = pool
+            .cat(&make_path(), usize::MAX, None, RetryPolicy::None)
+            .await
+            .unwrap();
+
+        assert_eq!(bytes.as_ref(), b"server_3")
     }
 
     #[tokio::test]
-    async fn get_block_forwards_the_request_to_the_fastest_client_that_can_provide_the_content() {
+    async fn get_block_streams_the_response_from_the_fastest_client() {
         let (server_1, client_1) = make_client().await;
         let (server_2, client_2) = make_client().await;
+        let (server_3, client_3) = make_client().await;
 
-        mock_head()
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_delay(ms(200)))
+        mock_get()
+            .respond_with(
+                ResponseTemplate::new(StatusCode::OK)
+                    .set_body_bytes(b"server_1")
+                    .set_delay(ms(300)),
+            )
             .expect(1)
             .mount(&server_1)
             .await;
 
-        mock_head()
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_delay(ms(100)))
+        mock_get()
+            .respond_with(
+                ResponseTemplate::new(StatusCode::OK)
+                    .set_body_bytes(b"server_2")
+                    .set_delay(ms(200)),
+            )
             .expect(1)
             .mount(&server_2)
             .await;
 
         mock_get()
-            .respond_with(ResponseTemplate::new(StatusCode::OK).set_body_bytes(b"some data"))
+            .respond_with(
+                ResponseTemplate::new(StatusCode::OK)
+                    .set_body_bytes(b"server_3")
+                    .set_delay(ms(100)),
+            )
             .expect(1)
-            .mount(&server_2)
+            .mount(&server_3)
             .await;
 
-        let clients = vec![client_1.into_boxed(), client_2.into_boxed()];
-        let pool = IpfsClientPool::with_clients(clients);
-        let block = pool.get_block(&make_path(), None).await.unwrap();
+        let clients: Vec<Arc<dyn IpfsClient>> = vec![client_1, client_2, client_3];
+        let pool = Arc::new(IpfsClientPool::new(clients, &discard()));
 
-        assert_eq!(block.as_ref(), b"some data")
+        let bytes = pool
+            .get_block(&make_path(), None, RetryPolicy::None)
+            .await
+            .unwrap();
+
+        assert_eq!(bytes.as_ref(), b"server_3")
     }
 }

--- a/graph/src/ipfs/retry_policy.rs
+++ b/graph/src/ipfs/retry_policy.rs
@@ -45,3 +45,169 @@ impl RetryPolicy {
             .no_timeout()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::ipfs::ContentPath;
+    use crate::log::discard;
+
+    const CID: &str = "QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn";
+
+    fn path() -> ContentPath {
+        ContentPath::new(CID).unwrap()
+    }
+
+    #[tokio::test]
+    async fn retry_policy_none_disables_retries() {
+        let counter = Arc::new(AtomicU64::new(0));
+
+        let err = RetryPolicy::None
+            .create::<()>("test", &discard())
+            .run({
+                let counter = counter.clone();
+                move || {
+                    let counter = counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        Err(IpfsError::RequestTimeout { path: path() })
+                    }
+                }
+            })
+            .await
+            .unwrap_err();
+
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+        assert!(matches!(err, IpfsError::RequestTimeout { .. }));
+    }
+
+    #[tokio::test]
+    async fn retry_policy_networking_retries_only_network_related_errors() {
+        let counter = Arc::new(AtomicU64::new(0));
+
+        let err = RetryPolicy::Networking
+            .create("test", &discard())
+            .run({
+                let counter = counter.clone();
+                move || {
+                    let counter = counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+
+                        if counter.load(Ordering::SeqCst) == 10 {
+                            return Err(IpfsError::RequestTimeout { path: path() });
+                        }
+
+                        reqwest::Client::new()
+                            .get("https://simulate-dns-lookup-failure")
+                            .timeout(Duration::from_millis(50))
+                            .send()
+                            .await?;
+
+                        Ok(())
+                    }
+                }
+            })
+            .await
+            .unwrap_err();
+
+        assert_eq!(counter.load(Ordering::SeqCst), 10);
+        assert!(matches!(err, IpfsError::RequestTimeout { .. }));
+    }
+
+    #[tokio::test]
+    async fn retry_policy_networking_stops_on_success() {
+        let counter = Arc::new(AtomicU64::new(0));
+
+        RetryPolicy::Networking
+            .create("test", &discard())
+            .run({
+                let counter = counter.clone();
+                move || {
+                    let counter = counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+
+                        if counter.load(Ordering::SeqCst) == 10 {
+                            return Ok(());
+                        }
+
+                        reqwest::Client::new()
+                            .get("https://simulate-dns-lookup-failure")
+                            .timeout(Duration::from_millis(50))
+                            .send()
+                            .await?;
+
+                        Ok(())
+                    }
+                }
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(counter.load(Ordering::SeqCst), 10);
+    }
+
+    #[tokio::test]
+    async fn retry_policy_non_deterministic_retries_all_non_deterministic_errors() {
+        let counter = Arc::new(AtomicU64::new(0));
+
+        let err = RetryPolicy::NonDeterministic
+            .create::<()>("test", &discard())
+            .run({
+                let counter = counter.clone();
+                move || {
+                    let counter = counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+
+                        if counter.load(Ordering::SeqCst) == 10 {
+                            return Err(IpfsError::ContentTooLarge {
+                                path: path(),
+                                max_size: 0,
+                            });
+                        }
+
+                        Err(IpfsError::RequestTimeout { path: path() })
+                    }
+                }
+            })
+            .await
+            .unwrap_err();
+
+        assert_eq!(counter.load(Ordering::SeqCst), 10);
+        assert!(matches!(err, IpfsError::ContentTooLarge { .. }));
+    }
+
+    #[tokio::test]
+    async fn retry_policy_non_deterministic_stops_on_success() {
+        let counter = Arc::new(AtomicU64::new(0));
+
+        RetryPolicy::NonDeterministic
+            .create("test", &discard())
+            .run({
+                let counter = counter.clone();
+                move || {
+                    let counter = counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+
+                        if counter.load(Ordering::SeqCst) == 10 {
+                            return Ok(());
+                        }
+
+                        Err(IpfsError::RequestTimeout { path: path() })
+                    }
+                }
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(counter.load(Ordering::SeqCst), 10);
+    }
+}

--- a/graph/src/ipfs/retry_policy.rs
+++ b/graph/src/ipfs/retry_policy.rs
@@ -4,21 +4,44 @@ use crate::ipfs::error::IpfsError;
 use crate::util::futures::retry;
 use crate::util::futures::RetryConfigNoTimeout;
 
-const DEFAULT_MAX_ATTEMPTS: usize = 100;
+/// This is a safety mechanism to prevent infinite spamming of IPFS servers
+/// in the event of logical or unhandled deterministic errors.
+const DEFAULT_MAX_ATTEMPTS: usize = 10_0000;
 
-/// Creates a retry policy for each request sent by IPFS clients.
-///
-/// Note: It is expected that timeouts will be set on the requests.
-pub fn retry_policy<O: Send + Sync + 'static>(
-    operation_name: &'static str,
-    logger: &Logger,
-) -> RetryConfigNoTimeout<O, IpfsError> {
-    retry(operation_name, logger)
-        .limit(DEFAULT_MAX_ATTEMPTS)
-        .when(|result: &Result<O, IpfsError>| match result {
-            Ok(_) => false,
-            Err(IpfsError::RequestFailed(err)) => !err.is_timeout() && err.is_retriable(),
-            Err(_) => false,
-        })
-        .no_timeout()
+/// Describes retry behavior when IPFS requests fail.
+#[derive(Clone, Copy, Debug)]
+pub enum RetryPolicy {
+    /// At the first error, immediately stops execution and returns the error.
+    None,
+
+    /// Retries the request if the error is related to the network connection.
+    Networking,
+
+    /// Retries the request if the error is related to the network connection,
+    /// and for any error that may be resolved by sending another request.
+    NonDeterministic,
+}
+
+impl RetryPolicy {
+    /// Creates a retry policy for every request sent to IPFS servers.
+    ///
+    /// Note: It is expected that retries will be wrapped in timeouts
+    ///       when necessary to make them more flexible.
+    pub(super) fn create<O: Send + Sync + 'static>(
+        self,
+        operation_name: impl ToString,
+        logger: &Logger,
+    ) -> RetryConfigNoTimeout<O, IpfsError> {
+        retry(operation_name, logger)
+            .limit(DEFAULT_MAX_ATTEMPTS)
+            .when(move |result: &Result<O, IpfsError>| match result {
+                Ok(_) => false,
+                Err(err) => match self {
+                    Self::None => false,
+                    Self::Networking => err.is_networking(),
+                    Self::NonDeterministic => !err.is_deterministic(),
+                },
+            })
+            .no_timeout()
+    }
 }

--- a/graph/src/ipfs/server_address.rs
+++ b/graph/src/ipfs/server_address.rs
@@ -8,8 +8,8 @@ use crate::derive::CheapClone;
 use crate::ipfs::IpfsError;
 use crate::ipfs::IpfsResult;
 
-#[derive(Clone, Debug, CheapClone)]
 /// Contains a valid IPFS server address.
+#[derive(Clone, Debug, CheapClone)]
 pub struct ServerAddress {
     inner: Arc<str>,
 }

--- a/runtime/test/src/common.rs
+++ b/runtime/test/src/common.rs
@@ -65,16 +65,14 @@ fn mock_host_exports(
         Arc::new(templates.iter().map(|t| t.into()).collect()),
     );
 
-    let ipfs_client = IpfsRpcClient::new_unchecked(ServerAddress::local_rpc_api(), &LOGGER)
-        .unwrap()
-        .into_boxed();
+    let client = IpfsRpcClient::new_unchecked(ServerAddress::local_rpc_api(), &LOGGER).unwrap();
 
     HostExports::new(
         subgraph_id,
         network,
         ds_details,
         Arc::new(IpfsResolver::new(
-            ipfs_client.into(),
+            Arc::new(client),
             Arc::new(EnvVars::default()),
         )),
         ens_lookup,

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -462,13 +462,13 @@ pub async fn setup<C: Blockchain>(
 
     let static_filters = env_vars.experimental_static_filters;
 
-    let ipfs_client: Arc<dyn IpfsClient> = graph::ipfs::IpfsRpcClient::new_unchecked(
-        graph::ipfs::ServerAddress::local_rpc_api(),
-        &logger,
-    )
-    .unwrap()
-    .into_boxed()
-    .into();
+    let ipfs_client: Arc<dyn IpfsClient> = Arc::new(
+        graph::ipfs::IpfsRpcClient::new_unchecked(
+            graph::ipfs::ServerAddress::local_rpc_api(),
+            &logger,
+        )
+        .unwrap(),
+    );
 
     let link_resolver = Arc::new(IpfsResolver::new(
         ipfs_client.cheap_clone(),


### PR DESCRIPTION
This PR reduces the number of unnecessary IPFS retries by requiring an explicit retry policy, so that different components of the graph-node can decide to use different types of retries, or not use retries at all.

Closes #5696

**Other improvements:**

IPFS client pool now reuses the initial response instead of doubling the number of requests.

**Future improvements:**

This PR includes the first steps in defining deterministic IPFS errors so that some retries can be eliminated altogether. This functionality is not part of this PR as it requires more thought and testing and will be added in a future PR.


