### PR TITLE
Install correct netcat package in Docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,7 +97,7 @@ EXPOSE 8020
 EXPOSE 8030
 
 RUN apt-get update \
-    && apt-get install -y libpq-dev ca-certificates netcat
+    && apt-get install -y libpq-dev ca-certificates netcat-openbsd
 
 ADD docker/wait_for docker/start /usr/local/bin/
 COPY --from=graph-node-build /usr/local/bin/graph-node /usr/local/bin/graphman /usr/local/bin/


### PR DESCRIPTION
In #5620, we updated our base Debian image tag, resulting in our installation of the `netcat` package failing due to being made a virtual package (provided by either `netcat-openbsd` and `netcat-traditional`). Here, we opt to specifically use `netcat-openbsd` to match Bullseye's default.

