### PR TITLE
Add graph-indexed header

### DIFF
--- a/graph/src/data/query/mod.rs
+++ b/graph/src/data/query/mod.rs
@@ -7,5 +7,5 @@ mod trace;
 pub use self::cache_status::CacheStatus;
 pub use self::error::{QueryError, QueryExecutionError};
 pub use self::query::{Query, QueryTarget, QueryVariables};
-pub use self::result::{QueryResult, QueryResults};
+pub use self::result::{LatestBlockInfo, QueryResult, QueryResults};
 pub use self::trace::Trace;

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -526,7 +526,7 @@ async fn execute_subgraph_query_internal(
         100,
         graphql_metrics(),
     ));
-    let mut result = QueryResults::empty(query.root_trace(trace));
+    let mut result = QueryResults::empty(query.root_trace(trace), None);
     let deployment = query.schema.id().clone();
     let store = STORE
         .clone()


### PR DESCRIPTION
This adds a `graph-indexed` header to query responses. The header value contains the block hash, number, and timestamp for the most recently processed block in the subgraph. This avoids the need to rewrite all queries to include `_meta { block { hash number timestamp } }` in either the indexer-service or gateway.

Related: https://github.com/edgeandnode/gateway/issues/900, https://github.com/graphprotocol/indexer-rs/issues/494