### PR TITLE
graph-node docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 # by running something like the following
 #   docker build --target STAGE -f docker/Dockerfile .
 
-FROM golang:bullseye as envsubst
+FROM golang:bookworm AS envsubst
 
 # v1.2.0
 ARG ENVSUBST_COMMIT_SHA=16035fe3571ad42c7796bf554f978bb2df64231b
@@ -13,7 +13,7 @@ ARG ENVSUBST_COMMIT_SHA=16035fe3571ad42c7796bf554f978bb2df64231b
 RUN go install github.com/a8m/envsubst/cmd/envsubst@$ENVSUBST_COMMIT_SHA \
     && strip -g /go/bin/envsubst
 
-FROM rust:bullseye as graph-node-build
+FROM rust:bookworm AS graph-node-build
 
 ARG COMMIT_SHA=unknown
 ARG REPO_NAME=unknown
@@ -44,7 +44,7 @@ RUN apt-get update \
     && echo "CARGO_DEV_BUILD='$CARGO_DEV_BUILD'" >> /etc/image-info
 
 # Debug image to access core dumps
-FROM graph-node-build as graph-node-debug
+FROM graph-node-build AS graph-node-debug
 RUN apt-get update \
     && apt-get install -y curl gdb postgresql-client
 
@@ -52,40 +52,40 @@ COPY docker/Dockerfile /Dockerfile
 COPY docker/bin/* /usr/local/bin/
 
 # The graph-node runtime image with only the executable
-FROM debian:bookworm-20241111-slim as graph-node
-ENV RUST_LOG ""
-ENV GRAPH_LOG ""
-ENV EARLY_LOG_CHUNK_SIZE ""
-ENV ETHEREUM_RPC_PARALLEL_REQUESTS ""
-ENV ETHEREUM_BLOCK_CHUNK_SIZE ""
+FROM debian:bookworm-20241111-slim AS graph-node
+ENV RUST_LOG=""
+ENV GRAPH_LOG=""
+ENV EARLY_LOG_CHUNK_SIZE=""
+ENV ETHEREUM_RPC_PARALLEL_REQUESTS=""
+ENV ETHEREUM_BLOCK_CHUNK_SIZE=""
 
-ENV postgres_host ""
-ENV postgres_user ""
-ENV postgres_pass ""
-ENV postgres_db ""
-ENV postgres_args "sslmode=prefer"
+ENV postgres_host=""
+ENV postgres_user=""
+ENV postgres_pass=""
+ENV postgres_db=""
+ENV postgres_args="sslmode=prefer"
 # The full URL to the IPFS node
-ENV ipfs ""
+ENV ipfs=""
 # The etherum network(s) to connect to. Set this to a space-separated
 # list of the networks where each entry has the form NAME:URL
-ENV ethereum ""
+ENV ethereum=""
 # The role the node should have, one of index-node, query-node, or
 # combined-node
-ENV node_role "combined-node"
+ENV node_role="combined-node"
 # The name of this node
-ENV node_id "default"
+ENV node_id="default"
 # The ethereum network polling interval  (in milliseconds)
-ENV ethereum_polling_interval ""
+ENV ethereum_polling_interval=""
 
 # The location of an optional configuration file for graph-node, as
 # described in ../docs/config.md
 # Using a configuration file is experimental, and the file format may
 # change in backwards-incompatible ways
-ENV GRAPH_NODE_CONFIG ""
+ENV GRAPH_NODE_CONFIG=""
 
 # Disable core dumps; this is useful for query nodes with large caches. Set
 # this to anything to disable coredumps (via 'ulimit -c 0')
-ENV disable_core_dumps ""
+ENV disable_core_dumps=""
 
 # HTTP port
 EXPOSE 8000


### PR DESCRIPTION
This PR updates all images to the same bookworm and fix the dockerfile deprecations syntax
