### PR TITLE
Do not allow multiple active runners for a subgraph

### DIFF
--- a/core/src/subgraph/context/mod.rs
+++ b/core/src/subgraph/context/mod.rs
@@ -58,6 +58,10 @@ impl SubgraphKeepAlive {
             self.sg_metrics.running_count.inc();
         }
     }
+
+    pub fn contains(&self, deployment_id: &DeploymentId) -> bool {
+        self.alive_map.read().unwrap().contains_key(deployment_id)
+    }
 }
 
 // The context keeps track of mutable in-memory state that is retained across blocks.

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -17,7 +17,7 @@ use graph::prelude::{
     SubgraphStore as _, BLOCK_NUMBER_MAX,
 };
 use graph::schema::{EntityKey, EntityType, InputSchema};
-use graph::slog::{info, warn};
+use graph::slog::{debug, info, warn};
 use graph::tokio::select;
 use graph::tokio::sync::Notify;
 use graph::tokio::task::JoinHandle;
@@ -936,6 +936,7 @@ impl Queue {
                         // Graceful shutdown. We also handled the request
                         // successfully
                         queue.queue.pop().await;
+                        debug!(logger, "Subgraph writer has processed a stop request");
                         return;
                     }
                     Ok(Err(e)) => {


### PR DESCRIPTION
This PR fixes a long-standing bug that caused many subgraphs to fail repeatedly when a simple sequence of errors, retries, and restarts occurred.

Closes #5452

## Context

There have been multiple reports of some subgraphs failing randomly, and restarts only helping temporarily. 

I have examined several days of logs for some subgraphs and found patterns that lead to this strange state when nothing seems to help recover the subgraphs. 

Based on that, I started to reproduce the bug locally and looked for a way to fix it with minimal refactoring.

## Reproducing the bug locally

- I set up a minimal subgraph to record block numbers and timestamps and deployed it locally.
- Modified the graph-node code _([here](https://github.com/graphprotocol/graph-node/blob/6b48bfda297eb253e9e802eed53452b9dc1b88d2/core/src/subgraph/runner.rs#L378))_ to introduce a non-deterministic error after processing 10 blocks.
- When the simulated error triggered, the runner entered a retry delay state.
- Then, I executed `graphman restart <ID>`.
- The subgraph restarted, creating a new runner, but the first runner continued waiting for the retry delay to expire.
- During the retry delay, the second runner progressed, but when the delay ended, the first runner initiated a soft restart. This replaced the block stream canceller in the context and terminated the second runner.
- At this stage, only the first runner remained, but its writer had been killed by the `graphman restart`, leading to indefinite failures.
- After that, restarts no longer helped.
- The simplest way to recover was to restart graph-node. Unassigns weren’t always reliable, as I observed scenarios with multiple (up to 4) failing runners for the same subgraph active at the same time.

_* There are many more ways to reproduce this bug, but I have chosen the simplest one._

## Testing the solution

I have tested the proposed solution in a local setup with attempts to reproduce the bug based on the patterns I saw in the logs, and none of them were successful. The fix detects the duplicate runner and shuts it down, allowing the new runner to progress.

_* I've set up a local Grafana loki instance to view logs and make sure that graph-node behaves as expected after the fix._