### PR TITLE
Add `deployment_status` metric

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,24 @@
 # NEWS
 
+## v0.36.1
+
+### What's new
+
+- A new `deployment_status` metric is added [(#5720)](https://github.com/graphprotocol/graph-node/pull/5720) with the
+  following behavior:
+    - Once graph-node has figured out that it should index a deployment, `deployment_status` is set to `1` _(starting)_;
+    - When the block stream is created and blocks are ready to be processed, `deployment_status` is set to `2` _(
+      running)_;
+    - When a deployment is unassigned, `deployment_status` is set to `3` _(stopped)_;
+    - If a temporary or permanent failure occurs, `deployment_status` is set to `4` _(failed)_;
+        - If indexing manages to recover from a temporary failure, the `deployment_status` is set back to `2` _(
+          running)_;
+
+### Breaking changes
+
+- The `deployment_failed` metric is removed and the failures are reported by the new `deployment_status`
+  metric. [(#5720)](https://github.com/graphprotocol/graph-node/pull/5720)
+
 ## v0.36.0
 
 ### Note on Firehose Extended Block Details

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -244,6 +244,8 @@ where
 
             debug!(self.logger, "Starting block stream");
 
+            self.metrics.subgraph.deployment_status.running();
+
             // Process events from the stream as long as no restart is needed
             loop {
                 let event = {
@@ -876,7 +878,7 @@ where
                     self.state.should_try_unfail_non_deterministic = false;
 
                     if let UnfailOutcome::Unfailed = outcome {
-                        self.metrics.stream.deployment_failed.set(0.0);
+                        self.metrics.subgraph.deployment_status.running();
                         self.state.backoff.reset();
                     }
                 }
@@ -909,7 +911,7 @@ where
 
             // Handle unexpected stream errors by marking the subgraph as failed.
             Err(e) => {
-                self.metrics.stream.deployment_failed.set(1.0);
+                self.metrics.subgraph.deployment_status.failed();
                 let last_good_block = self
                     .inputs
                     .store

--- a/graph/src/blockchain/block_stream.rs
+++ b/graph/src/blockchain/block_stream.rs
@@ -573,7 +573,6 @@ where
 #[derive(Clone)]
 pub struct BlockStreamMetrics {
     pub deployment_head: Box<Gauge>,
-    pub deployment_failed: Box<Gauge>,
     pub reverted_blocks: Gauge,
     pub stopwatch: StopwatchMetrics,
 }
@@ -605,16 +604,8 @@ impl BlockStreamMetrics {
                 labels.clone(),
             )
             .expect("failed to create `deployment_head` gauge");
-        let deployment_failed = registry
-            .new_gauge(
-                "deployment_failed",
-                "Boolean gauge to indicate whether the deployment has failed (1 == failed)",
-                labels,
-            )
-            .expect("failed to create `deployment_failed` gauge");
         Self {
             deployment_head,
-            deployment_failed,
             reverted_blocks,
             stopwatch,
         }

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -209,6 +209,10 @@ impl TestContext {
         let (logger, deployment, raw) = self.get_runner_context().await;
         let tp: Box<dyn TriggerProcessor<_, _>> = Box::new(SubgraphTriggerProcessor {});
 
+        let deployment_status_metric = self
+            .instance_manager
+            .new_deployment_status_metric(&deployment);
+
         self.instance_manager
             .build_subgraph_runner(
                 logger,
@@ -217,6 +221,7 @@ impl TestContext {
                 raw,
                 Some(stop_block.block_number()),
                 tp,
+                deployment_status_metric,
             )
             .await
             .unwrap()
@@ -234,6 +239,10 @@ impl TestContext {
             graph_chain_substreams::TriggerProcessor::new(deployment.clone()),
         );
 
+        let deployment_status_metric = self
+            .instance_manager
+            .new_deployment_status_metric(&deployment);
+
         self.instance_manager
             .build_subgraph_runner(
                 logger,
@@ -242,6 +251,7 @@ impl TestContext {
                 raw,
                 Some(stop_block.block_number()),
                 tp,
+                deployment_status_metric,
             )
             .await
             .unwrap()


### PR DESCRIPTION
This PR adds a new `deployment_status` metric with the following behavior:
- Once graph-node has figured out that it should index a deployment, `deployment_status` is set to `1` _(starting)_;
- When the block stream is created and blocks are ready to be processed, `deployment_status` is set to `2` _(running)_;
- When a deployment is unassigned, `deployment_status` is set to `3` _(stopped)_;
- If a temporary or permanent failure occurs, `deployment_status` is set to `4` _(failed)_;
    - If indexing manages to recover from a temporary failure, the `deployment_status` is set back to `2` _(running)_;

_No other values for `deployment_status` should be expected._

Closes #5405

## Breaking changes

The `deployment_failed` metric is removed and the failures are reported by the new `deployment_status` metric.

Node operators that relied on `deployment_failed` should switch to using `deployment_status`.

## Testing

The new metric was tested on a local graph-node and Prometheus setup. I have tested various scenarios such as errors, pauses, restarts and the metric behaves as expected and reports correct values.