### PR TITLE
Improve IPFS client selection

### DIFF
--- a/graph/src/ipfs/client.rs
+++ b/graph/src/ipfs/client.rs
@@ -36,16 +36,19 @@ pub trait IpfsClient: Send + Sync + 'static {
         timeout: Option<Duration>,
         retry_policy: RetryPolicy,
     ) -> IpfsResult<BoxStream<'static, IpfsResult<Bytes>>> {
-        let fut = retry_policy.create("IPFS.cat_stream", self.logger()).run({
-            let path = path.to_owned();
+        let fut = retry_policy
+            .create("IPFS.cat_stream", self.logger())
+            .no_timeout()
+            .run({
+                let path = path.to_owned();
 
-            move || {
-                let path = path.clone();
-                let client = self.clone();
+                move || {
+                    let path = path.clone();
+                    let client = self.clone();
 
-                async move { client.call(IpfsRequest::Cat(path)).await }
-            }
-        });
+                    async move { client.call(IpfsRequest::Cat(path)).await }
+                }
+            });
 
         let resp = run_with_optional_timeout(path, fut, timeout).await?;
 
@@ -63,22 +66,25 @@ pub trait IpfsClient: Send + Sync + 'static {
         timeout: Option<Duration>,
         retry_policy: RetryPolicy,
     ) -> IpfsResult<Bytes> {
-        let fut = retry_policy.create("IPFS.cat", self.logger()).run({
-            let path = path.to_owned();
+        let fut = retry_policy
+            .create("IPFS.cat", self.logger())
+            .no_timeout()
+            .run({
+                let path = path.to_owned();
 
-            move || {
-                let path = path.clone();
-                let client = self.clone();
+                move || {
+                    let path = path.clone();
+                    let client = self.clone();
 
-                async move {
-                    client
-                        .call(IpfsRequest::Cat(path))
-                        .await?
-                        .bytes(Some(max_size))
-                        .await
+                    async move {
+                        client
+                            .call(IpfsRequest::Cat(path))
+                            .await?
+                            .bytes(Some(max_size))
+                            .await
+                    }
                 }
-            }
-        });
+            });
 
         run_with_optional_timeout(path, fut, timeout).await
     }
@@ -93,22 +99,25 @@ pub trait IpfsClient: Send + Sync + 'static {
         timeout: Option<Duration>,
         retry_policy: RetryPolicy,
     ) -> IpfsResult<Bytes> {
-        let fut = retry_policy.create("IPFS.get_block", self.logger()).run({
-            let path = path.to_owned();
+        let fut = retry_policy
+            .create("IPFS.get_block", self.logger())
+            .no_timeout()
+            .run({
+                let path = path.to_owned();
 
-            move || {
-                let path = path.clone();
-                let client = self.clone();
+                move || {
+                    let path = path.clone();
+                    let client = self.clone();
 
-                async move {
-                    client
-                        .call(IpfsRequest::GetBlock(path))
-                        .await?
-                        .bytes(None)
-                        .await
+                    async move {
+                        client
+                            .call(IpfsRequest::GetBlock(path))
+                            .await?
+                            .bytes(None)
+                            .await
+                    }
                 }
-            }
-        });
+            });
 
         run_with_optional_timeout(path, fut, timeout).await
     }

--- a/graph/src/ipfs/gateway_client.rs
+++ b/graph/src/ipfs/gateway_client.rs
@@ -80,6 +80,8 @@ impl IpfsGatewayClient {
 
         let fut = RetryPolicy::NonDeterministic
             .create("IPFS.Gateway.send_test_request", &self.logger)
+            .no_logging()
+            .no_timeout()
             .run(move || {
                 let req = req.try_clone().expect("request can be cloned");
 

--- a/graph/src/ipfs/rpc_client.rs
+++ b/graph/src/ipfs/rpc_client.rs
@@ -69,6 +69,8 @@ impl IpfsRpcClient {
     async fn send_test_request(&self) -> anyhow::Result<()> {
         let fut = RetryPolicy::NonDeterministic
             .create("IPFS.RPC.send_test_request", &self.logger)
+            .no_logging()
+            .no_timeout()
             .run({
                 let client = self.to_owned();
 


### PR DESCRIPTION
This PR improves IPFS client selection by sending concurrent requests to all supported IPFS APIs and selecting the first one that responds with the expected status code.

Also, logging of IPFS test request retries has been disabled to not make it look like something is not working correctly.