### PR TITLE
compiler fix

### DIFF
--- a/core/src/subgraph/context/instance/hosts.rs
+++ b/core/src/subgraph/context/instance/hosts.rs
@@ -194,7 +194,7 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> OffchainHosts<C, T> {
     pub fn matches_by_address<'a>(
         &'a self,
         address: Option<&[u8]>,
-    ) -> Box<dyn Iterator<Item = &T::Host> + Send + 'a> {
+    ) -> Box<dyn Iterator<Item = &'a T::Host> + Send + 'a> {
         let Some(address) = address else {
             return Box::new(self.by_block.values().flatten().map(|host| host.as_ref()));
         };

--- a/graph/src/util/lfu_cache.rs
+++ b/graph/src/util/lfu_cache.rs
@@ -179,7 +179,7 @@ impl<K: Clone + Ord + Eq + Hash + Debug + CacheWeight, V: CacheWeight + Default>
         })
     }
 
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (&K, &V)> {
+    pub fn iter<'a>(&'a self) -> impl Iterator<Item = (&'a K, &'a V)> {
         self.queue
             .iter()
             .map(|entry| (&entry.0.key, &entry.0.value))


### PR DESCRIPTION
Rust 1.83 is more strict with implicit lifetimes. This fixes a couple of warnings.