### PR TITLE
Rework generation of the VID

### DIFF
--- a/chain/substreams/src/trigger.rs
+++ b/chain/substreams/src/trigger.rs
@@ -240,6 +240,7 @@ where
                     state.entity_cache.set(
                         key,
                         entity,
+                        block.number,
                         Some(&mut state.write_capacity_remaining),
                     )?;
                 }

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -1670,6 +1670,7 @@ async fn update_proof_of_indexing(
         key: EntityKey,
         digest: Bytes,
         block_time: BlockTime,
+        block: BlockNumber,
     ) -> Result<(), Error> {
         let digest_name = entity_cache.schema.poi_digest();
         let mut data = vec![
@@ -1684,11 +1685,12 @@ async fn update_proof_of_indexing(
             data.push((entity_cache.schema.poi_block_time(), block_time));
         }
         let poi = entity_cache.make_entity(data)?;
-        entity_cache.set(key, poi, None)
+        entity_cache.set(key, poi, block, None)
     }
 
     let _section_guard = stopwatch.start_section("update_proof_of_indexing");
 
+    let block_number = proof_of_indexing.get_block();
     let mut proof_of_indexing = proof_of_indexing.take();
 
     for (causality_region, stream) in proof_of_indexing.drain() {
@@ -1724,6 +1726,7 @@ async fn update_proof_of_indexing(
             entity_key,
             updated_proof_of_indexing,
             block_time,
+            block_number,
         )?;
     }
 

--- a/graph/src/components/subgraph/proof_of_indexing/online.rs
+++ b/graph/src/components/subgraph/proof_of_indexing/online.rs
@@ -242,6 +242,10 @@ impl ProofOfIndexing {
     pub fn take(self) -> HashMap<Id, BlockEventStream> {
         self.per_causality_region
     }
+
+    pub fn get_block(&self) -> BlockNumber {
+        self.block_number
+    }
 }
 
 pub struct ProofOfIndexingFinisher {

--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     derive::CacheWeight,
     prelude::{lazy_static, q, r, s, CacheWeight, QueryExecutionError},
     runtime::gas::{Gas, GasSizeOf},
-    schema::{EntityKey, EntityType},
+    schema::{input::VID_FIELD, EntityKey, EntityType},
     util::intern::{self, AtomPool},
     util::intern::{Error as InternError, NullValue, Object},
 };
@@ -908,6 +908,29 @@ impl Entity {
     /// return an error
     pub fn id(&self) -> Id {
         Id::try_from(self.get("id").unwrap().clone()).expect("the id is set to a valid value")
+    }
+
+    /// Return the VID of this entity and if its missing or of a type different than
+    /// i64 it panics.
+    pub fn vid(&self) -> i64 {
+        self.get(VID_FIELD)
+            .expect("the vid must be set")
+            .as_int8()
+            .expect("the vid must be set to a valid value")
+    }
+
+    /// Sets the VID of the entity. The previous one is returned.
+    pub fn set_vid(&mut self, value: i64) -> Result<Option<Value>, InternError> {
+        self.0.insert(VID_FIELD, value.into())
+    }
+
+    /// Sets the VID if it's not already set. Should be used only for tests.
+    #[cfg(debug_assertions)]
+    pub fn set_vid_if_empty(&mut self) {
+        let vid = self.get(VID_FIELD);
+        if vid.is_none() {
+            let _ = self.set_vid(100).expect("the vid should be set");
+        }
     }
 
     /// Merges an entity update `update` into this entity.

--- a/graph/src/data/subgraph/api_version.rs
+++ b/graph/src/data/subgraph/api_version.rs
@@ -54,11 +54,14 @@ pub const SPEC_VERSION_1_1_0: Version = Version::new(1, 1, 0);
 // Enables eth call declarations and indexed arguments(topics) filtering in manifest
 pub const SPEC_VERSION_1_2_0: Version = Version::new(1, 2, 0);
 
-// Enables subgraphs as datasource
+// Enables subgraphs as datasource.
+// Changes the way the VID field is generated. It used to be autoincrement. Now its
+// based on block number and the order of the entities in a block. The latter
+// represents the write order across all entity types in the subgraph.
 pub const SPEC_VERSION_1_3_0: Version = Version::new(1, 3, 0);
 
 // The latest spec version available
-pub const LATEST_VERSION: &Version = &SPEC_VERSION_1_2_0;
+pub const LATEST_VERSION: &Version = &SPEC_VERSION_1_3_0;
 
 pub const MIN_SPEC_VERSION: Version = Version::new(0, 0, 2);
 

--- a/graph/src/schema/input/mod.rs
+++ b/graph/src/schema/input/mod.rs
@@ -35,6 +35,7 @@ pub(crate) const POI_OBJECT: &str = "Poi$";
 const POI_DIGEST: &str = "digest";
 /// The name of the PoI attribute for storing the block time
 const POI_BLOCK_TIME: &str = "blockTime";
+pub(crate) const VID_FIELD: &str = "vid";
 
 pub mod kw {
     pub const ENTITY: &str = "entity";
@@ -1596,6 +1597,8 @@ fn atom_pool(document: &s::Document) -> AtomPool {
     pool.intern(POI_OBJECT);
     pool.intern(POI_DIGEST);
     pool.intern(POI_BLOCK_TIME);
+
+    pool.intern(VID_FIELD);
 
     for definition in &document.definitions {
         match definition {

--- a/graph/src/schema/mod.rs
+++ b/graph/src/schema/mod.rs
@@ -21,7 +21,7 @@ pub mod ast;
 mod entity_key;
 mod entity_type;
 mod fulltext;
-mod input;
+pub(crate) mod input;
 
 pub use api::{is_introspection_field, APISchemaError, INTROSPECTION_QUERY_TYPE};
 

--- a/runtime/test/src/test.rs
+++ b/runtime/test/src/test.rs
@@ -477,13 +477,13 @@ async fn test_ipfs_block() {
 // The user_data value we use with calls to ipfs_map
 const USER_DATA: &str = "user_data";
 
-fn make_thing(id: &str, value: &str) -> (String, EntityModification) {
+fn make_thing(id: &str, value: &str, vid: i64) -> (String, EntityModification) {
     const DOCUMENT: &str = " type Thing @entity { id: String!, value: String!, extra: String }";
     lazy_static! {
         static ref SCHEMA: InputSchema = InputSchema::raw(DOCUMENT, "doesntmatter");
         static ref THING_TYPE: EntityType = SCHEMA.entity_type("Thing").unwrap();
     }
-    let data = entity! { SCHEMA => id: id, value: value, extra: USER_DATA };
+    let data = entity! { SCHEMA => id: id, value: value, extra: USER_DATA, vid: vid };
     let key = THING_TYPE.parse_key(id).unwrap();
     (
         format!("{{ \"id\": \"{}\", \"value\": \"{}\"}}", id, value),
@@ -553,8 +553,8 @@ async fn test_ipfs_map(api_version: Version, json_error_msg: &str) {
     let subgraph_id = "ipfsMap";
 
     // Try it with two valid objects
-    let (str1, thing1) = make_thing("one", "eins");
-    let (str2, thing2) = make_thing("two", "zwei");
+    let (str1, thing1) = make_thing("one", "eins", 100);
+    let (str2, thing2) = make_thing("two", "zwei", 100);
     let ops = run_ipfs_map(
         subgraph_id,
         format!("{}\n{}", str1, str2),
@@ -1001,8 +1001,8 @@ async fn test_entity_store(api_version: Version) {
 
     let schema = store.input_schema(&deployment.hash).unwrap();
 
-    let alex = entity! { schema => id: "alex", name: "Alex" };
-    let steve = entity! { schema => id: "steve", name: "Steve" };
+    let alex = entity! { schema => id: "alex", name: "Alex", vid: 0i64 };
+    let steve = entity! { schema => id: "steve", name: "Steve", vid: 1i64 };
     let user_type = schema.entity_type("User").unwrap();
     test_store::insert_entities(
         &deployment,

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -350,9 +350,12 @@ impl HostExports {
 
         state.metrics.track_entity_write(&entity_type, &entity);
 
-        state
-            .entity_cache
-            .set(key, entity, Some(&mut state.write_capacity_remaining))?;
+        state.entity_cache.set(
+            key,
+            entity,
+            block,
+            Some(&mut state.write_capacity_remaining),
+        )?;
 
         Ok(())
     }

--- a/store/postgres/src/relational/ddl.rs
+++ b/store/postgres/src/relational/ddl.rs
@@ -116,12 +116,19 @@ impl Table {
             Ok(cols)
         }
 
+        // Currently the agregations entities don't have VIDs in insertion order
+        let vid_type = if self.object.is_object_type() {
+            "bigint"
+        } else {
+            "bigserial"
+        };
+
         if self.immutable {
             writeln!(
                 out,
                 "
     create table {qname} (
-        {vid}                  bigserial primary key,
+        {vid}                  {vid_type} primary key,
         {block}                int not null,\n\
         {cols},
         unique({id})
@@ -129,6 +136,7 @@ impl Table {
                 qname = self.qualified_name,
                 cols = columns_ddl(self)?,
                 vid = VID_COLUMN,
+                vid_type = vid_type,
                 block = BLOCK_COLUMN,
                 id = self.primary_key().name
             )
@@ -137,13 +145,14 @@ impl Table {
                 out,
                 r#"
     create table {qname} (
-        {vid}                  bigserial primary key,
+        {vid}                  {vid_type} primary key,
         {block_range}          int4range not null,
         {cols}
     );"#,
                 qname = self.qualified_name,
                 cols = columns_ddl(self)?,
                 vid = VID_COLUMN,
+                vid_type = vid_type,
                 block_range = BLOCK_RANGE_COLUMN
             )?;
 

--- a/store/postgres/src/relational/ddl_tests.rs
+++ b/store/postgres/src/relational/ddl_tests.rs
@@ -384,7 +384,7 @@ create type sgd0815."size"
     as enum ('large', 'medium', 'small');
 
     create table "sgd0815"."thing" (
-        vid                  bigserial primary key,
+        vid                  bigint primary key,
         block_range          int4range not null,
         "id"                 text not null,
         "big_thing"          text not null
@@ -405,7 +405,7 @@ create index attr_0_1_thing_big_thing
 
 
     create table "sgd0815"."scalar" (
-        vid                  bigserial primary key,
+        vid                  bigint primary key,
         block_range          int4range not null,
         "id"                 text not null,
         "bool"               boolean,
@@ -444,7 +444,7 @@ create index attr_1_7_scalar_color
 
 
     create table "sgd0815"."file_thing" (
-        vid                  bigserial primary key,
+        vid                  bigint primary key,
         block_range          int4range not null,
         causality_region     int not null,
         "id"                 text not null
@@ -469,7 +469,7 @@ create type sgd0815."size"
     as enum ('large', 'medium', 'small');
 
     create table "sgd0815"."thing" (
-        vid                  bigserial primary key,
+        vid                  bigint primary key,
         block_range          int4range not null,
         "id"                 text not null,
         "big_thing"          text not null
@@ -490,7 +490,7 @@ create index attr_0_1_thing_big_thing
 
 
     create table "sgd0815"."scalar" (
-        vid                  bigserial primary key,
+        vid                  bigint primary key,
         block_range          int4range not null,
         "id"                 text not null,
         "bool"               boolean,
@@ -515,7 +515,7 @@ create index attr_1_0_scalar_id
 
 
     create table "sgd0815"."file_thing" (
-        vid                  bigserial primary key,
+        vid                  bigint primary key,
         block_range          int4range not null,
         causality_region     int not null,
         "id"                 text not null
@@ -575,7 +575,7 @@ type SongStat @entity {
     played: Int!
 }"#;
 const MUSIC_DDL: &str = r#"create table "sgd0815"."musician" (
-        vid                  bigserial primary key,
+        vid                  bigint primary key,
         block_range          int4range not null,
         "id"                 text not null,
         "name"               text not null,
@@ -598,7 +598,7 @@ create index attr_0_2_musician_main_band
     on "sgd0815"."musician" using gist("main_band", block_range);
 
 create table "sgd0815"."band" (
-        vid                  bigserial primary key,
+        vid                  bigint primary key,
         block_range          int4range not null,
         "id"                 text not null,
         "name"               text not null,
@@ -618,8 +618,8 @@ create index attr_1_1_band_name
     on "sgd0815"."band" using btree(left("name", 256));
 
 create table "sgd0815"."song" (
-        vid                    bigserial primary key,
-        block$                 int not null,
+        vid                  bigint primary key,
+        block$               int not null,
         "id"                 text not null,
         "title"              text not null,
         "written_by"         text not null,
@@ -634,7 +634,7 @@ create index attr_2_1_song_written_by
     on "sgd0815"."song" using btree("written_by", block$);
 
 create table "sgd0815"."song_stat" (
-        vid                  bigserial primary key,
+        vid                  bigint primary key,
         block_range          int4range not null,
         "id"                 text not null,
         "played"             int4 not null
@@ -676,7 +676,7 @@ type Habitat @entity {
 }"#;
 
 const FOREST_DDL: &str = r#"create table "sgd0815"."animal" (
-        vid                  bigserial primary key,
+        vid                  bigint primary key,
         block_range          int4range not null,
         "id"                 text not null,
         "forest"             text
@@ -695,8 +695,8 @@ create index attr_0_1_animal_forest
     on "sgd0815"."animal" using gist("forest", block_range);
 
 create table "sgd0815"."forest" (
-        vid                  bigserial primary key,
-        block_range          int4range not null,
+        vid                bigint primary key,
+        block_range        int4range not null,
         "id"               text not null
 );
 alter table "sgd0815"."forest"
@@ -711,7 +711,7 @@ create index attr_1_0_forest_id
     on "sgd0815"."forest" using btree("id");
 
 create table "sgd0815"."habitat" (
-        vid                  bigserial primary key,
+        vid                  bigint primary key,
         block_range          int4range not null,
         "id"                 text not null,
         "most_common"        text not null,
@@ -763,7 +763,7 @@ type Habitat @entity {
 }"#;
 
 const FULLTEXT_DDL: &str = r#"create table "sgd0815"."animal" (
-        vid                  bigserial primary key,
+        vid                  bigint primary key,
         block_range          int4range not null,
         "id"                 text not null,
         "name"               text not null,
@@ -791,7 +791,7 @@ create index attr_0_4_animal_search
     on "sgd0815"."animal" using gin("search");
 
 create table "sgd0815"."forest" (
-        vid                  bigserial primary key,
+        vid                  bigint primary key,
         block_range          int4range not null,
         "id"                 text not null
 );
@@ -808,7 +808,7 @@ create index attr_1_0_forest_id
     on "sgd0815"."forest" using btree("id");
 
 create table "sgd0815"."habitat" (
-        vid                  bigserial primary key,
+        vid                  bigint primary key,
         block_range          int4range not null,
         "id"                 text not null,
         "most_common"        text not null,
@@ -843,7 +843,7 @@ enum Orientation {
 const FORWARD_ENUM_SQL: &str = r#"create type sgd0815."orientation"
     as enum ('DOWN', 'UP');
 create table "sgd0815"."thing" (
-        vid                  bigserial primary key,
+        vid                  bigint primary key,
         block_range          int4range not null,
         "id"                 text not null,
         "orientation"        "sgd0815"."orientation" not null
@@ -880,8 +880,8 @@ type Stats @aggregation(intervals: ["hour", "day"], source: "Data") {
 
 const TS_SQL: &str = r#"
 create table "sgd0815"."data" (
-    vid                  bigserial primary key,
-    block$                int not null,
+    vid                  bigint primary key,
+    block$               int not null,
     "id"                 int8 not null,
     "timestamp"          timestamptz not null,
     "amount"             numeric not null,
@@ -896,7 +896,7 @@ create index attr_0_1_data_amount
 
 create table "sgd0815"."stats_hour" (
     vid                  bigserial primary key,
-    block$                int not null,
+    block$               int not null,
     "id"                 int8 not null,
     "timestamp"          timestamptz not null,
     "volume"             numeric not null,
@@ -971,9 +971,9 @@ const LIFETIME_GQL: &str = r#"
 
 const LIFETIME_SQL: &str = r#"
 create table "sgd0815"."data" (
-    vid                  bigserial primary key,
-    block$                int not null,
-"id"                 int8 not null,
+    vid                  bigint primary key,
+    block$               int not null,
+    "id"                 int8 not null,
     "timestamp"          timestamptz not null,
     "group_1"            int4 not null,
     "group_2"            int4 not null,
@@ -993,8 +993,8 @@ on "sgd0815"."data" using btree("amount");
 
 create table "sgd0815"."stats_1_hour" (
     vid                  bigserial primary key,
-    block$                int not null,
-"id"                 int8 not null,
+    block$               int not null,
+    "id"                 int8 not null,
     "timestamp"          timestamptz not null,
     "volume"             numeric not null,
     unique(id)
@@ -1009,8 +1009,8 @@ on "sgd0815"."stats_1_hour" using btree("volume");
 
 create table "sgd0815"."stats_1_day" (
     vid                  bigserial primary key,
-    block$                int not null,
-"id"                 int8 not null,
+    block$               int not null,
+    "id"                 int8 not null,
     "timestamp"          timestamptz not null,
     "volume"             numeric not null,
     unique(id)
@@ -1025,8 +1025,8 @@ on "sgd0815"."stats_1_day" using btree("volume");
 
 create table "sgd0815"."stats_2_hour" (
     vid                  bigserial primary key,
-    block$                int not null,
-"id"                 int8 not null,
+    block$               int not null,
+    "id"                 int8 not null,
     "timestamp"          timestamptz not null,
     "group_1"            int4 not null,
     "volume"             numeric not null,
@@ -1045,8 +1045,8 @@ on "sgd0815"."stats_2_hour"(group_1, timestamp);
 
 create table "sgd0815"."stats_2_day" (
     vid                  bigserial primary key,
-    block$                int not null,
-"id"                 int8 not null,
+    block$               int not null,
+    "id"                 int8 not null,
     "timestamp"          timestamptz not null,
     "group_1"            int4 not null,
     "volume"             numeric not null,
@@ -1065,8 +1065,8 @@ on "sgd0815"."stats_2_day"(group_1, timestamp);
 
 create table "sgd0815"."stats_3_hour" (
     vid                  bigserial primary key,
-    block$                int not null,
-"id"                 int8 not null,
+    block$               int not null,
+    "id"                 int8 not null,
     "timestamp"          timestamptz not null,
     "group_2"            int4 not null,
     "group_1"            int4 not null,
@@ -1088,8 +1088,8 @@ on "sgd0815"."stats_3_hour"(group_2, group_1, timestamp);
 
 create table "sgd0815"."stats_3_day" (
     vid                  bigserial primary key,
-    block$                int not null,
-"id"                 int8 not null,
+    block$               int not null,
+    "id"                 int8 not null,
     "timestamp"          timestamptz not null,
     "group_2"            int4 not null,
     "group_1"            int4 not null,

--- a/store/postgres/src/relational/dsl.rs
+++ b/store/postgres/src/relational/dsl.rs
@@ -254,7 +254,10 @@ impl<'a> Table<'a> {
         }
 
         match column_names {
-            AttributeNames::All => cols.extend(self.meta.columns.iter()),
+            AttributeNames::All => {
+                cols.extend(self.meta.columns.iter());
+                cols.push(&*VID_COL);
+            }
             AttributeNames::Select(names) => {
                 let pk = self.meta.primary_key();
                 cols.push(pk);

--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -243,6 +243,7 @@ impl TablePair {
 
         let vid_seq = format!("{}_{VID_COLUMN}_seq", self.src.name);
 
+        let old_vid_form = !self.src.object.is_object_type();
         let mut query = String::new();
 
         // What we are about to do would get blocked by autovacuum on our
@@ -254,10 +255,12 @@ impl TablePair {
 
         // Make sure the vid sequence
         // continues from where it was
-        writeln!(
-            query,
-            "select setval('{dst_nsp}.{vid_seq}', nextval('{src_nsp}.{vid_seq}'));"
-        )?;
+        if old_vid_form {
+            writeln!(
+                query,
+                "select setval('{dst_nsp}.{vid_seq}', nextval('{src_nsp}.{vid_seq}'));"
+            )?;
+        }
 
         writeln!(query, "drop table {src_qname};")?;
         writeln!(query, "alter table {dst_qname} set schema {src_nsp}")?;

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -422,12 +422,13 @@ pub async fn insert_entities(
     deployment: &DeploymentLocator,
     entities: Vec<(EntityType, Entity)>,
 ) -> Result<(), StoreError> {
-    let insert_ops = entities
-        .into_iter()
-        .map(|(entity_type, data)| EntityOperation::Set {
+    let insert_ops = entities.into_iter().map(|(entity_type, mut data)| {
+        data.set_vid_if_empty();
+        EntityOperation::Set {
             key: entity_type.key(data.id()),
             data,
-        });
+        }
+    });
 
     transact_entity_operations(
         &SUBGRAPH_STORE,

--- a/store/test-store/tests/core/interfaces.rs
+++ b/store/test-store/tests/core/interfaces.rs
@@ -201,9 +201,9 @@ async fn reference_interface_derived() {
 
     let query = "query { events { id transaction { id } } }";
 
-    let buy = ("BuyEvent", entity! { schema => id: "buy" });
-    let sell1 = ("SellEvent", entity! { schema => id: "sell1" });
-    let sell2 = ("SellEvent", entity! { schema => id: "sell2" });
+    let buy = ("BuyEvent", entity! { schema => id: "buy", vid: 0i64 });
+    let sell1 = ("SellEvent", entity! { schema => id: "sell1", vid: 1i64 });
+    let sell2 = ("SellEvent", entity! { schema => id: "sell2", vid: 2i64 });
     let gift = (
         "GiftEvent",
         entity! { schema => id: "gift", transaction: "txn" },
@@ -278,11 +278,11 @@ async fn follow_interface_reference() {
 
     let parent = (
         "Animal",
-        entity! { schema => id: "parent", legs: 4, parent: Value::Null },
+        entity! { schema => id: "parent", legs: 4, parent: Value::Null, vid: 0i64},
     );
     let child = (
         "Animal",
-        entity! { schema => id: "child", legs: 3, parent: "parent" },
+        entity! { schema => id: "child", legs: 3, parent: "parent" , vid: 1i64},
     );
 
     let res = insert_and_query(subgraph_id, document, vec![parent, child], query)
@@ -459,16 +459,16 @@ async fn interface_inline_fragment_with_subquery() {
     ";
     let schema = InputSchema::raw(document, subgraph_id);
 
-    let mama_cow = ("Parent", entity! { schema =>  id: "mama_cow" });
+    let mama_cow = ("Parent", entity! { schema =>  id: "mama_cow", vid: 0i64 });
     let cow = (
         "Animal",
-        entity! { schema =>  id: "1", name: "cow", legs: 4, parent: "mama_cow" },
+        entity! { schema =>  id: "1", name: "cow", legs: 4, parent: "mama_cow", vid: 0i64 },
     );
 
-    let mama_bird = ("Parent", entity! { schema =>  id: "mama_bird" });
+    let mama_bird = ("Parent", entity! { schema =>  id: "mama_bird", vid: 1i64 });
     let bird = (
         "Bird",
-        entity! { schema =>  id: "2", airspeed: 5, legs: 2, parent: "mama_bird" },
+        entity! { schema =>  id: "2", airspeed: 5, legs: 2, parent: "mama_bird", vid: 1i64 },
     );
 
     let query = "query { leggeds(orderBy: legs) { legs ... on Bird { airspeed parent { id } } } }";
@@ -545,11 +545,11 @@ async fn alias() {
 
     let parent = (
         "Animal",
-        entity! { schema =>  id: "parent", legs: 4, parent: Value::Null },
+        entity! { schema =>  id: "parent", legs: 4, parent: Value::Null, vid: 0i64 },
     );
     let child = (
         "Animal",
-        entity! { schema =>  id: "child", legs: 3, parent: "parent" },
+        entity! { schema =>  id: "child", legs: 3, parent: "parent", vid: 1i64 },
     );
 
     let res = insert_and_query(subgraph_id, document, vec![parent, child], query)
@@ -608,9 +608,15 @@ async fn fragments_dont_panic() {
     ";
 
     // The panic manifests if two parents exist.
-    let parent = ("Parent", entity! { schema => id: "p", child: "c" });
-    let parent2 = ("Parent", entity! { schema => id: "p2", child: Value::Null });
-    let child = ("Child", entity! { schema => id:"c" });
+    let parent = (
+        "Parent",
+        entity! { schema => id: "p", child: "c", vid: 0i64 },
+    );
+    let parent2 = (
+        "Parent",
+        entity! { schema => id: "p2", child: Value::Null, vid: 1i64 },
+    );
+    let child = ("Child", entity! { schema => id:"c", vid: 2i64 });
 
     let res = insert_and_query(subgraph_id, document, vec![parent, parent2, child], query)
         .await
@@ -668,12 +674,15 @@ async fn fragments_dont_duplicate_data() {
     ";
 
     // This bug manifests if two parents exist.
-    let parent = ("Parent", entity! { schema => id: "p", children: vec!["c"] });
+    let parent = (
+        "Parent",
+        entity! { schema => id: "p", children: vec!["c"], vid: 0i64 },
+    );
     let parent2 = (
         "Parent",
-        entity! { schema => id: "b", children: Vec::<String>::new() },
+        entity! { schema => id: "b", children: Vec::<String>::new(), vid: 1i64 },
     );
-    let child = ("Child", entity! { schema => id:"c" });
+    let child = ("Child", entity! { schema => id:"c", vid: 2i64 });
 
     let res = insert_and_query(subgraph_id, document, vec![parent, parent2, child], query)
         .await
@@ -721,11 +730,11 @@ async fn redundant_fields() {
 
     let parent = (
         "Animal",
-        entity! { schema => id: "parent", parent: Value::Null },
+        entity! { schema => id: "parent", parent: Value::Null, vid: 0i64 },
     );
     let child = (
         "Animal",
-        entity! { schema => id: "child", parent: "parent" },
+        entity! { schema => id: "child", parent: "parent", vid: 1i64 },
     );
 
     let res = insert_and_query(subgraph_id, document, vec![parent, child], query)
@@ -783,8 +792,11 @@ async fn fragments_merge_selections() {
         }
     ";
 
-    let parent = ("Parent", entity! { schema => id: "p", children: vec!["c"] });
-    let child = ("Child", entity! { schema => id: "c", foo: 1 });
+    let parent = (
+        "Parent",
+        entity! { schema => id: "p", children: vec!["c"], vid: 0i64 },
+    );
+    let child = ("Child", entity! { schema => id: "c", foo: 1, vid: 1i64 });
 
     let res = insert_and_query(subgraph_id, document, vec![parent, child], query)
         .await
@@ -1081,11 +1093,11 @@ async fn enums() {
     let entities = vec![
         (
             "Trajectory",
-            entity! { schema =>  id: "1", direction: "EAST", meters: 10 },
+            entity! { schema =>  id: "1", direction: "EAST", meters: 10, vid: 0i64 },
         ),
         (
             "Trajectory",
-            entity! { schema =>  id: "2", direction: "NORTH", meters: 15 },
+            entity! { schema =>  id: "2", direction: "NORTH", meters: 15, vid: 1i64 },
         ),
     ];
     let query = "query { trajectories { id, direction, meters } }";
@@ -1134,15 +1146,15 @@ async fn enum_list_filters() {
     let entities = vec![
         (
             "Trajectory",
-            entity! { schema =>  id: "1", direction: "EAST", meters: 10 },
+            entity! { schema =>  id: "1", direction: "EAST", meters: 10, vid: 0i64 },
         ),
         (
             "Trajectory",
-            entity! { schema =>  id: "2", direction: "NORTH", meters: 15 },
+            entity! { schema =>  id: "2", direction: "NORTH", meters: 15, vid: 1i64 },
         ),
         (
             "Trajectory",
-            entity! { schema =>  id: "3", direction: "WEST", meters: 20 },
+            entity! { schema =>  id: "3", direction: "WEST", meters: 20, vid: 2i64 },
         ),
     ];
 
@@ -1327,8 +1339,8 @@ async fn derived_interface_bytes() {
 
     let entities = vec![
         ("Pool", entity! { schema =>  id: b("0xf001") }),
-        ("Sell", entity! { schema =>  id: b("0xc0"), pool: "0xf001"}),
-        ("Buy", entity! { schema =>  id: b("0xb0"), pool: "0xf001"}),
+        ("Sell", entity! { schema =>  id: b("0xc0"), pool: "0xf001" }),
+        ("Buy", entity! { schema =>  id: b("0xb0"), pool: "0xf001" }),
     ];
 
     let res = insert_and_query(subgraph_id, document, entities, query)

--- a/store/test-store/tests/graphql/query.rs
+++ b/store/test-store/tests/graphql/query.rs
@@ -424,9 +424,12 @@ async fn insert_test_entities(
             .into_iter()
             .map(|(typename, entities)| {
                 let entity_type = schema.entity_type(typename).unwrap();
-                entities.into_iter().map(move |data| EntityOperation::Set {
-                    key: entity_type.key(data.id()),
-                    data,
+                entities.into_iter().map(move |mut data| {
+                    data.set_vid_if_empty();
+                    EntityOperation::Set {
+                        key: entity_type.key(data.id()),
+                        data,
+                    }
                 })
             })
             .flatten()
@@ -468,115 +471,118 @@ async fn insert_test_entities(
         (
             "Musician",
             vec![
-                entity! { is => id: "m1", name: "John", mainBand: "b1", bands: vec!["b1", "b2"], favoriteCount: 10, birthDate: timestamp.clone() },
-                entity! { is => id: "m2", name: "Lisa", mainBand: "b1", bands: vec!["b1"], favoriteCount: 100, birthDate: timestamp.clone() },
+                entity! { is => id: "m1", name: "John", mainBand: "b1", bands: vec!["b1", "b2"], favoriteCount: 10, birthDate: timestamp.clone(), vid: 0i64 },
+                entity! { is => id: "m2", name: "Lisa", mainBand: "b1", bands: vec!["b1"], favoriteCount: 100, birthDate: timestamp.clone(), vid: 1i64 },
             ],
         ),
-        ("Publisher", vec![entity! { is => id: pub1 }]),
+        ("Publisher", vec![entity! { is => id: pub1, vid: 0i64 }]),
         (
             "Band",
             vec![
-                entity! { is => id: "b1", name: "The Musicians", originalSongs: vec![s[1], s[2]] },
-                entity! { is => id: "b2", name: "The Amateurs",  originalSongs: vec![s[1], s[3], s[4]] },
+                entity! { is => id: "b1", name: "The Musicians", originalSongs: vec![s[1], s[2]], vid: 0i64 },
+                entity! { is => id: "b2", name: "The Amateurs",  originalSongs: vec![s[1], s[3], s[4]], vid: 1i64 },
             ],
         ),
         (
             "Song",
             vec![
-                entity! { is => id: s[1], sid: "s1", title: "Cheesy Tune",  publisher: pub1, writtenBy: "m1", media: vec![md[1], md[2]] },
-                entity! { is => id: s[2], sid: "s2", title: "Rock Tune",    publisher: pub1, writtenBy: "m2", media: vec![md[3], md[4]] },
-                entity! { is => id: s[3], sid: "s3", title: "Pop Tune",     publisher: pub1, writtenBy: "m1", media: vec![md[5]] },
-                entity! { is => id: s[4], sid: "s4", title: "Folk Tune",    publisher: pub1, writtenBy: "m3", media: vec![md[6]] },
+                entity! { is => id: s[1], sid: "s1", title: "Cheesy Tune",  publisher: pub1, writtenBy: "m1", media: vec![md[1], md[2]], vid: 0i64 },
+                entity! { is => id: s[2], sid: "s2", title: "Rock Tune",    publisher: pub1, writtenBy: "m2", media: vec![md[3], md[4]], vid: 1i64 },
+                entity! { is => id: s[3], sid: "s3", title: "Pop Tune",     publisher: pub1, writtenBy: "m1", media: vec![md[5]], vid: 2i64 },
+                entity! { is => id: s[4], sid: "s4", title: "Folk Tune",    publisher: pub1, writtenBy: "m3", media: vec![md[6]], vid: 3i64 },
             ],
         ),
         (
             "User",
             vec![
-                entity! { is => id: "u1", name: "User 1", latestSongReview: "r3", latestBandReview: "r1", latestReview: "r3" },
+                entity! { is => id: "u1", name: "User 1", latestSongReview: "r3", latestBandReview: "r1", latestReview: "r3", vid: 0i64 },
             ],
         ),
         (
             "SongStat",
             vec![
-                entity! { is => id: s[1], played: 10 },
-                entity! { is => id: s[2], played: 15 },
+                entity! { is => id: s[1], played: 10, vid: 0i64 },
+                entity! { is => id: s[2], played: 15, vid: 1i64 },
             ],
         ),
         (
             "BandReview",
             vec![
-                entity! { is => id: "r1", body: "Bad musicians",        band: "b1", author: "u1" },
-                entity! { is => id: "r2", body: "Good amateurs",        band: "b2", author: "u2" },
-                entity! { is => id: "r5", body: "Very Bad musicians",   band: "b1", author: "u3" },
+                entity! { is => id: "r1", body: "Bad musicians",        band: "b1", author: "u1", vid: 0i64 },
+                entity! { is => id: "r2", body: "Good amateurs",        band: "b2", author: "u2", vid: 1i64 },
+                entity! { is => id: "r5", body: "Very Bad musicians",   band: "b1", author: "u3", vid: 2i64 },
             ],
         ),
         (
             "SongReview",
             vec![
-                entity! { is => id: "r3", body: "Bad",                  song: s[2], author: "u1" },
-                entity! { is => id: "r4", body: "Good",                 song: s[3], author: "u2" },
-                entity! { is => id: "r6", body: "Very Bad",             song: s[2], author: "u3" },
+                entity! { is => id: "r3", body: "Bad",                  song: s[2], author: "u1", vid: 0i64 },
+                entity! { is => id: "r4", body: "Good",                 song: s[3], author: "u2", vid: 1i64 },
+                entity! { is => id: "r6", body: "Very Bad",             song: s[2], author: "u3", vid: 2i64 },
             ],
         ),
         (
             "User",
             vec![
-                entity! { is => id: "u1", name: "Baden",        latestSongReview: "r3", latestBandReview: "r1", latestReview: "r1" },
-                entity! { is => id: "u2", name: "Goodwill",     latestSongReview: "r4", latestBandReview: "r2", latestReview: "r2" },
+                entity! { is => id: "u1", name: "Baden",        latestSongReview: "r3", latestBandReview: "r1", latestReview: "r1", vid: 0i64 },
+                entity! { is => id: "u2", name: "Goodwill",     latestSongReview: "r4", latestBandReview: "r2", latestReview: "r2", vid: 1i64 },
             ],
         ),
         (
             "AnonymousUser",
             vec![
-                entity! { is => id: "u3", name: "Anonymous 3",  latestSongReview: "r6", latestBandReview: "r5", latestReview: "r5" },
+                entity! { is => id: "u3", name: "Anonymous 3",  latestSongReview: "r6", latestBandReview: "r5", latestReview: "r5", vid: 0i64 },
             ],
         ),
         (
             "Photo",
             vec![
-                entity! { is => id: md[1],   title: "Cheesy Tune Single Cover",  author: "u1" },
-                entity! { is => id: md[3],   title: "Rock Tune Single Cover",    author: "u1" },
-                entity! { is => id: md[5],   title: "Pop Tune Single Cover",     author: "u1" },
+                entity! { is => id: md[1],   title: "Cheesy Tune Single Cover",  author: "u1", vid: 0i64 },
+                entity! { is => id: md[3],   title: "Rock Tune Single Cover",    author: "u1", vid: 1i64 },
+                entity! { is => id: md[5],   title: "Pop Tune Single Cover",     author: "u1", vid: 2i64 },
             ],
         ),
         (
             "Video",
             vec![
-                entity! { is => id: md[2],   title: "Cheesy Tune Music Video",   author: "u2" },
-                entity! { is => id: md[4],   title: "Rock Tune Music Video",     author: "u2" },
-                entity! { is => id: md[6],   title: "Folk Tune Music Video",     author: "u2" },
+                entity! { is => id: md[2],   title: "Cheesy Tune Music Video",   author: "u2", vid: 0i64 },
+                entity! { is => id: md[4],   title: "Rock Tune Music Video",     author: "u2", vid: 1i64 },
+                entity! { is => id: md[6],   title: "Folk Tune Music Video",     author: "u2", vid: 2i64 },
             ],
         ),
         (
             "Album",
-            vec![entity! { is => id: "rl1",   title: "Pop and Folk",    songs: vec![s[3], s[4]] }],
+            vec![
+                entity! { is => id: "rl1",   title: "Pop and Folk",    songs: vec![s[3], s[4]], vid: 0i64 },
+            ],
         ),
         (
             "Single",
             vec![
-                entity! { is => id: "rl2",  title: "Rock",           songs: vec![s[2]] },
-                entity! { is => id: "rl3",  title: "Cheesy",         songs: vec![s[1]] },
-                entity! { is => id: "rl4",  title: "Silence",        songs: Vec::<graph::prelude::Value>::new() },
+                entity! { is => id: "rl2",  title: "Rock",           songs: vec![s[2]], vid: 0i64 },
+                entity! { is => id: "rl3",  title: "Cheesy",         songs: vec![s[1]], vid: 1i64 },
+                entity! { is => id: "rl4",  title: "Silence",        songs: Vec::<graph::prelude::Value>::new(), vid: 2i64 },
             ],
         ),
         (
             "Plays",
             vec![
-                entity! { is => id: 1i64, timestamp: ts0, song: s[1], user: "u1"},
-                entity! { is => id: 2i64, timestamp: ts0, song: s[1], user: "u2"},
-                entity! { is => id: 3i64, timestamp: ts0, song: s[2], user: "u1"},
-                entity! { is => id: 4i64, timestamp: ts0, song: s[1], user: "u1"},
-                entity! { is => id: 5i64, timestamp: ts0, song: s[1], user: "u1"},
+                entity! { is => id: 1i64, timestamp: ts0, song: s[1], user: "u1", vid: 0i64 },
+                entity! { is => id: 2i64, timestamp: ts0, song: s[1], user: "u2", vid: 1i64 },
+                entity! { is => id: 3i64, timestamp: ts0, song: s[2], user: "u1", vid: 2i64 },
+                entity! { is => id: 4i64, timestamp: ts0, song: s[1], user: "u1", vid: 3i64 },
+                entity! { is => id: 5i64, timestamp: ts0, song: s[1], user: "u1", vid: 4i64 },
             ],
         ),
     ];
+
     let entities0 = insert_ops(&manifest.schema, entities0);
 
     let entities1 = vec![(
         "Musician",
         vec![
-            entity! { is => id: "m3", name: "Tom", mainBand: "b2", bands: vec!["b1", "b2"], favoriteCount: 5, birthDate: timestamp.clone() },
-            entity! { is => id: "m4", name: "Valerie", bands: Vec::<String>::new(), favoriteCount: 20, birthDate: timestamp.clone() },
+            entity! { is => id: "m3", name: "Tom", mainBand: "b2", bands: vec!["b1", "b2"], favoriteCount: 5, birthDate: timestamp.clone(), vid: 2i64 },
+            entity! { is => id: "m4", name: "Valerie", bands: Vec::<String>::new(), favoriteCount: 20, birthDate: timestamp.clone(), vid: 3i64 },
         ],
     )];
     let entities1 = insert_ops(&manifest.schema, entities1);

--- a/store/test-store/tests/postgres/aggregation.rs
+++ b/store/test-store/tests/postgres/aggregation.rs
@@ -79,9 +79,10 @@ pub async fn insert(
     let schema = ReadStore::input_schema(store);
     let ops = entities
         .into_iter()
-        .map(|data| {
+        .map(|mut data| {
             let data_type = schema.entity_type("Data").unwrap();
             let key = data_type.key(data.id());
+            data.set_vid_if_empty();
             EntityOperation::Set { data, key }
         })
         .collect();
@@ -125,8 +126,8 @@ async fn insert_test_data(store: Arc<dyn WritableStore>, deployment: DeploymentL
 
     let ts64 = TIMES[0];
     let entities = vec![
-        entity! { schema => id: 1i64, timestamp: ts64, token: TOKEN1.clone(), price: bd(1), amount: bd(10) },
-        entity! { schema => id: 2i64, timestamp: ts64, token: TOKEN2.clone(), price: bd(1), amount: bd(1) },
+        entity! { schema => id: 1i64, timestamp: ts64, token: TOKEN1.clone(), price: bd(1), amount: bd(10), vid: 11i64 },
+        entity! { schema => id: 2i64, timestamp: ts64, token: TOKEN2.clone(), price: bd(1), amount: bd(1), vid: 12i64 },
     ];
 
     insert(&store, &deployment, BLOCKS[0].clone(), TIMES[0], entities)
@@ -135,8 +136,8 @@ async fn insert_test_data(store: Arc<dyn WritableStore>, deployment: DeploymentL
 
     let ts64 = TIMES[1];
     let entities = vec![
-        entity! { schema => id: 11i64, timestamp: ts64, token: TOKEN1.clone(), price: bd(2), amount: bd(2) },
-        entity! { schema => id: 12i64, timestamp: ts64, token: TOKEN2.clone(), price: bd(2), amount: bd(20) },
+        entity! { schema => id: 11i64, timestamp: ts64, token: TOKEN1.clone(), price: bd(2), amount: bd(2), vid: 21i64 },
+        entity! { schema => id: 12i64, timestamp: ts64, token: TOKEN2.clone(), price: bd(2), amount: bd(20), vid: 22i64 },
     ];
     insert(&store, &deployment, BLOCKS[1].clone(), TIMES[1], entities)
         .await
@@ -144,8 +145,8 @@ async fn insert_test_data(store: Arc<dyn WritableStore>, deployment: DeploymentL
 
     let ts64 = TIMES[2];
     let entities = vec![
-        entity! { schema => id: 21i64, timestamp: ts64, token: TOKEN1.clone(), price: bd(3), amount: bd(30) },
-        entity! { schema => id: 22i64, timestamp: ts64, token: TOKEN2.clone(), price: bd(3), amount: bd(3) },
+        entity! { schema => id: 21i64, timestamp: ts64, token: TOKEN1.clone(), price: bd(3), amount: bd(30), vid: 31i64 },
+        entity! { schema => id: 22i64, timestamp: ts64, token: TOKEN2.clone(), price: bd(3), amount: bd(3), vid: 32i64 },
     ];
     insert(&store, &deployment, BLOCKS[2].clone(), TIMES[2], entities)
         .await
@@ -153,8 +154,8 @@ async fn insert_test_data(store: Arc<dyn WritableStore>, deployment: DeploymentL
 
     let ts64 = TIMES[3];
     let entities = vec![
-        entity! { schema => id: 31i64, timestamp: ts64, token: TOKEN1.clone(), price: bd(4), amount: bd(4) },
-        entity! { schema => id: 32i64, timestamp: ts64, token: TOKEN2.clone(), price: bd(4), amount: bd(40) },
+        entity! { schema => id: 31i64, timestamp: ts64, token: TOKEN1.clone(), price: bd(4), amount: bd(4), vid: 41i64 },
+        entity! { schema => id: 32i64, timestamp: ts64, token: TOKEN2.clone(), price: bd(4), amount: bd(40), vid: 42i64 },
     ];
     insert(&store, &deployment, BLOCKS[3].clone(), TIMES[3], entities)
         .await
@@ -173,10 +174,10 @@ fn stats_hour(schema: &InputSchema) -> Vec<Vec<Entity>> {
     let block2 = vec![
         entity! { schema => id: 11i64, timestamp: ts2, token: TOKEN1.clone(),
         sum: bd(3), sum_sq: bd(5), max: bd(10), first: bd(10), last: bd(2),
-        value: bd(14), totalValue: bd(14) },
+        value: bd(14), totalValue: bd(14), vid: 1i64 },
         entity! { schema => id: 12i64, timestamp: ts2, token: TOKEN2.clone(),
         sum: bd(3), sum_sq: bd(5), max: bd(20), first: bd(1),  last: bd(20),
-        value: bd(41), totalValue: bd(41) },
+        value: bd(41), totalValue: bd(41), vid: 2i64 },
     ];
 
     let ts3 = BlockTime::since_epoch(3600, 0);
@@ -186,10 +187,10 @@ fn stats_hour(schema: &InputSchema) -> Vec<Vec<Entity>> {
         let mut v2 = vec![
             entity! { schema => id: 21i64, timestamp: ts3, token: TOKEN1.clone(),
             sum: bd(3), sum_sq: bd(9), max: bd(30), first: bd(30), last: bd(30),
-            value: bd(90), totalValue: bd(104) },
+            value: bd(90), totalValue: bd(104), vid: 3i64 },
             entity! { schema => id: 22i64, timestamp: ts3, token: TOKEN2.clone(),
             sum: bd(3), sum_sq: bd(9), max: bd(3),  first: bd(3), last: bd(3),
-            value: bd(9), totalValue: bd(50)},
+            value: bd(9), totalValue: bd(50), vid: 4i64 },
         ];
         v1.append(&mut v2);
         v1

--- a/store/test-store/tests/postgres/graft.rs
+++ b/store/test-store/tests/postgres/graft.rs
@@ -175,6 +175,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
         184.4,
         false,
         None,
+        0,
     );
     transact_entity_operations(&store, &deployment, BLOCKS[0].clone(), vec![test_entity_1])
         .await
@@ -189,6 +190,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
         159.1,
         true,
         Some("red"),
+        1,
     );
     let test_entity_3_1 = create_test_entity(
         "3",
@@ -199,6 +201,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
         111.7,
         false,
         Some("blue"),
+        2,
     );
     transact_entity_operations(
         &store,
@@ -218,6 +221,7 @@ async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator 
         111.7,
         false,
         None,
+        3,
     );
     transact_entity_operations(
         &store,
@@ -241,6 +245,7 @@ fn create_test_entity(
     weight: f64,
     coffee: bool,
     favorite_color: Option<&str>,
+    vid: i64,
 ) -> EntityOperation {
     let bin_name = scalar::Bytes::from_str(&hex::encode(name)).unwrap();
     let test_entity = entity! { TEST_SUBGRAPH_SCHEMA =>
@@ -252,7 +257,8 @@ fn create_test_entity(
         seconds_age: age * 31557600,
         weight: Value::BigDecimal(weight.into()),
         coffee: coffee,
-        favorite_color: favorite_color
+        favorite_color: favorite_color,
+        vid: vid,
     };
 
     let entity_type = TEST_SUBGRAPH_SCHEMA.entity_type(entity_type).unwrap();
@@ -324,6 +330,7 @@ async fn check_graft(
 
     // Make our own entries for block 2
     shaq.set("email", "shaq@gmail.com").unwrap();
+    let _ = shaq.set_vid(3);
     let op = EntityOperation::Set {
         key: user_type.parse_key("3").unwrap(),
         data: shaq,
@@ -601,6 +608,7 @@ fn prune() {
                 157.1,
                 true,
                 Some("red"),
+                4,
             );
             transact_and_wait(&store, &src, BLOCKS[5].clone(), vec![user2])
                 .await

--- a/store/test-store/tests/postgres/relational.rs
+++ b/store/test-store/tests/postgres/relational.rs
@@ -212,11 +212,13 @@ lazy_static! {
             bigInt: big_int.clone(),
             bigIntArray: vec![big_int.clone(), (big_int + 1.into())],
             color: "yellow",
+            vid: 0i64,
         }
     };
     static ref EMPTY_NULLABLESTRINGS_ENTITY: Entity = {
         entity! { THINGS_SCHEMA =>
             id: "one",
+            vid: 0i64,
         }
     };
     static ref SCALAR_TYPE: EntityType = THINGS_SCHEMA.entity_type("Scalar").unwrap();
@@ -325,6 +327,7 @@ fn insert_user_entity(
     drinks: Option<Vec<&str>>,
     visits: i64,
     block: BlockNumber,
+    vid: i64,
 ) {
     let user = make_user(
         &layout.input_schema,
@@ -337,6 +340,7 @@ fn insert_user_entity(
         favorite_color,
         drinks,
         visits,
+        vid,
     );
 
     insert_entity_at(conn, layout, entity_type, vec![user], block);
@@ -353,6 +357,7 @@ fn make_user(
     favorite_color: Option<&str>,
     drinks: Option<Vec<&str>>,
     visits: i64,
+    vid: i64,
 ) -> Entity {
     let favorite_color = favorite_color
         .map(|s| Value::String(s.to_owned()))
@@ -368,7 +373,8 @@ fn make_user(
         weight: BigDecimal::from(weight),
         coffee: coffee,
         favorite_color: favorite_color,
-        visits: visits
+        visits: visits,
+        vid: vid,
     };
     if let Some(drinks) = drinks {
         user.insert("drinks", drinks.into()).unwrap();
@@ -391,6 +397,7 @@ fn insert_users(conn: &mut PgConnection, layout: &Layout) {
         None,
         60,
         0,
+        0,
     );
     insert_user_entity(
         conn,
@@ -406,6 +413,7 @@ fn insert_users(conn: &mut PgConnection, layout: &Layout) {
         Some(vec!["beer", "wine"]),
         50,
         0,
+        1,
     );
     insert_user_entity(
         conn,
@@ -421,6 +429,7 @@ fn insert_users(conn: &mut PgConnection, layout: &Layout) {
         Some(vec!["coffee", "tea"]),
         22,
         0,
+        2,
     );
 }
 
@@ -438,6 +447,7 @@ fn update_user_entity(
     drinks: Option<Vec<&str>>,
     visits: i64,
     block: BlockNumber,
+    vid: i64,
 ) {
     let user = make_user(
         &layout.input_schema,
@@ -450,6 +460,7 @@ fn update_user_entity(
         favorite_color,
         drinks,
         visits,
+        vid,
     );
     update_entity_at(conn, layout, entity_type, vec![user], block);
 }
@@ -461,17 +472,19 @@ fn insert_pet(
     id: &str,
     name: &str,
     block: BlockNumber,
+    vid: i64,
 ) {
     let pet = entity! { layout.input_schema =>
         id: id,
-        name: name
+        name: name,
+        vid: vid,
     };
     insert_entity_at(conn, layout, entity_type, vec![pet], block);
 }
 
 fn insert_pets(conn: &mut PgConnection, layout: &Layout) {
-    insert_pet(conn, layout, &*DOG_TYPE, "pluto", "Pluto", 0);
-    insert_pet(conn, layout, &*CAT_TYPE, "garfield", "Garfield", 0);
+    insert_pet(conn, layout, &*DOG_TYPE, "pluto", "Pluto", 0, 0);
+    insert_pet(conn, layout, &*CAT_TYPE, "garfield", "Garfield", 0, 1);
 }
 
 fn create_schema(conn: &mut PgConnection) -> Layout {
@@ -604,6 +617,7 @@ fn update() {
         entity.set("string", "updated").unwrap();
         entity.remove("strings");
         entity.set("bool", Value::Null).unwrap();
+        entity.set("vid", 1i64).unwrap();
         let key = SCALAR_TYPE.key(entity.id());
 
         let entity_type = layout.input_schema.entity_type("Scalar").unwrap();
@@ -631,8 +645,10 @@ fn update_many() {
         let mut one = SCALAR_ENTITY.clone();
         let mut two = SCALAR_ENTITY.clone();
         two.set("id", "two").unwrap();
+        two.set("vid", 1i64).unwrap();
         let mut three = SCALAR_ENTITY.clone();
         three.set("id", "three").unwrap();
+        three.set("vid", 2i64).unwrap();
         insert_entity(
             conn,
             layout,
@@ -653,6 +669,10 @@ fn update_many() {
         three.set("string", "updated in a different way").unwrap();
         three.remove("strings");
         three.set("color", "red").unwrap();
+
+        one.set("vid", 3i64).unwrap();
+        two.set("vid", 4i64).unwrap();
+        three.set("vid", 5i64).unwrap();
 
         // generate keys
         let entity_type = layout.input_schema.entity_type("Scalar").unwrap();
@@ -720,10 +740,13 @@ fn serialize_bigdecimal() {
 
         // Update with overwrite
         let mut entity = SCALAR_ENTITY.clone();
+        let mut vid = 1i64;
 
         for d in &["50", "50.00", "5000", "0.5000", "0.050", "0.5", "0.05"] {
             let d = BigDecimal::from_str(d).unwrap();
             entity.set("bigDecimal", d).unwrap();
+            entity.set("vid", vid).unwrap();
+            vid += 1;
 
             let key = SCALAR_TYPE.key(entity.id());
             let entity_type = layout.input_schema.entity_type("Scalar").unwrap();
@@ -755,7 +778,8 @@ fn enum_arrays() {
         let spectrum = entity! { THINGS_SCHEMA =>
             id: "rainbow",
             main: "yellow",
-            all: vec!["yellow", "red", "BLUE"]
+            all: vec!["yellow", "red", "BLUE"],
+            vid: 0i64
         };
 
         insert_entity(
@@ -803,6 +827,7 @@ fn delete() {
         insert_entity(conn, layout, &*SCALAR_TYPE, vec![SCALAR_ENTITY.clone()]);
         let mut two = SCALAR_ENTITY.clone();
         two.set("id", "two").unwrap();
+        two.set("vid", 1i64).unwrap();
         insert_entity(conn, layout, &*SCALAR_TYPE, vec![two]);
 
         // Delete where nothing is getting deleted
@@ -837,8 +862,10 @@ fn insert_many_and_delete_many() {
         let one = SCALAR_ENTITY.clone();
         let mut two = SCALAR_ENTITY.clone();
         two.set("id", "two").unwrap();
+        two.set("vid", 1i64).unwrap();
         let mut three = SCALAR_ENTITY.clone();
         three.set("id", "three").unwrap();
+        three.set("vid", 2i64).unwrap();
         insert_entity(conn, layout, &*SCALAR_TYPE, vec![one, two, three]);
 
         // confidence test: there should be 3 scalar entities in store right now
@@ -919,6 +946,7 @@ fn conflicting_entity() {
         cat: &str,
         dog: &str,
         ferret: &str,
+        vid: i64,
     ) {
         let conflicting =
             |conn: &mut PgConnection, entity_type: &EntityType, types: Vec<&EntityType>| {
@@ -944,7 +972,7 @@ fn conflicting_entity() {
         let dog_type = layout.input_schema.entity_type(dog).unwrap();
         let ferret_type = layout.input_schema.entity_type(ferret).unwrap();
 
-        let fred = entity! { layout.input_schema => id: id.clone(), name: id.clone() };
+        let fred = entity! { layout.input_schema => id: id.clone(), name: id.clone(), vid: vid };
         insert_entity(conn, layout, &cat_type, vec![fred]);
 
         // If we wanted to create Fred the dog, which is forbidden, we'd run this:
@@ -958,10 +986,10 @@ fn conflicting_entity() {
 
     run_test(|mut conn, layout| {
         let id = Value::String("fred".to_string());
-        check(&mut conn, layout, id, "Cat", "Dog", "Ferret");
+        check(&mut conn, layout, id, "Cat", "Dog", "Ferret", 0);
 
         let id = Value::Bytes(scalar::Bytes::from_str("0xf1ed").unwrap());
-        check(&mut conn, layout, id, "ByteCat", "ByteDog", "ByteFerret");
+        check(&mut conn, layout, id, "ByteCat", "ByteDog", "ByteFerret", 1);
     })
 }
 
@@ -973,7 +1001,8 @@ fn revert_block() {
         let set_fred = |conn: &mut PgConnection, name, block| {
             let fred = entity! { layout.input_schema =>
                 id: id,
-                name: name
+                name: name,
+                vid: block as i64,
             };
             if block == 0 {
                 insert_entity_at(conn, layout, &*CAT_TYPE, vec![fred], block);
@@ -1013,6 +1042,7 @@ fn revert_block() {
                 let marty = entity! { layout.input_schema =>
                     id: id,
                     order: block,
+                    vid: (block + 10) as i64
                 };
                 insert_entity_at(conn, layout, &*MINK_TYPE, vec![marty], block);
             }
@@ -1091,6 +1121,7 @@ impl<'a> QueryChecker<'a> {
             None,
             23,
             0,
+            3,
         );
         insert_pets(conn, layout);
 
@@ -1203,6 +1234,7 @@ fn check_block_finds() {
             None,
             55,
             1,
+            4,
         );
 
         checker
@@ -1745,10 +1777,10 @@ struct FilterChecker<'a> {
 impl<'a> FilterChecker<'a> {
     fn new(conn: &'a mut PgConnection, layout: &'a Layout) -> Self {
         let (a1, a2, a2b, a3) = ferrets();
-        insert_pet(conn, layout, &*FERRET_TYPE, "a1", &a1, 0);
-        insert_pet(conn, layout, &*FERRET_TYPE, "a2", &a2, 0);
-        insert_pet(conn, layout, &*FERRET_TYPE, "a2b", &a2b, 0);
-        insert_pet(conn, layout, &*FERRET_TYPE, "a3", &a3, 0);
+        insert_pet(conn, layout, &*FERRET_TYPE, "a1", &a1, 0, 0);
+        insert_pet(conn, layout, &*FERRET_TYPE, "a2", &a2, 0, 1);
+        insert_pet(conn, layout, &*FERRET_TYPE, "a2b", &a2b, 0, 2);
+        insert_pet(conn, layout, &*FERRET_TYPE, "a3", &a3, 0, 3);
 
         Self { conn, layout }
     }
@@ -1892,7 +1924,8 @@ fn check_filters() {
             &*FERRET_TYPE,
             vec![entity! { layout.input_schema =>
               id: "a1",
-              name: "Test"
+              name: "Test",
+              vid: 5i64
             }],
             1,
         );


### PR DESCRIPTION
This PR changes the generation of the VID in such a way that entities have an order determined by the order of the blockchain transactions from which they originate, rather than to be ordered by the current implementation of the graph-node and the VID autogenerated by the database. This in turn will ensure that the dependant subgraphs would have a deterministic order of their input entities and it would be consistent across different graph-node deployments producing the same POI.