### PR TITLE
docker: use env vars for network/node in compose file

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -35,7 +35,8 @@ docker run -it \
 The Docker Compose setup requires an Ethereum network name and node
 to connect to. By default, it will use `mainnet:http://host.docker.internal:8545`
 in order to connect to an Ethereum node running on your host machine.
-You can replace this with anything else in `docker-compose.yaml`.
+You can replace this with anything else in `docker-compose.yaml` or set the
+environment variables `NETWORK_NAME` and `ETHEREUM_RPC_URL`.
 
 After you have set up an Ethereum node—e.g. Ganache or Parity—simply
 clone this repository and run

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       postgres_pass: let-me-in
       postgres_db: graph-node
       ipfs: 'ipfs:5001'
-      ethereum: 'mainnet:http://host.docker.internal:8545'
+      ethereum: ${NETWORK_NAME:-mainnet}:${ETHEREUM_RPC_URL:-http://host.docker.internal:8545}
       GRAPH_LOG: info
   ipfs:
     image: ipfs/kubo:v0.17.0


### PR DESCRIPTION
By setting `NETWORK_NAME` and `ETHEREUM_RPC_URL` environment variables in reading those in the `docker-compose.yaml` file, customization will not require modifying the file.

