### PR TITLE
docker: more secure PG env vars and ports cleanup

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -35,7 +35,8 @@ docker run -it \
 The Docker Compose setup requires an Ethereum network name and node
 to connect to. By default, it will use `mainnet:http://host.docker.internal:8545`
 in order to connect to an Ethereum node running on your host machine.
-You can replace this with anything else in `docker-compose.yaml`.
+You can replace this with anything else in `docker-compose.yaml` or set the
+environment variables `NETWORK_NAME` and `ETHEREUM_RPC_URL`.
 
 After you have set up an Ethereum node—e.g. Ganache or Parity—simply
 clone this repository and run

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       postgres_pass: let-me-in
       postgres_db: graph-node
       ipfs: 'ipfs:5001'
-      ethereum: 'mainnet:http://host.docker.internal:8545'
+      ethereum: ${NETWORK_NAME:-mainnet}:${ETHEREUM_RPC_URL:-http://host.docker.internal:8545}
       GRAPH_LOG: info
   ipfs:
     image: ipfs/kubo:v0.17.0

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       - '8000:8000'
       - '8001:8001'
       - '8020:8020'
-      - '8030:8030'
-      - '8040:8040'
     depends_on:
       - ipfs
       - postgres
@@ -29,8 +27,6 @@ services:
       - ./data/ipfs:/data/ipfs:Z
   postgres:
     image: postgres
-    ports:
-      - '5432:5432'
     command:
       [
         "postgres",

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,8 +15,8 @@ services:
       - host.docker.internal:host-gateway
     environment:
       postgres_host: postgres
-      postgres_user: graph-node
-      postgres_pass: let-me-in
+      postgres_user: ${POSTGRES_USER:-graph-node}
+      postgres_pass: ${POSTGRESS_PASSWORD:-let-me-in}
       postgres_db: graph-node
       ipfs: 'ipfs:5001'
       ethereum: ${NETWORK_NAME:-mainnet}:${ETHEREUM_RPC_URL:-http://host.docker.internal:8545}
@@ -38,8 +38,8 @@ services:
         "-cmax_connections=200"
       ]
     environment:
-      POSTGRES_USER: graph-node
-      POSTGRES_PASSWORD: let-me-in
+      POSTGRES_USER: ${POSTGRES_USER:-graph-node}
+      POSTGRES_PASSWORD: ${POSTGRESS_PASSWORD:-let-me-in}
       POSTGRES_DB: graph-node
       # FIXME: remove this env. var. which we shouldn't need. Introduced by
       # <https://github.com/graphprotocol/graph-node/pull/3511>, maybe as a


### PR DESCRIPTION
The Docker compose file has hardcoded values for the Postgres user and password. This change allows setting other more secure values when starting up the processes.

In addition, exposed ports not needed were removed.

Note that https://github.com/graphprotocol/graph-node/pull/5762 should ideally be merged first.