### PR TITLE
store: Fix handling of enum arrays

### DIFF
--- a/store/postgres/src/relational/dsl.rs
+++ b/store/postgres/src/relational/dsl.rs
@@ -322,7 +322,8 @@ impl<'a> Table<'a> {
             table: &'b Table<'b>,
             column: &'b RelColumn,
         ) {
-            let name = format!("{}.{}::text", table.alias.as_str(), &column.name);
+            let cast = if column.is_list() { "text[]" } else { "text" };
+            let name = format!("{}.{}::{}", table.alias.as_str(), &column.name, cast);
 
             match (column.is_list(), column.is_nullable()) {
                 (true, true) => select.add_field(sql::<Nullable<Array<Text>>>(&name)),


### PR DESCRIPTION
Roundtripping arrays of enums would fail because we would read an array of enums back as a single string "{yellow,red,BLUE}" instead of the array ["yellow", "red", "BLUE"]. Storing an update to such an entity, even if users make no changes to that field, would fail because Postgres expects an array and we were sending a scalar value.

This fixes a bug introduced in PR
https://github.com/graphprotocol/graph-node/pull/5372

