### PR TITLE
Add tracking for new metrics in CSV (`entity_changes`, `storage_size`)

### DIFF
--- a/graph/src/components/metrics/block_state.rs
+++ b/graph/src/components/metrics/block_state.rs
@@ -17,7 +17,7 @@ use crate::{
     util::cache_weight::CacheWeight,
 };
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct BlockStateMetrics {
     pub gas_counter: HashMap<CounterKey, u64>,
     pub op_counter: HashMap<CounterKey, u64>,
@@ -201,11 +201,16 @@ impl BlockStateMetrics {
         }
     }
 
-    pub fn track_storage_size_change(&mut self, entity_type: &EntityType, entity: &Entity, is_removal: bool) {
+    pub fn track_storage_size_change(
+        &mut self,
+        entity_type: &EntityType,
+        entity: &Entity,
+        is_removal: bool,
+    ) {
         if ENV_VARS.enable_dips_metrics {
             let key = CounterKey::Entity(entity_type.clone(), entity.id());
             let size = entity.weight() as u64;
-            
+
             let storage = self.current_storage_size.entry(key).or_insert(0);
             if is_removal {
                 *storage = storage.saturating_sub(size);
@@ -215,7 +220,12 @@ impl BlockStateMetrics {
         }
     }
 
-    pub fn track_storage_size_change_batch(&mut self, entity_type: &EntityType, entities: &[Entity], is_removal: bool) {
+    pub fn track_storage_size_change_batch(
+        &mut self,
+        entity_type: &EntityType,
+        entities: &[Entity],
+        is_removal: bool,
+    ) {
         if ENV_VARS.enable_dips_metrics {
             for entity in entities {
                 self.track_storage_size_change(entity_type, entity, is_removal);

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -373,7 +373,7 @@ impl HostExports {
     }
 
     pub(crate) fn store_remove(
-        &mut self,
+        &self,
         logger: &Logger,
         state: &mut BlockState,
         proof_of_indexing: &SharedProofOfIndexing,
@@ -1250,7 +1250,7 @@ impl HostExports {
     }
 
     fn remove_entity(
-        &mut self,
+        &self,
         key: &EntityKey,
         state: &mut BlockState,
     ) -> Result<(), HostExportError> {


### PR DESCRIPTION
**This PR introduces tracking for entity count changes and current storage size of entities in BlockStateMetrics.**

While the tracking mechanism follows a similar pattern to other metrics (`gas`, `op`, `read_bytes`, `write_bytes`), there's an important distinction in how the newly introduced metrics `entity_changes`  and `storage_size` values are recorded:
- The other metrics use monotonic counters that accumulate totals over time (e.g., total bytes read)
- The new `entity_count_changes` metric tracks the net change in entity counts per block (e.g., +5 id_1 added, -2 id_2 removed)
- The new `storage_size` metric tracks the actual current size of stored entities as a live readout. If the entity increases/reduces in size due to a write event, then this metric will reflect the new size of the entity after the write event.

For `entity_count_changes`, each block's measurement represents changes that occurred within that block, not cumulative totals or absolute counts. To determine the total number of entities at a given block, these changes would need to be summed across all previous blocks.