### PR TITLE
Subgraph composition spec version

### DIFF
--- a/graph/src/schema/entity_type.rs
+++ b/graph/src/schema/entity_type.rs
@@ -150,6 +150,14 @@ impl EntityType {
     pub fn is_object_type(&self) -> bool {
         self.schema.is_object_type(self.atom)
     }
+
+    // Changes the way the VID field is generated. It used to be autoincrement. Now its
+    // based on block number and the order of the entities in a block. The latter
+    // represents the write order across all entity types in the subgraph.
+    pub fn strict_vid_order(&self) -> bool {
+        // Currently the agregations entities don't have VIDs in insertion order
+        self.schema.strict_vid_order() && self.is_object_type()
+    }
 }
 
 impl fmt::Display for EntityType {

--- a/graph/src/schema/input/mod.rs
+++ b/graph/src/schema/input/mod.rs
@@ -17,6 +17,7 @@ use crate::data::graphql::{DirectiveExt, DocumentExt, ObjectTypeExt, TypeExt, Va
 use crate::data::store::{
     self, EntityValidationError, IdType, IntoEntityIterator, TryIntoEntityIterator, ValueType, ID,
 };
+use crate::data::subgraph::SPEC_VERSION_1_3_0;
 use crate::data::value::Word;
 use crate::derive::CheapClone;
 use crate::prelude::q::Value;
@@ -955,6 +956,7 @@ pub struct Inner {
     pool: Arc<AtomPool>,
     /// A list of all timeseries types by interval
     agg_mappings: Box<[AggregationMapping]>,
+    spec_version: Version,
 }
 
 impl InputSchema {
@@ -1042,6 +1044,7 @@ impl InputSchema {
                 enum_map,
                 pool,
                 agg_mappings,
+                spec_version: spec_version.clone(),
             }),
         })
     }
@@ -1584,6 +1587,10 @@ impl InputSchema {
             (TypeInfo::Aggregation(_), None) => None,
         }?;
         Some(EntityType::new(self.cheap_clone(), obj_type.name))
+    }
+
+    pub fn strict_vid_order(&self) -> bool {
+        self.inner.spec_version >= SPEC_VERSION_1_3_0
     }
 }
 

--- a/store/postgres/src/relational/ddl.rs
+++ b/store/postgres/src/relational/ddl.rs
@@ -116,8 +116,7 @@ impl Table {
             Ok(cols)
         }
 
-        // Currently the agregations entities don't have VIDs in insertion order
-        let vid_type = if self.object.is_object_type() {
+        let vid_type = if self.object.strict_vid_order() {
             "bigint"
         } else {
             "bigserial"

--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -243,7 +243,6 @@ impl TablePair {
 
         let vid_seq = format!("{}_{VID_COLUMN}_seq", self.src.name);
 
-        let old_vid_form = !self.src.object.is_object_type();
         let mut query = String::new();
 
         // What we are about to do would get blocked by autovacuum on our
@@ -253,9 +252,9 @@ impl TablePair {
                   "src" => src_nsp.as_str(), "error" => e.to_string());
         }
 
-        // Make sure the vid sequence
-        // continues from where it was
-        if old_vid_form {
+        // Make sure the vid sequence continues from where it was in case
+        // that we use autoincrementing order of the DB
+        if !self.src.object.strict_vid_order() {
             writeln!(
                 query,
                 "select setval('{dst_nsp}.{vid_seq}', nextval('{src_nsp}.{vid_seq}'));"

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -2377,7 +2377,7 @@ impl<'a> QueryFragment<Pg> for InsertQuery<'a> {
         let out = &mut out;
         out.unsafe_to_cache_prepared();
 
-        let new_vid_form = self.table.object.is_object_type();
+        let strict_vid_order = self.table.object.strict_vid_order();
 
         // Construct a query
         //   insert into schema.table(column, ...)
@@ -2404,7 +2404,7 @@ impl<'a> QueryFragment<Pg> for InsertQuery<'a> {
             out.push_sql(CAUSALITY_REGION_COLUMN);
         };
 
-        if new_vid_form {
+        if strict_vid_order {
             out.push_sql(", vid");
         }
         out.push_sql(") values\n");
@@ -2424,7 +2424,7 @@ impl<'a> QueryFragment<Pg> for InsertQuery<'a> {
                 out.push_sql(", ");
                 out.push_bind_param::<Integer, _>(&row.causality_region)?;
             };
-            if new_vid_form {
+            if strict_vid_order {
                 out.push_sql(", ");
                 out.push_bind_param::<BigInt, _>(&row.vid)?;
             }
@@ -4827,7 +4827,7 @@ impl<'a> QueryFragment<Pg> for CopyEntityBatchQuery<'a> {
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
 
-        let new_vid_form = self.src.object.is_object_type();
+        let strict_vid_order = self.src.object.strict_vid_order();
 
         // Construct a query
         //   insert into {dst}({columns})
@@ -4849,7 +4849,7 @@ impl<'a> QueryFragment<Pg> for CopyEntityBatchQuery<'a> {
             out.push_sql(", ");
             out.push_sql(CAUSALITY_REGION_COLUMN);
         };
-        if new_vid_form {
+        if strict_vid_order {
             out.push_sql(", vid");
         }
 
@@ -4917,7 +4917,7 @@ impl<'a> QueryFragment<Pg> for CopyEntityBatchQuery<'a> {
                 ));
             }
         }
-        if new_vid_form {
+        if strict_vid_order {
             out.push_sql(", vid");
         }
 

--- a/store/test-store/src/store.rs
+++ b/store/test-store/src/store.rs
@@ -163,7 +163,7 @@ pub async fn create_subgraph(
 
     let manifest = SubgraphManifest::<graph::blockchain::mock::MockBlockchain> {
         id: subgraph_id.clone(),
-        spec_version: Version::new(1, 0, 0),
+        spec_version: Version::new(1, 3, 0),
         features: BTreeSet::new(),
         description: Some(format!("manifest for {}", subgraph_id)),
         repository: Some(format!("repo for {}", subgraph_id)),
@@ -227,7 +227,7 @@ pub async fn create_test_subgraph_with_features(
 
     let manifest = SubgraphManifest::<graph::blockchain::mock::MockBlockchain> {
         id: subgraph_id.clone(),
-        spec_version: Version::new(1, 0, 0),
+        spec_version: Version::new(1, 3, 0),
         features,
         description: Some(format!("manifest for {}", subgraph_id)),
         repository: Some(format!("repo for {}", subgraph_id)),

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -448,7 +448,7 @@ where
 async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator {
     let manifest = SubgraphManifest::<graph_chain_ethereum::Chain> {
         id: LOAD_RELATED_ID.clone(),
-        spec_version: Version::new(1, 0, 0),
+        spec_version: Version::new(1, 3, 0),
         features: Default::default(),
         description: None,
         repository: None,

--- a/store/test-store/tests/postgres/graft.rs
+++ b/store/test-store/tests/postgres/graft.rs
@@ -136,7 +136,7 @@ where
 async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator {
     let manifest = SubgraphManifest::<graph_chain_ethereum::Chain> {
         id: TEST_SUBGRAPH_ID.clone(),
-        spec_version: Version::new(1, 0, 0),
+        spec_version: Version::new(1, 3, 0),
         features: Default::default(),
         description: None,
         repository: None,

--- a/store/test-store/tests/postgres/store.rs
+++ b/store/test-store/tests/postgres/store.rs
@@ -165,7 +165,7 @@ where
 async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator {
     let manifest = SubgraphManifest::<graph_chain_ethereum::Chain> {
         id: TEST_SUBGRAPH_ID.clone(),
-        spec_version: Version::new(1, 0, 0),
+        spec_version: Version::new(1, 3, 0),
         features: Default::default(),
         description: None,
         repository: None,
@@ -1270,7 +1270,7 @@ fn entity_changes_are_fired_and_forwarded_to_subscriptions() {
             .expect("Failed to parse user schema");
         let manifest = SubgraphManifest::<graph_chain_ethereum::Chain> {
             id: subgraph_id.clone(),
-            spec_version: Version::new(1, 0, 0),
+            spec_version: Version::new(1, 3, 0),
             features: Default::default(),
             description: None,
             repository: None,

--- a/store/test-store/tests/postgres/subgraph.rs
+++ b/store/test-store/tests/postgres/subgraph.rs
@@ -170,7 +170,7 @@ fn create_subgraph() {
 
         let manifest = SubgraphManifest::<graph_chain_ethereum::Chain> {
             id,
-            spec_version: Version::new(1, 0, 0),
+            spec_version: Version::new(1, 3, 0),
             features: Default::default(),
             description: None,
             repository: None,
@@ -547,7 +547,7 @@ fn subgraph_features() {
         } = get_subgraph_features(id.to_string()).unwrap();
 
         assert_eq!(NAME, subgraph_id.as_str());
-        assert_eq!("1.0.0", spec_version);
+        assert_eq!("1.3.0", spec_version);
         assert_eq!("1.0.0", api_version.unwrap());
         assert_eq!(NETWORK_NAME, network);
         assert_eq!(

--- a/store/test-store/tests/postgres/writable.rs
+++ b/store/test-store/tests/postgres/writable.rs
@@ -50,7 +50,7 @@ lazy_static! {
 async fn insert_test_data(store: Arc<DieselSubgraphStore>) -> DeploymentLocator {
     let manifest = SubgraphManifest::<graph_chain_ethereum::Chain> {
         id: TEST_SUBGRAPH_ID.clone(),
-        spec_version: Version::new(1, 0, 0),
+        spec_version: Version::new(1, 3, 0),
         features: Default::default(),
         description: None,
         repository: None,


### PR DESCRIPTION
This PR aims to base `VID` generation on `spec_version` so that both old and new way of generating `VID` will work simultaneously in the single binary. Some code that was removed in https://github.com/graphprotocol/graph-node/pull/5737 is reintroduced here.