### PR TITLE
Fix bug in chunk size calculation

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -266,3 +266,9 @@ those.
 - `GRAPH_POSTPONE_ATTRIBUTE_INDEX_CREATION`: During the coping of a subgraph
   postponing creation of certain indexes (btree, attribute based ones), would
   speed up syncing
+- `GRAPH_STORE_INSERT_EXTRA_COLS`: Makes it possible to work around bugs in
+  the subgraph writing code that manifest as Postgres errors saying 'number
+  of parameters must be between 0 and 65535' Such errors are always
+  graph-node bugs, but since it is hard to work around them, setting this
+  variable to something like 10 makes it possible to work around such a bug
+  while it is being fixed (default: 0)

--- a/graph/src/env/store.rs
+++ b/graph/src/env/store.rs
@@ -128,6 +128,11 @@ pub struct EnvVarsStore {
     /// sufficiently, probably after 2024-12-01
     /// Defaults to `false`, i.e. using the new fixed behavior
     pub last_rollup_from_poi: bool,
+    /// Safety switch to increase the number of columns used when
+    /// calculating the chunk size in `InsertQuery::chunk_size`. This can be
+    /// used to work around Postgres errors complaining 'number of
+    /// parameters must be between 0 and 65535' when inserting entities
+    pub insert_extra_cols: usize,
 }
 
 // This does not print any values avoid accidentally leaking any sensitive env vars
@@ -177,6 +182,7 @@ impl From<InnerStore> for EnvVarsStore {
             use_brin_for_all_query_types: x.use_brin_for_all_query_types,
             disable_block_cache_for_lookup: x.disable_block_cache_for_lookup,
             last_rollup_from_poi: x.last_rollup_from_poi,
+            insert_extra_cols: x.insert_extra_cols,
         }
     }
 }
@@ -240,6 +246,8 @@ pub struct InnerStore {
     disable_block_cache_for_lookup: bool,
     #[envconfig(from = "GRAPH_STORE_LAST_ROLLUP_FROM_POI", default = "false")]
     last_rollup_from_poi: bool,
+    #[envconfig(from = "GRAPH_STORE_INSERT_EXTRA_COLS", default = "0")]
+    insert_extra_cols: usize,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -2198,7 +2198,11 @@ impl<'a> InsertQuery<'a> {
     /// query, and depends on what columns `table` has and how they get put
     /// into the query
     pub fn chunk_size(table: &Table) -> usize {
+        // We always have one column for the block number/range
         let mut count = 1;
+        if table.has_causality_region {
+            count += 1;
+        }
         for column in table.columns.iter() {
             // This code depends closely on how `walk_ast` and `QueryValue`
             // put values into bind variables

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -2199,7 +2199,7 @@ impl<'a> InsertQuery<'a> {
     /// into the query
     pub fn chunk_size(table: &Table) -> usize {
         // We always have one column for the block number/range
-        let mut count = 1;
+        let mut count = 1 + ENV_VARS.store.insert_extra_cols;
         if table.has_causality_region {
             count += 1;
         }


### PR DESCRIPTION
When inserting entities during subgraph syncing, we split the entities that need to be written into chunks which we want to be as large as possible for best performance. Since Postgres only allows using 65k bind variables, the number of entities we can insert in one chunk is roughly 65k/#columns. The code did not account for the `causality_region` when calculating the number of columns to be inserted.

Since we had issues with this calculations in the past and it's next to impossible for operators to work around it, this also introduces an environment variable `GRAPH_STORE_INSERT_EXTRA_COLS` that operators can use to work around this issue should we ever screw up this calculation again.