### PR TITLE
Make copy/graft/prune work with unevenly distributed rows

### DIFF
--- a/graph/src/util/mod.rs
+++ b/graph/src/util/mod.rs
@@ -12,6 +12,8 @@ pub mod error;
 
 pub mod stats;
 
+pub mod ogive;
+
 pub mod cache_weight;
 
 pub mod timed_rw_lock;

--- a/graph/src/util/ogive.rs
+++ b/graph/src/util/ogive.rs
@@ -1,0 +1,279 @@
+use std::ops::RangeInclusive;
+
+use crate::{constraint_violation, prelude::StoreError};
+
+/// A helper to deal with cumulative histograms, also known as ogives. This
+/// implementation is restricted to histograms where each bin has the same
+/// size. As a cumulative function of a histogram, an ogive is a piecewise
+/// linear function `f` and since it is strictly monotonically increasing,
+/// it has an inverse `g`.
+///
+/// For the given `points`, `f(points[i]) = i * bin_size` and `f` is the
+/// piecewise linear interpolant between those points. The inverse `g` is
+/// the piecewise linear interpolant of `g(i * bin_size) = points[i]`. Note
+/// that that means that `f` divides the y-axis into `points.len()` equal
+/// parts.
+///
+/// The word 'ogive' is somewhat obscure, but has a lot fewer letters than
+/// 'piecewise linear function'. Copolit also claims that it is also a lot
+/// more fun to say.
+pub struct Ogive {
+    /// The breakpoints of the piecewise linear function
+    points: Vec<f64>,
+    /// The size of each bin; the linear piece from `points[i]` to
+    /// `points[i+1]` rises by this much
+    bin_size: f64,
+    /// The range of the ogive, i.e., the minimum and maximum entries from
+    /// points
+    range: RangeInclusive<i64>,
+}
+
+impl Ogive {
+    /// Create an ogive from a histogram with breaks at the given points and
+    /// a total count of `total` entries. As a function, the ogive is 0 at
+    /// `points[0]` and `total` at `points[points.len() - 1]`.
+    ///
+    /// The `points` must have at least one entry. The `points` are sorted
+    /// and deduplicated, i.e., they don't have to be in ascending order.
+    pub fn from_equi_histogram(mut points: Vec<i64>, total: usize) -> Result<Self, StoreError> {
+        if points.is_empty() {
+            return Err(constraint_violation!(
+                "histogram must have at least one point"
+            ));
+        }
+
+        points.sort_unstable();
+        points.dedup();
+
+        let bins = points.len() - 1;
+        let bin_size = total as f64 / bins as f64;
+        let range = points[0]..=points[bins];
+        let points = points.into_iter().map(|p| p as f64).collect();
+        Ok(Self {
+            points,
+            bin_size,
+            range,
+        })
+    }
+
+    pub fn start(&self) -> i64 {
+        *self.range.start()
+    }
+
+    pub fn end(&self) -> i64 {
+        *self.range.end()
+    }
+
+    /// Find the next point `next` such that there are `size` entries
+    /// between `point` and `next`, i.e., such that `f(next) - f(point) =
+    /// size`.
+    ///
+    /// It is an error if `point` is smaller than `points[0]`. If `point` is
+    /// bigger than `points.last()`, that is returned instead.
+    ///
+    /// The method calculates `g(f(point) + size)`
+    pub fn next_point(&self, point: i64, size: usize) -> Result<i64, StoreError> {
+        if point >= *self.range.end() {
+            return Ok(*self.range.end());
+        }
+        // This can only fail if point < self.range.start
+        self.check_in_range(point)?;
+
+        let point_value = self.value(point)?;
+        let next_value = point_value + size as i64;
+        let next_point = self.inverse(next_value)?;
+        Ok(next_point)
+    }
+
+    /// Return the index of the support point immediately preceding `point`.
+    /// It is an error if `point` is outside the range of points of this
+    /// ogive; this also implies that the returned index is always strictly
+    /// less than `self.points.len() - 1`
+    fn interval_start(&self, point: i64) -> Result<usize, StoreError> {
+        self.check_in_range(point)?;
+
+        let point = point as f64;
+        let idx = self
+            .points
+            .iter()
+            .position(|&p| point < p)
+            .unwrap_or(self.points.len() - 1)
+            - 1;
+        Ok(idx)
+    }
+
+    /// Return the value of the ogive at `point`, i.e., `f(point)`. It is an
+    /// error if `point` is outside the range of points of this ogive.
+    fn value(&self, point: i64) -> Result<i64, StoreError> {
+        if self.points.len() == 1 {
+            return Ok(*self.range.end());
+        }
+
+        let idx = self.interval_start(point)?;
+        let bin_size = self.bin_size as f64;
+        let (a, b) = (self.points[idx], self.points[idx + 1]);
+        let point = point as f64;
+        let value = (idx as f64 + (point - a) / (b - a)) * bin_size;
+        Ok(value as i64)
+    }
+
+    /// Return the value of the inverse ogive at `value`, i.e., `g(value)`.
+    /// It is an error if `value` is negative. If `value` is greater than
+    /// the total count of the ogive, the maximum point of the ogive is
+    /// returned.
+    fn inverse(&self, value: i64) -> Result<i64, StoreError> {
+        let value = value as f64;
+        if value < 0.0 {
+            return Err(constraint_violation!("value {} can not be negative", value));
+        }
+        let idx = (value / self.bin_size) as usize;
+        if idx >= self.points.len() - 1 {
+            return Ok(*self.range.end());
+        }
+        let (a, b) = (self.points[idx] as f64, self.points[idx + 1] as f64);
+        let lambda = (value - idx as f64 * self.bin_size) / self.bin_size;
+        let x = (1.0 - lambda) * a + lambda * b;
+        Ok(x as i64)
+    }
+
+    fn check_in_range(&self, point: i64) -> Result<(), StoreError> {
+        if !self.range.contains(&point) {
+            return Err(constraint_violation!(
+                "point {} is outside of the range [{}, {}]",
+                point,
+                self.range.start(),
+                self.range.end(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple() {
+        // This is just the linear function y = (70 / 5) * (x - 10)
+        let points: Vec<i64> = vec![10, 20, 30, 40, 50, 60];
+        let ogive = Ogive::from_equi_histogram(points, 700).unwrap();
+
+        // The function represented by `points`
+        fn f(x: i64) -> i64 {
+            70 * (x - 10) / 5
+        }
+
+        // The inverse of `f`
+        fn g(x: i64) -> i64 {
+            x * 5 / 70 + 10
+        }
+
+        // Check that the ogive is correct
+        assert_eq!(ogive.bin_size, 700 as f64 / 5 as f64);
+        assert_eq!(ogive.range, 10..=60);
+
+        // Test value method
+        for point in vec![20, 30, 45, 50, 60] {
+            assert_eq!(ogive.value(point).unwrap(), f(point), "value for {}", point);
+        }
+
+        // Test next_point method
+        for step in vec![50, 140, 200] {
+            for value in vec![10, 20, 30, 35, 45, 50, 60] {
+                assert_eq!(
+                    ogive.next_point(value, step).unwrap(),
+                    g(f(value) + step as i64).min(60),
+                    "inverse for {} with step {}",
+                    value,
+                    step
+                );
+            }
+        }
+
+        // Exceeding the range caps it at the maximum point
+        assert_eq!(ogive.next_point(50, 140).unwrap(), 60);
+        assert_eq!(ogive.next_point(50, 500).unwrap(), 60);
+
+        // Point to the left of the range should return an error
+        assert!(ogive.next_point(9, 140).is_err());
+        // Point to the right of the range gets capped
+        assert_eq!(ogive.next_point(61, 140).unwrap(), 60);
+    }
+
+    #[test]
+    fn single_bin() {
+        // A histogram with only one bin
+        let points: Vec<i64> = vec![10, 20];
+        let ogive = Ogive::from_equi_histogram(points, 700).unwrap();
+
+        // The function represented by `points`
+        fn f(x: i64) -> i64 {
+            700 * (x - 10) / 10
+        }
+
+        // The inverse of `f`
+        fn g(x: i64) -> i64 {
+            x * 10 / 700 + 10
+        }
+
+        // Check that the ogive is correct
+        assert_eq!(ogive.bin_size, 700 as f64 / 1 as f64);
+        assert_eq!(ogive.range, 10..=20);
+
+        // Test value method
+        for point in vec![10, 15, 20] {
+            assert_eq!(ogive.value(point).unwrap(), f(point), "value for {}", point);
+        }
+
+        // Test next_point method
+        for step in vec![50, 140, 200] {
+            for value in vec![10, 15, 20] {
+                assert_eq!(
+                    ogive.next_point(value, step).unwrap(),
+                    g(f(value) + step as i64).min(20),
+                    "inverse for {} with step {}",
+                    value,
+                    step
+                );
+            }
+        }
+
+        // Exceeding the range caps it at the maximum point
+        assert_eq!(ogive.next_point(20, 140).unwrap(), 20);
+        assert_eq!(ogive.next_point(20, 500).unwrap(), 20);
+
+        // Point to the left of the range should return an error
+        assert!(ogive.next_point(9, 140).is_err());
+        // Point to the right of the range gets capped
+        assert_eq!(ogive.next_point(21, 140).unwrap(), 20);
+    }
+
+    #[test]
+    fn one_bin() {
+        let points: Vec<i64> = vec![10];
+        let ogive = Ogive::from_equi_histogram(points, 700).unwrap();
+
+        assert_eq!(ogive.next_point(10, 1).unwrap(), 10);
+        assert_eq!(ogive.next_point(10, 4).unwrap(), 10);
+        assert_eq!(ogive.next_point(15, 1).unwrap(), 10);
+
+        assert!(ogive.next_point(9, 1).is_err());
+    }
+
+    #[test]
+    fn exponential() {
+        let points: Vec<i64> = vec![32, 48, 56, 60, 62, 64];
+        let ogive = Ogive::from_equi_histogram(points, 100).unwrap();
+
+        assert_eq!(ogive.value(50).unwrap(), 25);
+        assert_eq!(ogive.value(56).unwrap(), 40);
+        assert_eq!(ogive.value(58).unwrap(), 50);
+        assert_eq!(ogive.value(63).unwrap(), 90);
+
+        assert_eq!(ogive.next_point(32, 40).unwrap(), 56);
+        assert_eq!(ogive.next_point(50, 10).unwrap(), 54);
+        assert_eq!(ogive.next_point(50, 50).unwrap(), 61);
+        assert_eq!(ogive.next_point(40, 40).unwrap(), 58);
+    }
+}

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -36,6 +36,7 @@ mod store;
 mod store_events;
 mod subgraph_store;
 pub mod transaction_receipt;
+mod vid_batcher;
 mod writable;
 
 pub mod graphman;

--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -18,10 +18,9 @@ use graph::{
 use itertools::Itertools;
 
 use crate::{
-    catalog,
-    copy::AdaptiveBatchSize,
-    deployment,
+    catalog, deployment,
     relational::{Table, VID_COLUMN},
+    vid_batcher::AdaptiveBatchSize,
 };
 
 use super::{Catalog, Layout, Namespace};

--- a/store/postgres/src/vid_batcher.rs
+++ b/store/postgres/src/vid_batcher.rs
@@ -1,0 +1,63 @@
+use std::time::Duration;
+
+use diesel::{
+    deserialize::FromSql,
+    pg::Pg,
+    serialize::{Output, ToSql},
+    sql_types::BigInt,
+};
+use graph::env::ENV_VARS;
+
+use crate::relational::Table;
+
+/// The initial batch size for tables that do not have an array column
+const INITIAL_BATCH_SIZE: i64 = 10_000;
+/// The initial batch size for tables that do have an array column; those
+/// arrays can be large and large arrays will slow down copying a lot. We
+/// therefore tread lightly in that case
+const INITIAL_BATCH_SIZE_LIST: i64 = 100;
+
+/// Track the desired size of a batch in such a way that doing the next
+/// batch gets close to TARGET_DURATION for the time it takes to copy one
+/// batch, but don't step up the size by more than 2x at once
+#[derive(Debug, Queryable)]
+pub(crate) struct AdaptiveBatchSize {
+    pub size: i64,
+}
+
+impl AdaptiveBatchSize {
+    pub fn new(table: &Table) -> Self {
+        let size = if table.columns.iter().any(|col| col.is_list()) {
+            INITIAL_BATCH_SIZE_LIST
+        } else {
+            INITIAL_BATCH_SIZE
+        };
+
+        Self { size }
+    }
+
+    // adjust batch size by trying to extrapolate in such a way that we
+    // get close to TARGET_DURATION for the time it takes to copy one
+    // batch, but don't step up batch_size by more than 2x at once
+    pub fn adapt(&mut self, duration: Duration) {
+        // Avoid division by zero
+        let duration = duration.as_millis().max(1);
+        let new_batch_size = self.size as f64
+            * ENV_VARS.store.batch_target_duration.as_millis() as f64
+            / duration as f64;
+        self.size = (2 * self.size).min(new_batch_size.round() as i64);
+    }
+}
+
+impl ToSql<BigInt, Pg> for AdaptiveBatchSize {
+    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> diesel::serialize::Result {
+        <i64 as ToSql<BigInt, Pg>>::to_sql(&self.size, out)
+    }
+}
+
+impl FromSql<BigInt, Pg> for AdaptiveBatchSize {
+    fn from_sql(bytes: diesel::pg::PgValue) -> diesel::deserialize::Result<Self> {
+        let size = <i64 as FromSql<BigInt, Pg>>::from_sql(bytes)?;
+        Ok(AdaptiveBatchSize { size })
+    }
+}

--- a/store/postgres/src/vid_batcher.rs
+++ b/store/postgres/src/vid_batcher.rs
@@ -1,9 +1,6 @@
 use std::time::{Duration, Instant};
 
 use diesel::{
-    deserialize::FromSql,
-    pg::Pg,
-    serialize::{Output, ToSql},
     sql_query,
     sql_types::{BigInt, Integer},
     PgConnection, RunQueryDsl as _,
@@ -59,22 +56,6 @@ impl AdaptiveBatchSize {
         let new_batch_size = self.size as f64 * self.target.as_millis() as f64 / duration as f64;
         self.size = (2 * self.size).min(new_batch_size.round() as i64);
         self.size
-    }
-}
-
-impl ToSql<BigInt, Pg> for AdaptiveBatchSize {
-    fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> diesel::serialize::Result {
-        <i64 as ToSql<BigInt, Pg>>::to_sql(&self.size, out)
-    }
-}
-
-impl FromSql<BigInt, Pg> for AdaptiveBatchSize {
-    fn from_sql(bytes: diesel::pg::PgValue) -> diesel::deserialize::Result<Self> {
-        let size = <i64 as FromSql<BigInt, Pg>>::from_sql(bytes)?;
-        Ok(AdaptiveBatchSize {
-            size,
-            target: ENV_VARS.store.batch_target_duration,
-        })
     }
 }
 


### PR DESCRIPTION
When we copy/graft/prune, we split the entire work that needs to be done into batches that are meant to take roughly three minutes to avoid bloating the `subgraph_deployment` table. Pruning causes a very serious problem with that, and when that happens it can be crippling for the performance of the overall system.

The code that adjusts the size of the batch to hit that target tacitly assumes that the actual work is distributed linearly, i.e., if we ask for work covering 10,000 rows (going by `vid`), we are fine with getting fewer rows, maybe even just a handful, but this needs to be uniform: any 10,000 row batch needs to have roughly the same number of rows. Pruning breaks this assumption since in a pruned subgraph, the beginning of the subgraph (as determined by block numbers) will be much sparser than the later parts. In one case, this misled the estimation logic to eventually try and copy 160M rows since that's what the early part of the subgraph indicated could be copied in the three minutes, as the subgraph was pruned and the range of 160M row numbers only contained 128 rows in the beginning of the subgraph. After that, the subgraph was dense and copying 160M `vid`'s would take many hours.

This PR removes the assumption that the relation between `vid` and actual rows is linear. It uses the `histogram_bounds` from `pg_stats` to build a piecewise linear function, and estimates the number of rows in a given `vid` range using that piecewise linear function (the `Ogive` in the code) Now, when we ask for a batch of 10,000 rows, the code will adapt to an uneven `vid` distribution and return different size `vid` ranges for different parts of the table.