### PR TITLE
pass list of indexes when pruning a subgraph

### DIFF
--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -1715,7 +1715,7 @@ impl Table {
     pub fn new_like(&self, namespace: &Namespace, name: &SqlName) -> Arc<Table> {
         let other = Table {
             object: self.object.clone(),
-            nsp: self.nsp.clone(),
+            nsp: namespace.clone(),
             name: name.clone(),
             qualified_name: SqlName::qualified_name(namespace, name),
             columns: self.columns.clone(),

--- a/store/postgres/src/relational/ddl.rs
+++ b/store/postgres/src/relational/ddl.rs
@@ -403,13 +403,7 @@ impl Table {
         if index_def.is_some() && ENV_VARS.postpone_attribute_index_creation {
             let arr = index_def
                 .unwrap()
-                .indexes_for_table(
-                    &catalog.site.namespace,
-                    &self.name.to_string(),
-                    &self,
-                    false,
-                    false,
-                )
+                .indexes_for_table(&self.nsp, &self.name.to_string(), &self, false, false)
                 .map_err(|_| fmt::Error)?;
             for (_, sql) in arr {
                 writeln!(out, "{};", sql).expect("properly formated index statements")

--- a/store/postgres/src/relational/index.rs
+++ b/store/postgres/src/relational/index.rs
@@ -440,7 +440,7 @@ impl CreateIndex {
         }
     }
 
-    fn with_nsp(&self, nsp2: String) -> Result<Self, Error> {
+    pub fn with_nsp(&self, nsp2: String) -> Result<Self, Error> {
         let s = self.clone();
         match s {
             CreateIndex::Unknown { defn: _ } => Err(anyhow!("Failed to parse the index")),

--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Write, sync::Arc};
+use std::{collections::HashMap, fmt::Write, sync::Arc, time::Instant};
 
 use diesel::{
     connection::SimpleConnection,
@@ -58,7 +58,7 @@ impl TablePair {
         } else {
             // In case of pruning we don't do delayed creation of indexes,
             // as the asumption is that there is not that much data inserted.
-            dst.as_ddl(schema, catalog, None, &mut query)?;
+            dst.as_ddl(schema, catalog, Some(&list), &mut query)?;
         }
         conn.batch_execute(&query)?;
 

--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -56,6 +56,12 @@ impl TablePair {
         if catalog::table_exists(conn, dst_nsp.as_str(), &dst.name)? {
             writeln!(query, "truncate table {};", dst.qualified_name)?;
         } else {
+            let mut list = IndexList {
+                indexes: HashMap::new(),
+            };
+            let indexes = load_indexes_from_table(conn, &src, src_nsp.as_str())?;
+            list.indexes.insert(src.name.to_string(), indexes);
+
             // In case of pruning we don't do delayed creation of indexes,
             // as the asumption is that there is not that much data inserted.
             dst.as_ddl(schema, catalog, Some(&list), &mut query)?;


### PR DESCRIPTION
Fixes #5787 and bug mentioned in previous [PR](https://github.com/graphprotocol/graph-node/pull/5791#discussion_r1950129026)