### PR TITLE
Subgraph Composition: More validations

### DIFF
--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -700,10 +700,10 @@ impl<C: Blockchain> UnvalidatedSubgraphManifest<C> {
             .filter(|ds| matches!(ds, DataSource::Subgraph(_)))
             .count();
 
-        if subgraph_ds_count > 1 {
+        if subgraph_ds_count > 5 {
             errors.push(SubgraphManifestValidationError::DataSourceValidation(
                 "subgraph".to_string(),
-                anyhow!("Cannot have more than one subgraph datasource"),
+                anyhow!("Cannot have more than 5 subgraph datasources"),
             ));
         }
 

--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -719,6 +719,23 @@ impl<C: Blockchain> UnvalidatedSubgraphManifest<C> {
             ));
         }
 
+        // Check for duplicate source subgraphs
+        let mut seen_sources = std::collections::HashSet::new();
+        for ds in data_sources.iter() {
+            if let DataSource::Subgraph(ds) = ds {
+                let source_id = ds.source.address();
+                if !seen_sources.insert(source_id.clone()) {
+                    errors.push(SubgraphManifestValidationError::DataSourceValidation(
+                        "subgraph".to_string(),
+                        anyhow!(
+                            "Multiple subgraph datasources cannot use the same source subgraph {}",
+                            source_id
+                        ),
+                    ));
+                }
+            }
+        }
+
         errors
     }
 

--- a/graph/src/data_source/subgraph.rs
+++ b/graph/src/data_source/subgraph.rs
@@ -292,9 +292,7 @@ impl UnresolvedDataSource {
             .iter()
             .any(|ds| matches!(ds, crate::data_source::DataSource::Subgraph(_)))
         {
-            return Err(anyhow!(
-                "Nested subgraph data sources are not supported."
-            ));
+            return Err(anyhow!("Nested subgraph data sources are not supported."));
         }
 
         if source_spec_version < &SPEC_VERSION_1_3_0 {

--- a/graph/src/data_source/subgraph.rs
+++ b/graph/src/data_source/subgraph.rs
@@ -287,6 +287,16 @@ impl UnresolvedDataSource {
         let source_manifest = self.resolve_source_manifest::<C>(resolver, logger).await?;
         let source_spec_version = &source_manifest.spec_version;
 
+        if source_manifest
+            .data_sources
+            .iter()
+            .any(|ds| matches!(ds, crate::data_source::DataSource::Subgraph(_)))
+        {
+            return Err(anyhow!(
+                "Nested subgraph data sources are not supported."
+            ));
+        }
+
         if source_spec_version < &SPEC_VERSION_1_3_0 {
             return Err(anyhow!(
                 "Source subgraph manifest spec version {} is not supported, minimum supported version is {}",

--- a/store/test-store/tests/chain/ethereum/manifest.rs
+++ b/store/test-store/tests/chain/ethereum/manifest.rs
@@ -318,7 +318,7 @@ dataSources:
         - Profile
     network: mainnet
     source:
-      address: 'QmSource'
+      address: 'QmSource2'
       startBlock: 9562500
     mapping:
       apiVersion: 0.0.6
@@ -1706,60 +1706,6 @@ dataSources:
         let decls = &ds.mapping.handlers[0].calls.decls;
         assert_eq!(3, decls.len());
     });
-}
-
-#[tokio::test]
-async fn multiple_subgraph_ds_manifest_should_fail() {
-    let yaml = "
-schema:
-  file:
-    /: /ipfs/Qmschema
-dataSources:
-  - name: SubgraphSource1
-    kind: subgraph
-    entities:
-        - User
-    network: mainnet
-    source: 
-      address: 'QmSource'
-      startBlock: 9562480
-    mapping:
-      apiVersion: 0.0.6
-      language: wasm/assemblyscript
-      entities:
-        - TestEntity
-      file:
-        /: /ipfs/Qmmapping
-      handlers:
-        - handler: handleEntity
-          entity: User
-  - name: SubgraphSource2
-    kind: subgraph
-    entities:
-        - Profile
-    network: mainnet
-    source:
-      address: 'QmSource2'
-      startBlock: 9562500
-    mapping:
-      apiVersion: 0.0.6
-      language: wasm/assemblyscript
-      entities:
-        - TestEntity
-      file:
-        /: /ipfs/Qmmapping
-      handlers:
-        - handler: handleProfile
-          entity: Profile
-specVersion: 1.3.0
-";
-
-    let result = try_resolve_manifest(yaml, SPEC_VERSION_1_3_0).await;
-    assert!(result.is_err());
-    let err = result.unwrap_err();
-    assert!(err
-        .to_string()
-        .contains("Cannot have more than one subgraph datasource"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
This PR
- Sets a hard limit (5) on the number of datasources that can be composed together 
- Prevents nesting of subgraph datasources
