### PR TITLE
update pull request trigger for ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
   pull_request:
-    types: [opened, synchronize, reopened]
+    branches: [master]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Any reason why this just triggers on specific pr action types atm.?