### PR TITLE
Add `deployment_synced` metric

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,19 @@
 # NEWS
 
-## v0.36.1
+## v0.38.0
+
+### What's new
+
+- A new `deployment_synced` metric is added [(#5816)](https://github.com/graphprotocol/graph-node/pull/5816)
+  that indicates whether a deployment has reached the chain head since it was deployed.
+
+  **Possible values for the metric:**
+    - `0` - means that the deployment is not synced;
+    - `1` - means that the deployment is synced;
+
+  _If a deployment is not running, the metric reports no value for that deployment._
+
+## v0.37.0
 
 ### What's new
 

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -205,6 +205,8 @@ where
     }
 
     async fn run_inner(mut self, break_on_restart: bool) -> Result<Self, SubgraphRunnerError> {
+        self.update_deployment_synced_metric();
+
         // If a subgraph failed for deterministic reasons, before start indexing, we first
         // revert the deployment head. It should lead to the same result since the error was
         // deterministic.
@@ -292,6 +294,8 @@ where
                             .observe_block_processed(block_start.elapsed(), res.block_finished());
                         res
                     })?;
+
+                self.update_deployment_synced_metric();
 
                 // It is possible that the subgraph was unassigned, but the runner was in
                 // a retry delay state and did not observe the cancel signal.
@@ -1230,6 +1234,13 @@ where
         }
 
         Ok((mods, processed_data_sources, persisted_data_sources))
+    }
+
+    fn update_deployment_synced_metric(&self) {
+        self.metrics
+            .subgraph
+            .deployment_synced
+            .record(self.inputs.store.is_deployment_synced());
     }
 }
 


### PR DESCRIPTION
This PR adds a new `deployment_synced` metric that indicates whether a deployment has reached the chain head since it was deployed.

Possible values for the metric:
- `0` - means that the deployment is not synced;
- `1` - means that the deployment is synced;

If a deployment is not running, the metric reports no value for that deployment.

Closes #5813

## Example of the metric in use

![deployment_synced_metric](https://github.com/user-attachments/assets/79697291-c50f-4060-a8d3-011c3fd3c2b9)

_* All values in the example are for the same subgraph deployment._
