### PR TITLE
Remove separate entity counting step at end of copy

### DIFF
--- a/store/postgres/src/deployment.rs
+++ b/store/postgres/src/deployment.rs
@@ -1249,17 +1249,12 @@ pub fn update_entity_count(
     Ok(())
 }
 
-/// Set the deployment's entity count to whatever `full_count_query` produces
-pub fn set_entity_count(
-    conn: &mut PgConnection,
-    site: &Site,
-    full_count_query: &str,
-) -> Result<(), StoreError> {
+/// Set the deployment's entity count back to `0`
+pub fn clear_entity_count(conn: &mut PgConnection, site: &Site) -> Result<(), StoreError> {
     use subgraph_deployment as d;
 
-    let full_count_query = format!("({})", full_count_query);
     update(d::table.filter(d::id.eq(site.id)))
-        .set(d::entity_count.eq(sql(&full_count_query)))
+        .set(d::entity_count.eq(BigDecimal::from(0)))
         .execute(conn)?;
     Ok(())
 }

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1570,13 +1570,10 @@ impl DeploymentStore {
                     .number
                     .checked_add(1)
                     .expect("block numbers fit into an i32");
-                dst.revert_block(conn, block_to_revert)?;
-                info!(logger, "Rewound subgraph to block {}", block.number;
-                      "time_ms" => start.elapsed().as_millis());
+                let (_, count) = dst.revert_block(conn, block_to_revert)?;
+                deployment::update_entity_count(conn, &dst.site, count)?;
 
-                let start = Instant::now();
-                deployment::set_entity_count(conn, &dst.site, &dst.count_query)?;
-                info!(logger, "Counted the entities";
+                info!(logger, "Rewound subgraph to block {}", block.number;
                       "time_ms" => start.elapsed().as_millis());
 
                 deployment::set_history_blocks(

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1306,7 +1306,8 @@ impl DeploymentStore {
                 let layout = self.layout(conn, site.clone())?;
 
                 if truncate {
-                    deployment::set_entity_count(conn, site.as_ref(), layout.count_query.as_str())?;
+                    layout.truncate_tables(conn)?;
+                    deployment::clear_entity_count(conn, site.as_ref())?;
                 } else {
                     let count = layout.revert_block(conn, block)?;
                     deployment::update_entity_count(conn, site.as_ref(), count)?;
@@ -1570,7 +1571,7 @@ impl DeploymentStore {
                     .number
                     .checked_add(1)
                     .expect("block numbers fit into an i32");
-                let (_, count) = dst.revert_block(conn, block_to_revert)?;
+                let count = dst.revert_block(conn, block_to_revert)?;
                 deployment::update_entity_count(conn, &dst.site, count)?;
 
                 info!(logger, "Rewound subgraph to block {}", block.number;

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -73,7 +73,7 @@ use graph::data::store::{Id, IdList, IdType, BYTES_SCALAR};
 use graph::data::subgraph::schema::POI_TABLE;
 use graph::prelude::{
     anyhow, info, BlockNumber, DeploymentHash, Entity, EntityOperation, Logger,
-    QueryExecutionError, StoreError, StoreEvent, ValueType,
+    QueryExecutionError, StoreError, ValueType,
 };
 
 use crate::block_range::{BoundSide, BLOCK_COLUMN, BLOCK_RANGE_COLUMN};
@@ -1004,11 +1004,11 @@ impl Layout {
         Ok(count)
     }
 
-    pub fn truncate_tables(&self, conn: &mut PgConnection) -> Result<StoreEvent, StoreError> {
+    pub fn truncate_tables(&self, conn: &mut PgConnection) -> Result<(), StoreError> {
         for table in self.tables.values() {
             sql_query(&format!("TRUNCATE TABLE {}", table.qualified_name)).execute(conn)?;
         }
-        Ok(StoreEvent::new(vec![]))
+        Ok(())
     }
 
     /// Revert the block with number `block` and all blocks with higher

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -1037,6 +1037,9 @@ impl Layout {
     /// numbers. After this operation, only entity versions inserted or
     /// updated at blocks with numbers strictly lower than `block` will
     /// remain
+    ///
+    /// The `i32` that is returned is the amount by which the entity count
+    /// for the subgraph needs to be adjusted
     pub fn revert_block(
         &self,
         conn: &mut PgConnection,


### PR DESCRIPTION
We used to count all entities in the destination after all data had been copied; for large subgraphs, that can be a very slow operation, and in some cases makes the copy operation fail because the underlying fdw connection times out.

With this PR, we now update the entity count with every batch we copy.