### PR TITLE
node: Make output of `graphman info`more concise

### DIFF
--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -143,6 +143,12 @@ pub enum Command {
         /// List only used (current and pending) versions
         #[clap(long, short)]
         used: bool,
+        /// List names only for the active deployment
+        #[clap(long, short)]
+        brief: bool,
+        /// Do not print subgraph names
+        #[clap(long, short = 'N')]
+        no_name: bool,
     },
     /// Manage unused deployments
     ///
@@ -1127,6 +1133,8 @@ async fn main() -> anyhow::Result<()> {
             status,
             used,
             all,
+            brief,
+            no_name,
         } => {
             let (store, primary_pool) = ctx.store_and_primary();
 
@@ -1142,6 +1150,8 @@ async fn main() -> anyhow::Result<()> {
                 status,
                 used,
                 all,
+                brief,
+                no_name,
             };
 
             commands::deployment::info::run(ctx, args)

--- a/node/src/manager/display.rs
+++ b/node/src/manager/display.rs
@@ -1,3 +1,7 @@
+use std::io::{self, Write};
+
+const LINE_WIDTH: usize = 78;
+
 pub struct List {
     pub headers: Vec<String>,
     pub rows: Vec<Vec<String>>,
@@ -29,8 +33,6 @@ impl List {
     }
 
     pub fn render(&self) {
-        const LINE_WIDTH: usize = 78;
-
         let header_width = self.headers.iter().map(|h| h.len()).max().unwrap_or(0);
         let header_width = if header_width < 5 { 5 } else { header_width };
         let mut first = true;
@@ -50,5 +52,99 @@ impl List {
                 println!("{:width$} | {}", header, value, width = header_width);
             }
         }
+    }
+}
+
+/// A more general list of columns than `List`. In practical terms, this is
+/// a very simple table with two columns, where both columns are
+/// left-aligned
+pub struct Columns {
+    widths: Vec<usize>,
+    rows: Vec<Row>,
+}
+
+impl Columns {
+    pub fn push_row<R: Into<Row>>(&mut self, row: R) {
+        let row = row.into();
+        for (idx, width) in row.widths().iter().enumerate() {
+            if idx >= self.widths.len() {
+                self.widths.push(*width);
+            } else {
+                self.widths[idx] = (*width).max(self.widths[idx]);
+            }
+        }
+        self.rows.push(row);
+    }
+
+    pub fn render(&self, out: &mut dyn Write) -> io::Result<()> {
+        for row in &self.rows {
+            row.render(out, &self.widths)?;
+        }
+        Ok(())
+    }
+}
+
+impl Default for Columns {
+    fn default() -> Self {
+        Self {
+            widths: Vec::new(),
+            rows: Vec::new(),
+        }
+    }
+}
+
+pub enum Row {
+    Cells(Vec<String>),
+    Separator,
+}
+
+impl Row {
+    pub fn separator() -> Self {
+        Self::Separator
+    }
+
+    fn widths(&self) -> Vec<usize> {
+        match self {
+            Row::Cells(cells) => cells.iter().map(|cell| cell.len()).collect(),
+            Row::Separator => vec![],
+        }
+    }
+
+    fn render(&self, out: &mut dyn Write, widths: &[usize]) -> io::Result<()> {
+        match self {
+            Row::Cells(cells) => {
+                for (idx, cell) in cells.iter().enumerate() {
+                    if idx > 0 {
+                        write!(out, " | ")?;
+                    }
+                    write!(out, "{cell:width$}", width = widths[idx])?;
+                }
+            }
+            Row::Separator => {
+                let total_width = widths.iter().sum::<usize>();
+                let extra_width = if total_width >= LINE_WIDTH {
+                    0
+                } else {
+                    LINE_WIDTH - total_width
+                };
+                for (idx, width) in widths.iter().enumerate() {
+                    if idx > 0 {
+                        write!(out, "-+-")?;
+                    }
+                    if idx == widths.len() - 1 {
+                        write!(out, "{:-<width$}", "", width = width + extra_width)?;
+                    } else {
+                        write!(out, "{:-<width$}", "")?;
+                    }
+                }
+            }
+        }
+        writeln!(out)
+    }
+}
+
+impl From<[&str; 2]> for Row {
+    fn from(row: [&str; 2]) -> Self {
+        Self::Cells(row.iter().map(|s| s.to_string()).collect())
     }
 }


### PR DESCRIPTION
graphman info prints one fairly big block of text for each subgraph version. A lot of the information is repetetive since it is tied to a deployment, not a subgraph name. To make the output more usable, it is now organized around deployments, and lists all the names for a deployment in one place, like:

```
Namespace        | sgd114 [primary]
Hash             | QmVsp1bC9rS3rf861cXgyvsqkpdsTXKSnS4729boXZvZyH
Versions         | u65281/s53035/latest (current)
                 | u65281/s53035/v2 (current)
Chain            | mainnet
Node ID          | default
Active           | true
Paused           | false
Synced           | false
Health           | healthy
Earliest Block   | 9923743
Latest Block     | 9931270
Chain Head Block | 20988707
   Blocks behind | 11057437
```

The new options `--brief` and `--no-name` can be used to further cut down on the output by supressing names for all but active deployments or suppressing all names

