### PR TITLE
server/graphman: Fix failing test

### DIFF
--- a/server/graphman/tests/deployment_mutation.rs
+++ b/server/graphman/tests/deployment_mutation.rs
@@ -517,7 +517,7 @@ fn graphql_can_reassign_deployment() {
             json!({
                 "query": r#"mutation {
                     deployment {
-                        reassign(deployment: { hash: "subgraph_1" }, node: "test") {
+                        reassign(deployment: { hash: "subgraph_1" }, node: "testGraphQLAssignment") {
                             ... on EmptyResponse {
                                 success
                             }
@@ -536,7 +536,7 @@ fn graphql_can_reassign_deployment() {
             "data": {
                 "deployment": {
                     "reassign": {
-                        "success": true,
+                        "warnings": ["This is the only deployment assigned to 'testGraphQLAssignment'. Please make sure that the node ID is spelled correctly."],
                     }
                 }
             }


### PR DESCRIPTION
I am not 100% sure that this is the right fix for that test, but it was failing for me locally.

I would also suggest that the response when it has warnings should contain success data, i.e., that it looks something like
```json
"data": {
  "deployment": {
    "reassign": {
      "success": true,
      "warnings": ["..."],
    }  }  }
```

@isum @shiyasmohd Would love your take on that.