### PR TITLE
Graphman: Do not use hardcoded node ID in tests

### DIFF
--- a/server/graphman/src/entities/warning_response.rs
+++ b/server/graphman/src/entities/warning_response.rs
@@ -2,11 +2,15 @@ use async_graphql::SimpleObject;
 
 #[derive(Clone, Debug, SimpleObject)]
 pub struct CompletedWithWarnings {
+    pub success: bool,
     pub warnings: Vec<String>,
 }
 
 impl CompletedWithWarnings {
     pub fn new(warnings: Vec<String>) -> Self {
-        Self { warnings }
+        Self {
+            success: true,
+            warnings,
+        }
     }
 }


### PR DESCRIPTION
This PR ensures that the correct node ID is used by tests, as there are some differences between running tests locally and on the CI.