### PR TITLE
Reduce block range on Monad getLogs RPC call size failures

### DIFF
--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -407,6 +407,7 @@ impl EthereumAdapter {
             "503 Service Unavailable",   // Alchemy
             "ServerError(-32000)",       // Alchemy
             "Try with this block range", // zKSync era
+            "block range too large",     // Monad
         ];
 
         if from > to {


### PR DESCRIPTION
This PR white-lists the Monad Network RPC error caused by calling getLogs with a block range that is too large. It allows the block range to be reduced until a successful response is received.