### PR TITLE
More descriptive manifest resolve error

### DIFF
--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -370,7 +370,7 @@ pub enum SubgraphManifestResolveError {
     NonUtf8,
     #[error("subgraph is not valid YAML")]
     InvalidFormat,
-    #[error("resolve error: {0}")]
+    #[error("resolve error: {0:#}")]
     ResolveError(#[from] anyhow::Error),
 }
 

--- a/graph/src/data_source/common.rs
+++ b/graph/src/data_source/common.rs
@@ -81,7 +81,8 @@ impl UnresolvedMappingABI {
                 self.name, self.file.link
             )
         })?;
-        let contract = Contract::load(&*contract_bytes)?;
+        let contract = Contract::load(&*contract_bytes)
+            .with_context(|| format!("failed to load ABI {}", self.name))?;
         Ok(MappingABI {
             name: self.name,
             contract,


### PR DESCRIPTION
The other day with @marcusrein we've ran into an issue with Explorer for one of the chains supplying slightly invalid ABI (one of the required fields was being lost during serialization). 

`graph init` would scaffold subgraph for this ABI but `graph deploy` request to Graph Node would fail with a very generic error:

`
✖ Failed to deploy to Graph node http://localhost:8020/: subgraph resolve error: resolve error: failed to resolve data source Contract with source_address Some(0x88b8e2161dedc77ef4ab7585569d2415a1c1055d) and source_start_block 4900000
`

Deployment: `QmejLsgNNWCWT25HqVsgWZ6VgDBWpaR7RijQeYdcDZn6k3`


This PR makes error message more descriptive for the subgraph developer:

`
✖ Failed to deploy to Graph node http://localhost:8020/: subgraph resolve error: resolve error: failed to resolve data source Contract with source_address Some(0x88b8e2161dedc77ef4ab7585569d2415a1c1055d) and source_start_block 4900000: failed to resolve mapping /ipfs/QmWmftR3RhDtRJpeK8JhgcP1Bys8cwMCwpMs6LH2noh1A3: failed to load ABI Contract: Serialization error: missing field `anonymous` at line 169 column 3: missing field "anonymous" at line 169 column 3
`

