### PR TITLE
Stop pretending that there are subgraphs that don't support PoI

### DIFF
--- a/core/src/subgraph/context/mod.rs
+++ b/core/src/subgraph/context/mod.rs
@@ -126,11 +126,7 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
     ) -> Result<BlockState, MappingError> {
         let error_count = state.deterministic_errors.len();
 
-        if let Some(proof_of_indexing) = proof_of_indexing {
-            proof_of_indexing
-                .borrow_mut()
-                .start_handler(causality_region);
-        }
+        proof_of_indexing.start_handler(causality_region);
 
         let start = Instant::now();
 
@@ -156,16 +152,12 @@ impl<C: Blockchain, T: RuntimeHostBuilder<C>> IndexingContext<C, T> {
         let elapsed = start.elapsed().as_secs_f64();
         subgraph_metrics.observe_trigger_processing_duration(elapsed);
 
-        if let Some(proof_of_indexing) = proof_of_indexing {
-            if state.deterministic_errors.len() != error_count {
-                assert!(state.deterministic_errors.len() == error_count + 1);
+        if state.deterministic_errors.len() != error_count {
+            assert!(state.deterministic_errors.len() == error_count + 1);
 
-                // If a deterministic error has happened, write a new
-                // ProofOfIndexingEvent::DeterministicError to the SharedProofOfIndexing.
-                proof_of_indexing
-                    .borrow_mut()
-                    .write_deterministic_error(logger, causality_region);
-            }
+            // If a deterministic error has happened, write a new
+            // ProofOfIndexingEvent::DeterministicError to the SharedProofOfIndexing.
+            proof_of_indexing.write_deterministic_error(logger, causality_region);
         }
 
         Ok(state)

--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -367,14 +367,10 @@ where
         debug!(logger, "Start processing block";
                "triggers" => triggers.len());
 
-        let proof_of_indexing = if self.inputs.store.supports_proof_of_indexing().await? {
-            Some(Arc::new(AtomicRefCell::new(ProofOfIndexing::new(
-                block_ptr.number,
-                self.inputs.poi_version,
-            ))))
-        } else {
-            None
-        };
+        let proof_of_indexing = Some(Arc::new(AtomicRefCell::new(ProofOfIndexing::new(
+            block_ptr.number,
+            self.inputs.poi_version,
+        ))));
 
         // Causality region for onchain triggers.
         let causality_region = PoICausalityRegion::from_network(&self.inputs.network);
@@ -1318,14 +1314,10 @@ where
             .deployment_head
             .set(block_ptr.number as f64);
 
-        let proof_of_indexing = if self.inputs.store.supports_proof_of_indexing().await? {
-            Some(Arc::new(AtomicRefCell::new(ProofOfIndexing::new(
-                block_ptr.number,
-                self.inputs.poi_version,
-            ))))
-        } else {
-            None
-        };
+        let proof_of_indexing = Some(Arc::new(AtomicRefCell::new(ProofOfIndexing::new(
+            block_ptr.number,
+            self.inputs.poi_version,
+        ))));
 
         // Causality region for onchain triggers.
         let causality_region = PoICausalityRegion::from_network(&self.inputs.network);

--- a/core/src/subgraph/trigger_processor.rs
+++ b/core/src/subgraph/trigger_processor.rs
@@ -39,11 +39,7 @@ where
             return Ok(state);
         }
 
-        if let Some(proof_of_indexing) = proof_of_indexing {
-            proof_of_indexing
-                .borrow_mut()
-                .start_handler(causality_region);
-        }
+        proof_of_indexing.start_handler(causality_region);
 
         for HostedTrigger {
             host,
@@ -73,16 +69,12 @@ where
             }
         }
 
-        if let Some(proof_of_indexing) = proof_of_indexing {
-            if state.deterministic_errors.len() != error_count {
-                assert!(state.deterministic_errors.len() == error_count + 1);
+        if state.deterministic_errors.len() != error_count {
+            assert!(state.deterministic_errors.len() == error_count + 1);
 
-                // If a deterministic error has happened, write a new
-                // ProofOfIndexingEvent::DeterministicError to the SharedProofOfIndexing.
-                proof_of_indexing
-                    .borrow_mut()
-                    .write_deterministic_error(logger, causality_region);
-            }
+            // If a deterministic error has happened, write a new
+            // ProofOfIndexingEvent::DeterministicError to the SharedProofOfIndexing.
+            proof_of_indexing.write_deterministic_error(logger, causality_region);
         }
 
         Ok(state)

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -365,8 +365,6 @@ pub trait WritableStore: ReadStore + DeploymentCursorTracker {
     /// Set subgraph status to failed with the given error as the cause.
     async fn fail_subgraph(&self, error: SubgraphError) -> Result<(), StoreError>;
 
-    async fn supports_proof_of_indexing(&self) -> Result<bool, StoreError>;
-
     /// Transact the entity changes from a single block atomically into the store, and update the
     /// subgraph block pointer to `block_ptr_to`, and update the firehose cursor to `firehose_cursor`
     ///

--- a/runtime/test/src/common.rs
+++ b/runtime/test/src/common.rs
@@ -1,6 +1,7 @@
 use ethabi::Contract;
 use graph::blockchain::BlockTime;
 use graph::components::store::DeploymentLocator;
+use graph::components::subgraph::SharedProofOfIndexing;
 use graph::data::subgraph::*;
 use graph::data_source;
 use graph::data_source::common::MappingABI;
@@ -127,7 +128,7 @@ pub fn mock_context(
             .unwrap(),
             Default::default(),
         ),
-        proof_of_indexing: None,
+        proof_of_indexing: SharedProofOfIndexing::ignored(),
         host_fns: Arc::new(Vec::new()),
         debug_fork: None,
         mapping_logger: Logger::root(slog::Discard, o!()),

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::ops::Deref;
 use std::str::FromStr;
 use std::time::{Duration, Instant};
 
@@ -32,18 +31,6 @@ use crate::module::WasmInstance;
 use crate::{error::DeterminismLevel, module::IntoTrap};
 
 use super::module::WasmInstanceData;
-
-fn write_poi_event(
-    proof_of_indexing: &SharedProofOfIndexing,
-    poi_event: &ProofOfIndexingEvent,
-    causality_region: &str,
-    logger: &Logger,
-) {
-    if let Some(proof_of_indexing) = proof_of_indexing {
-        let mut proof_of_indexing = proof_of_indexing.deref().borrow_mut();
-        proof_of_indexing.write(logger, causality_region, poi_event);
-    }
-}
 
 impl IntoTrap for HostExportError {
     fn determinism_level(&self) -> DeterminismLevel {
@@ -336,8 +323,7 @@ impl HostExports {
             .map_err(|e| HostExportError::Deterministic(anyhow!(e)))?;
 
         let poi_section = stopwatch.start_section("host_export_store_set__proof_of_indexing");
-        write_poi_event(
-            proof_of_indexing,
+        proof_of_indexing.write_event(
             &ProofOfIndexingEvent::SetEntity {
                 entity_type: &key.entity_type.typename(),
                 id: &key.entity_id.to_string(),
@@ -369,8 +355,7 @@ impl HostExports {
         entity_id: String,
         gas: &GasCounter,
     ) -> Result<(), HostExportError> {
-        write_poi_event(
-            proof_of_indexing,
+        proof_of_indexing.write_event(
             &ProofOfIndexingEvent::RemoveEntity {
                 entity_type: &entity_type,
                 id: &entity_id,

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -916,20 +916,6 @@ impl DeploymentStore {
         }
     }
 
-    pub(crate) async fn supports_proof_of_indexing<'a>(
-        &self,
-        site: Arc<Site>,
-    ) -> Result<bool, StoreError> {
-        let store = self.clone();
-        self.with_conn(move |conn, cancel| {
-            cancel.check_cancel()?;
-            let layout = store.layout(conn, site)?;
-            Ok(layout.supports_proof_of_indexing())
-        })
-        .await
-        .map_err(Into::into)
-    }
-
     pub(crate) async fn get_proof_of_indexing(
         &self,
         site: Arc<Site>,
@@ -949,10 +935,6 @@ impl DeploymentStore {
                 cancel.check_cancel()?;
 
                 let layout = store.layout(conn, site.cheap_clone())?;
-
-                if !layout.supports_proof_of_indexing() {
-                    return Ok(None);
-                }
 
                 conn.transaction::<_, CancelableError<anyhow::Error>, _>(move |conn| {
                     let mut block_ptr = block.cheap_clone();

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -375,10 +375,6 @@ impl Layout {
         }
     }
 
-    pub fn supports_proof_of_indexing(&self) -> bool {
-        self.tables.contains_key(&self.input_schema.poi_type())
-    }
-
     pub fn create_relational_schema(
         conn: &mut PgConnection,
         site: Arc<Site>,

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -279,15 +279,6 @@ impl SyncStore {
         .await
     }
 
-    async fn supports_proof_of_indexing(&self) -> Result<bool, StoreError> {
-        retry::forever_async(&self.logger, "supports_proof_of_indexing", || async {
-            self.writable
-                .supports_proof_of_indexing(self.site.clone())
-                .await
-        })
-        .await
-    }
-
     fn get(&self, key: &EntityKey, block: BlockNumber) -> Result<Option<Entity>, StoreError> {
         retry::forever(&self.logger, "get", || {
             self.writable.get(self.site.cheap_clone(), key, block)
@@ -1665,10 +1656,6 @@ impl WritableStoreTrait for WritableStore {
 
     async fn fail_subgraph(&self, error: SubgraphError) -> Result<(), StoreError> {
         self.store.fail_subgraph(error).await
-    }
-
-    async fn supports_proof_of_indexing(&self) -> Result<bool, StoreError> {
-        self.store.supports_proof_of_indexing().await
     }
 
     async fn transact_block_operations(

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -121,10 +121,6 @@ impl WritableStore for MockStore {
         unimplemented!()
     }
 
-    async fn supports_proof_of_indexing(&self) -> Result<bool, StoreError> {
-        unimplemented!()
-    }
-
     async fn transact_block_operations(
         &self,
         _: BlockPtr,


### PR DESCRIPTION
Subgraphs have in fact supported proof of indexing for almost 5 years since commit 40fd330c and we can therefore stop pretending that `WritableStore.supports_proof_of_indexing` would ever return `false`