### PR TITLE
Avoid a few clones in ABI conversion

### DIFF
--- a/chain/ethereum/src/runtime/abi.rs
+++ b/chain/ethereum/src/runtime/abi.rs
@@ -420,68 +420,68 @@ where
     const INDEX_ASC_TYPE_ID: IndexForAscTypeId = IndexForAscTypeId::EthereumCall;
 }
 
-impl ToAscObj<AscEthereumBlock> for EthereumBlockData {
+impl<'a> ToAscObj<AscEthereumBlock> for EthereumBlockData<'a> {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
         gas: &GasCounter,
     ) -> Result<AscEthereumBlock, HostExportError> {
         Ok(AscEthereumBlock {
-            hash: asc_new(heap, &self.hash, gas)?,
-            parent_hash: asc_new(heap, &self.parent_hash, gas)?,
-            uncles_hash: asc_new(heap, &self.uncles_hash, gas)?,
-            author: asc_new(heap, &self.author, gas)?,
-            state_root: asc_new(heap, &self.state_root, gas)?,
-            transactions_root: asc_new(heap, &self.transactions_root, gas)?,
-            receipts_root: asc_new(heap, &self.receipts_root, gas)?,
-            number: asc_new(heap, &BigInt::from(self.number), gas)?,
-            gas_used: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_used), gas)?,
-            gas_limit: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_limit), gas)?,
-            timestamp: asc_new(heap, &BigInt::from_unsigned_u256(&self.timestamp), gas)?,
-            difficulty: asc_new(heap, &BigInt::from_unsigned_u256(&self.difficulty), gas)?,
+            hash: asc_new(heap, self.hash(), gas)?,
+            parent_hash: asc_new(heap, self.parent_hash(), gas)?,
+            uncles_hash: asc_new(heap, self.uncles_hash(), gas)?,
+            author: asc_new(heap, self.author(), gas)?,
+            state_root: asc_new(heap, self.state_root(), gas)?,
+            transactions_root: asc_new(heap, self.transactions_root(), gas)?,
+            receipts_root: asc_new(heap, self.receipts_root(), gas)?,
+            number: asc_new(heap, &BigInt::from(self.number()), gas)?,
+            gas_used: asc_new(heap, &BigInt::from_unsigned_u256(self.gas_used()), gas)?,
+            gas_limit: asc_new(heap, &BigInt::from_unsigned_u256(self.gas_limit()), gas)?,
+            timestamp: asc_new(heap, &BigInt::from_unsigned_u256(self.timestamp()), gas)?,
+            difficulty: asc_new(heap, &BigInt::from_unsigned_u256(self.difficulty()), gas)?,
             total_difficulty: asc_new(
                 heap,
-                &BigInt::from_unsigned_u256(&self.total_difficulty),
+                &BigInt::from_unsigned_u256(self.total_difficulty()),
                 gas,
             )?,
             size: self
-                .size
+                .size()
                 .map(|size| asc_new(heap, &BigInt::from_unsigned_u256(&size), gas))
                 .unwrap_or(Ok(AscPtr::null()))?,
         })
     }
 }
 
-impl ToAscObj<AscEthereumBlock_0_0_6> for EthereumBlockData {
+impl<'a> ToAscObj<AscEthereumBlock_0_0_6> for EthereumBlockData<'a> {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
         gas: &GasCounter,
     ) -> Result<AscEthereumBlock_0_0_6, HostExportError> {
         Ok(AscEthereumBlock_0_0_6 {
-            hash: asc_new(heap, &self.hash, gas)?,
-            parent_hash: asc_new(heap, &self.parent_hash, gas)?,
-            uncles_hash: asc_new(heap, &self.uncles_hash, gas)?,
-            author: asc_new(heap, &self.author, gas)?,
-            state_root: asc_new(heap, &self.state_root, gas)?,
-            transactions_root: asc_new(heap, &self.transactions_root, gas)?,
-            receipts_root: asc_new(heap, &self.receipts_root, gas)?,
-            number: asc_new(heap, &BigInt::from(self.number), gas)?,
-            gas_used: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_used), gas)?,
-            gas_limit: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_limit), gas)?,
-            timestamp: asc_new(heap, &BigInt::from_unsigned_u256(&self.timestamp), gas)?,
-            difficulty: asc_new(heap, &BigInt::from_unsigned_u256(&self.difficulty), gas)?,
+            hash: asc_new(heap, self.hash(), gas)?,
+            parent_hash: asc_new(heap, self.parent_hash(), gas)?,
+            uncles_hash: asc_new(heap, self.uncles_hash(), gas)?,
+            author: asc_new(heap, self.author(), gas)?,
+            state_root: asc_new(heap, self.state_root(), gas)?,
+            transactions_root: asc_new(heap, self.transactions_root(), gas)?,
+            receipts_root: asc_new(heap, self.receipts_root(), gas)?,
+            number: asc_new(heap, &BigInt::from(self.number()), gas)?,
+            gas_used: asc_new(heap, &BigInt::from_unsigned_u256(self.gas_used()), gas)?,
+            gas_limit: asc_new(heap, &BigInt::from_unsigned_u256(self.gas_limit()), gas)?,
+            timestamp: asc_new(heap, &BigInt::from_unsigned_u256(self.timestamp()), gas)?,
+            difficulty: asc_new(heap, &BigInt::from_unsigned_u256(self.difficulty()), gas)?,
             total_difficulty: asc_new(
                 heap,
-                &BigInt::from_unsigned_u256(&self.total_difficulty),
+                &BigInt::from_unsigned_u256(self.total_difficulty()),
                 gas,
             )?,
             size: self
-                .size
+                .size()
                 .map(|size| asc_new(heap, &BigInt::from_unsigned_u256(&size), gas))
                 .unwrap_or(Ok(AscPtr::null()))?,
             base_fee_per_block: self
-                .base_fee_per_gas
+                .base_fee_per_gas()
                 .map(|base_fee| asc_new(heap, &BigInt::from_unsigned_u256(&base_fee), gas))
                 .unwrap_or(Ok(AscPtr::null()))?,
         })
@@ -554,12 +554,12 @@ impl ToAscObj<AscEthereumTransaction_0_0_6> for EthereumTransactionData {
     }
 }
 
-impl<T, B> ToAscObj<AscEthereumEvent<T, B>> for EthereumEventData
+impl<'a, T, B> ToAscObj<AscEthereumEvent<T, B>> for EthereumEventData<'a>
 where
     T: AscType + AscIndexId,
     B: AscType + AscIndexId,
     EthereumTransactionData: ToAscObj<T>,
-    EthereumBlockData: ToAscObj<B>,
+    EthereumBlockData<'a>: ToAscObj<B>,
 {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
@@ -586,13 +586,13 @@ where
     }
 }
 
-impl<T, B> ToAscObj<AscEthereumEvent_0_0_7<T, B>>
-    for (EthereumEventData, Option<&TransactionReceipt>)
+impl<'a, T, B> ToAscObj<AscEthereumEvent_0_0_7<T, B>>
+    for (EthereumEventData<'a>, Option<&TransactionReceipt>)
 where
     T: AscType + AscIndexId,
     B: AscType + AscIndexId,
     EthereumTransactionData: ToAscObj<T>,
-    EthereumBlockData: ToAscObj<B>,
+    EthereumBlockData<'a>: ToAscObj<B>,
 {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
@@ -718,7 +718,7 @@ impl ToAscObj<AscEthereumTransactionReceipt> for &TransactionReceipt {
     }
 }
 
-impl ToAscObj<AscEthereumCall> for EthereumCallData {
+impl<'a> ToAscObj<AscEthereumCall> for EthereumCallData<'a> {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
@@ -734,8 +734,8 @@ impl ToAscObj<AscEthereumCall> for EthereumCallData {
     }
 }
 
-impl ToAscObj<AscEthereumCall_0_0_3<AscEthereumTransaction_0_0_2, AscEthereumBlock>>
-    for EthereumCallData
+impl<'a> ToAscObj<AscEthereumCall_0_0_3<AscEthereumTransaction_0_0_2, AscEthereumBlock>>
+    for EthereumCallData<'a>
 {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
@@ -756,8 +756,8 @@ impl ToAscObj<AscEthereumCall_0_0_3<AscEthereumTransaction_0_0_2, AscEthereumBlo
     }
 }
 
-impl ToAscObj<AscEthereumCall_0_0_3<AscEthereumTransaction_0_0_6, AscEthereumBlock_0_0_6>>
-    for EthereumCallData
+impl<'a> ToAscObj<AscEthereumCall_0_0_3<AscEthereumTransaction_0_0_6, AscEthereumBlock_0_0_6>>
+    for EthereumCallData<'a>
 {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,

--- a/chain/ethereum/src/runtime/abi.rs
+++ b/chain/ethereum/src/runtime/abi.rs
@@ -37,18 +37,6 @@ impl AscType for AscLogParamArray {
     }
 }
 
-impl ToAscObj<AscLogParamArray> for Vec<ethabi::LogParam> {
-    fn to_asc_obj<H: AscHeap + ?Sized>(
-        &self,
-        heap: &mut H,
-        gas: &GasCounter,
-    ) -> Result<AscLogParamArray, HostExportError> {
-        let content: Result<Vec<_>, _> = self.iter().map(|x| asc_new(heap, x, gas)).collect();
-        let content = content?;
-        Ok(AscLogParamArray(Array::new(&content, heap, gas)?))
-    }
-}
-
 impl ToAscObj<AscLogParamArray> for &[ethabi::LogParam] {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
@@ -737,7 +725,7 @@ impl<'a> ToAscObj<AscEthereumCall> for EthereumCallData<'a> {
         gas: &GasCounter,
     ) -> Result<AscEthereumCall, HostExportError> {
         Ok(AscEthereumCall {
-            address: asc_new(heap, &self.to, gas)?,
+            address: asc_new(heap, self.to(), gas)?,
             block: asc_new(heap, &self.block, gas)?,
             transaction: asc_new(heap, &self.transaction, gas)?,
             inputs: asc_new(heap, &self.inputs, gas)?,
@@ -758,8 +746,8 @@ impl<'a> ToAscObj<AscEthereumCall_0_0_3<AscEthereumTransaction_0_0_2, AscEthereu
         HostExportError,
     > {
         Ok(AscEthereumCall_0_0_3 {
-            to: asc_new(heap, &self.to, gas)?,
-            from: asc_new(heap, &self.from, gas)?,
+            to: asc_new(heap, self.to(), gas)?,
+            from: asc_new(heap, self.from(), gas)?,
             block: asc_new(heap, &self.block, gas)?,
             transaction: asc_new(heap, &self.transaction, gas)?,
             inputs: asc_new(heap, &self.inputs, gas)?,
@@ -780,8 +768,8 @@ impl<'a> ToAscObj<AscEthereumCall_0_0_3<AscEthereumTransaction_0_0_6, AscEthereu
         HostExportError,
     > {
         Ok(AscEthereumCall_0_0_3 {
-            to: asc_new(heap, &self.to, gas)?,
-            from: asc_new(heap, &self.from, gas)?,
+            to: asc_new(heap, self.to(), gas)?,
+            from: asc_new(heap, self.from(), gas)?,
             block: asc_new(heap, &self.block, gas)?,
             transaction: asc_new(heap, &self.transaction, gas)?,
             inputs: asc_new(heap, &self.inputs, gas)?,

--- a/chain/ethereum/src/runtime/abi.rs
+++ b/chain/ethereum/src/runtime/abi.rs
@@ -121,6 +121,7 @@ impl AscIndexId for AscLogArray {
 
 #[repr(C)]
 #[derive(AscType)]
+#[allow(non_camel_case_types)]
 pub struct AscUnresolvedContractCall_0_0_4 {
     pub contract_name: AscPtr<AscString>,
     pub contract_address: AscPtr<AscAddress>,
@@ -201,6 +202,7 @@ impl AscIndexId for AscEthereumBlock {
 
 #[repr(C)]
 #[derive(AscType)]
+#[allow(non_camel_case_types)]
 pub(crate) struct AscEthereumBlock_0_0_6 {
     pub hash: AscPtr<AscH256>,
     pub parent_hash: AscPtr<AscH256>,
@@ -225,6 +227,7 @@ impl AscIndexId for AscEthereumBlock_0_0_6 {
 
 #[repr(C)]
 #[derive(AscType)]
+#[allow(non_camel_case_types)]
 pub(crate) struct AscEthereumTransaction_0_0_1 {
     pub hash: AscPtr<AscH256>,
     pub index: AscPtr<AscBigInt>,
@@ -241,6 +244,7 @@ impl AscIndexId for AscEthereumTransaction_0_0_1 {
 
 #[repr(C)]
 #[derive(AscType)]
+#[allow(non_camel_case_types)]
 pub(crate) struct AscEthereumTransaction_0_0_2 {
     pub hash: AscPtr<AscH256>,
     pub index: AscPtr<AscBigInt>,
@@ -258,6 +262,7 @@ impl AscIndexId for AscEthereumTransaction_0_0_2 {
 
 #[repr(C)]
 #[derive(AscType)]
+#[allow(non_camel_case_types)]
 pub(crate) struct AscEthereumTransaction_0_0_6 {
     pub hash: AscPtr<AscH256>,
     pub index: AscPtr<AscBigInt>,
@@ -346,6 +351,7 @@ impl AscIndexId for AscEthereumTransactionReceipt {
 /// `receipt` field.
 #[repr(C)]
 #[derive(AscType)]
+#[allow(non_camel_case_types)]
 pub(crate) struct AscEthereumEvent_0_0_7<T, B>
 where
     T: AscType,
@@ -392,6 +398,7 @@ impl AscIndexId for AscEthereumCall {
 
 #[repr(C)]
 #[derive(AscType)]
+#[allow(non_camel_case_types)]
 pub(crate) struct AscEthereumCall_0_0_3<T, B>
 where
     T: AscType,

--- a/chain/ethereum/src/runtime/abi.rs
+++ b/chain/ethereum/src/runtime/abi.rs
@@ -488,68 +488,68 @@ impl<'a> ToAscObj<AscEthereumBlock_0_0_6> for EthereumBlockData<'a> {
     }
 }
 
-impl ToAscObj<AscEthereumTransaction_0_0_1> for EthereumTransactionData {
+impl<'a> ToAscObj<AscEthereumTransaction_0_0_1> for EthereumTransactionData<'a> {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
         gas: &GasCounter,
     ) -> Result<AscEthereumTransaction_0_0_1, HostExportError> {
         Ok(AscEthereumTransaction_0_0_1 {
-            hash: asc_new(heap, &self.hash, gas)?,
-            index: asc_new(heap, &BigInt::from_unsigned_u128(self.index), gas)?,
-            from: asc_new(heap, &self.from, gas)?,
+            hash: asc_new(heap, self.hash(), gas)?,
+            index: asc_new(heap, &BigInt::from_unsigned_u128(self.index()), gas)?,
+            from: asc_new(heap, self.from(), gas)?,
             to: self
-                .to
+                .to()
                 .map(|to| asc_new(heap, &to, gas))
                 .unwrap_or(Ok(AscPtr::null()))?,
-            value: asc_new(heap, &BigInt::from_unsigned_u256(&self.value), gas)?,
-            gas_limit: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_limit), gas)?,
-            gas_price: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_price), gas)?,
+            value: asc_new(heap, &BigInt::from_unsigned_u256(self.value()), gas)?,
+            gas_limit: asc_new(heap, &BigInt::from_unsigned_u256(self.gas_limit()), gas)?,
+            gas_price: asc_new(heap, &BigInt::from_unsigned_u256(self.gas_price()), gas)?,
         })
     }
 }
 
-impl ToAscObj<AscEthereumTransaction_0_0_2> for EthereumTransactionData {
+impl<'a> ToAscObj<AscEthereumTransaction_0_0_2> for EthereumTransactionData<'a> {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
         gas: &GasCounter,
     ) -> Result<AscEthereumTransaction_0_0_2, HostExportError> {
         Ok(AscEthereumTransaction_0_0_2 {
-            hash: asc_new(heap, &self.hash, gas)?,
-            index: asc_new(heap, &BigInt::from_unsigned_u128(self.index), gas)?,
-            from: asc_new(heap, &self.from, gas)?,
+            hash: asc_new(heap, self.hash(), gas)?,
+            index: asc_new(heap, &BigInt::from_unsigned_u128(self.index()), gas)?,
+            from: asc_new(heap, self.from(), gas)?,
             to: self
-                .to
+                .to()
                 .map(|to| asc_new(heap, &to, gas))
                 .unwrap_or(Ok(AscPtr::null()))?,
-            value: asc_new(heap, &BigInt::from_unsigned_u256(&self.value), gas)?,
-            gas_limit: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_limit), gas)?,
-            gas_price: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_price), gas)?,
-            input: asc_new(heap, &*self.input, gas)?,
+            value: asc_new(heap, &BigInt::from_unsigned_u256(self.value()), gas)?,
+            gas_limit: asc_new(heap, &BigInt::from_unsigned_u256(self.gas_limit()), gas)?,
+            gas_price: asc_new(heap, &BigInt::from_unsigned_u256(self.gas_price()), gas)?,
+            input: asc_new(heap, self.input(), gas)?,
         })
     }
 }
 
-impl ToAscObj<AscEthereumTransaction_0_0_6> for EthereumTransactionData {
+impl<'a> ToAscObj<AscEthereumTransaction_0_0_6> for EthereumTransactionData<'a> {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
         gas: &GasCounter,
     ) -> Result<AscEthereumTransaction_0_0_6, HostExportError> {
         Ok(AscEthereumTransaction_0_0_6 {
-            hash: asc_new(heap, &self.hash, gas)?,
-            index: asc_new(heap, &BigInt::from_unsigned_u128(self.index), gas)?,
-            from: asc_new(heap, &self.from, gas)?,
+            hash: asc_new(heap, self.hash(), gas)?,
+            index: asc_new(heap, &BigInt::from_unsigned_u128(self.index()), gas)?,
+            from: asc_new(heap, self.from(), gas)?,
             to: self
-                .to
+                .to()
                 .map(|to| asc_new(heap, &to, gas))
                 .unwrap_or(Ok(AscPtr::null()))?,
-            value: asc_new(heap, &BigInt::from_unsigned_u256(&self.value), gas)?,
-            gas_limit: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_limit), gas)?,
-            gas_price: asc_new(heap, &BigInt::from_unsigned_u256(&self.gas_price), gas)?,
-            input: asc_new(heap, &*self.input, gas)?,
-            nonce: asc_new(heap, &BigInt::from_unsigned_u256(&self.nonce), gas)?,
+            value: asc_new(heap, &BigInt::from_unsigned_u256(self.value()), gas)?,
+            gas_limit: asc_new(heap, &BigInt::from_unsigned_u256(self.gas_limit()), gas)?,
+            gas_price: asc_new(heap, &BigInt::from_unsigned_u256(self.gas_price()), gas)?,
+            input: asc_new(heap, self.input(), gas)?,
+            nonce: asc_new(heap, &BigInt::from_unsigned_u256(self.nonce()), gas)?,
         })
     }
 }
@@ -558,7 +558,7 @@ impl<'a, T, B> ToAscObj<AscEthereumEvent<T, B>> for EthereumEventData<'a>
 where
     T: AscType + AscIndexId,
     B: AscType + AscIndexId,
-    EthereumTransactionData: ToAscObj<T>,
+    EthereumTransactionData<'a>: ToAscObj<T>,
     EthereumBlockData<'a>: ToAscObj<B>,
 {
     fn to_asc_obj<H: AscHeap + ?Sized>(
@@ -591,7 +591,7 @@ impl<'a, T, B> ToAscObj<AscEthereumEvent_0_0_7<T, B>>
 where
     T: AscType + AscIndexId,
     B: AscType + AscIndexId,
-    EthereumTransactionData: ToAscObj<T>,
+    EthereumTransactionData<'a>: ToAscObj<T>,
     EthereumBlockData<'a>: ToAscObj<B>,
 {
     fn to_asc_obj<H: AscHeap + ?Sized>(

--- a/chain/ethereum/src/trigger.rs
+++ b/chain/ethereum/src/trigger.rs
@@ -420,44 +420,77 @@ impl TriggerData for EthereumTrigger {
 }
 
 /// Ethereum block data.
-#[derive(Clone, Debug, Default)]
-pub struct EthereumBlockData {
-    pub hash: H256,
-    pub parent_hash: H256,
-    pub uncles_hash: H256,
-    pub author: H160,
-    pub state_root: H256,
-    pub transactions_root: H256,
-    pub receipts_root: H256,
-    pub number: U64,
-    pub gas_used: U256,
-    pub gas_limit: U256,
-    pub timestamp: U256,
-    pub difficulty: U256,
-    pub total_difficulty: U256,
-    pub size: Option<U256>,
-    pub base_fee_per_gas: Option<U256>,
+#[derive(Clone, Debug)]
+pub struct EthereumBlockData<'a> {
+    block: &'a Block<Transaction>,
 }
 
-impl<'a, T> From<&'a Block<T>> for EthereumBlockData {
-    fn from(block: &'a Block<T>) -> EthereumBlockData {
-        EthereumBlockData {
-            hash: block.hash.unwrap(),
-            parent_hash: block.parent_hash,
-            uncles_hash: block.uncles_hash,
-            author: block.author,
-            state_root: block.state_root,
-            transactions_root: block.transactions_root,
-            receipts_root: block.receipts_root,
-            number: block.number.unwrap(),
-            gas_used: block.gas_used,
-            gas_limit: block.gas_limit,
-            timestamp: block.timestamp,
-            difficulty: block.difficulty,
-            total_difficulty: block.total_difficulty.unwrap_or_default(),
-            size: block.size,
-            base_fee_per_gas: block.base_fee_per_gas,
-        }
+impl<'a> From<&'a Block<Transaction>> for EthereumBlockData<'a> {
+    fn from(block: &'a Block<Transaction>) -> EthereumBlockData<'a> {
+        EthereumBlockData { block }
+    }
+}
+
+impl<'a> EthereumBlockData<'a> {
+    pub fn hash(&self) -> &H256 {
+        self.block.hash.as_ref().unwrap()
+    }
+
+    pub fn parent_hash(&self) -> &H256 {
+        &self.block.parent_hash
+    }
+
+    pub fn uncles_hash(&self) -> &H256 {
+        &self.block.uncles_hash
+    }
+
+    pub fn author(&self) -> &H160 {
+        &self.block.author
+    }
+
+    pub fn state_root(&self) -> &H256 {
+        &self.block.state_root
+    }
+
+    pub fn transactions_root(&self) -> &H256 {
+        &self.block.transactions_root
+    }
+
+    pub fn receipts_root(&self) -> &H256 {
+        &self.block.receipts_root
+    }
+
+    pub fn number(&self) -> U64 {
+        self.block.number.unwrap()
+    }
+
+    pub fn gas_used(&self) -> &U256 {
+        &self.block.gas_used
+    }
+
+    pub fn gas_limit(&self) -> &U256 {
+        &self.block.gas_limit
+    }
+
+    pub fn timestamp(&self) -> &U256 {
+        &self.block.timestamp
+    }
+
+    pub fn difficulty(&self) -> &U256 {
+        &self.block.difficulty
+    }
+
+    pub fn total_difficulty(&self) -> &U256 {
+        static DEFAULT: U256 = U256::zero();
+        self.block.total_difficulty.as_ref().unwrap_or(&DEFAULT)
+    }
+
+    pub fn size(&self) -> &Option<U256> {
+        &self.block.size
+    }
+
+    pub fn base_fee_per_gas(&self) -> &Option<U256> {
+        &self.block.base_fee_per_gas
     }
 }
 
@@ -496,22 +529,22 @@ impl From<&'_ Transaction> for EthereumTransactionData {
 
 /// An Ethereum event logged from a specific contract address and block.
 #[derive(Debug, Clone)]
-pub struct EthereumEventData {
+pub struct EthereumEventData<'a> {
     pub address: Address,
     pub log_index: U256,
     pub transaction_log_index: U256,
     pub log_type: Option<String>,
-    pub block: EthereumBlockData,
+    pub block: EthereumBlockData<'a>,
     pub transaction: EthereumTransactionData,
     pub params: Vec<LogParam>,
 }
 
 /// An Ethereum call executed within a transaction within a block to a contract address.
 #[derive(Debug, Clone)]
-pub struct EthereumCallData {
+pub struct EthereumCallData<'a> {
     pub from: Address,
     pub to: Address,
-    pub block: EthereumBlockData,
+    pub block: EthereumBlockData<'a>,
     pub transaction: EthereumTransactionData,
     pub inputs: Vec<LogParam>,
     pub outputs: Vec<LogParam>,


### PR DESCRIPTION
We have a few structs that are only used to bounce data into WASM, but they copied a bunch of data needlessly. This PR gets rid of these copies