### PR TITLE
graph: improve error message for block not found in Ethereum network

### DIFF
--- a/graph/src/data/subgraph/mod.rs
+++ b/graph/src/data/subgraph/mod.rs
@@ -348,7 +348,7 @@ pub enum SubgraphManifestValidationError {
     MultipleEthereumNetworks,
     #[error("subgraph must have at least one Ethereum network data source")]
     EthereumNetworkRequired,
-    #[error("the specified block must exist on the Ethereum network")]
+    #[error("the specified block {0} must exist on the Ethereum network")]
     BlockNotFound(String),
     #[error("schema validation failed: {0:?}")]
     SchemaValidationError(Vec<SchemaValidationError>),


### PR DESCRIPTION
Improve the `BlockNotFound` error when deploying subgraphs by adding the block number in the error message