### PR TITLE
store: Remove unused SSL support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,9 +2145,7 @@ dependencies = [
  "lazy_static",
  "lru_time_cache",
  "maybe-owned",
- "openssl",
  "postgres",
- "postgres-openssl",
  "pretty_assertions",
  "rand",
  "serde",
@@ -3564,19 +3562,6 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tokio-postgres",
-]
-
-[[package]]
-name = "postgres-openssl"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de0ea6504e07ca78355a6fb88ad0f36cafe9e696cbc6717f16a207f3a60be72"
-dependencies = [
- "futures 0.3.30",
- "openssl",
- "tokio",
- "tokio-openssl",
  "tokio-postgres",
 ]
 
@@ -5171,18 +5156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-openssl"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffab79df67727f6acf57f1ff743091873c24c579b1e2ce4d8f53e47ded4d63d"
-dependencies = [
- "futures-util",
- "openssl",
- "openssl-sys",
  "tokio",
 ]
 

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -21,8 +21,6 @@ lazy_static = "1.5"
 lru_time_cache = "0.11"
 maybe-owned = "0.3.4"
 postgres = "0.19.1"
-openssl = "0.10.64"
-postgres-openssl = "0.5.0"
 rand = "0.8.4"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/store/postgres/src/notification_listener.rs
+++ b/store/postgres/src/notification_listener.rs
@@ -4,10 +4,8 @@ use diesel::sql_types::Text;
 use graph::prelude::tokio::sync::mpsc::error::SendTimeoutError;
 use graph::util::backoff::ExponentialBackoff;
 use lazy_static::lazy_static;
-use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
-use postgres::Notification;
 use postgres::{fallible_iterator::FallibleIterator, Client};
-use postgres_openssl::MakeTlsConnector;
+use postgres::{NoTls, Notification};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 use std::thread;
@@ -123,12 +121,7 @@ impl NotificationListener {
             let mut backoff =
                 ExponentialBackoff::new(Duration::from_secs(1), Duration::from_secs(30));
             loop {
-                let mut builder = SslConnector::builder(SslMethod::tls())
-                    .expect("unable to create SslConnector builder");
-                builder.set_verify(SslVerifyMode::NONE);
-                let connector = MakeTlsConnector::new(builder.build());
-
-                let res = Client::connect(postgres_url, connector).and_then(|mut conn| {
+                let res = Client::connect(postgres_url, NoTls).and_then(|mut conn| {
                     conn.execute(format!("LISTEN {}", channel_name).as_str(), &[])?;
                     Ok(conn)
                 });


### PR DESCRIPTION
We could, in theory, establish SSL connections for the notification listener. Since that uses the same PG URL as the main connections for data through diesel, it was actually not possible to use SSL as we don't support it for our diesel connections.

Until we are able to set up SSL connections across the board, remove the defunct SSL support in the notification listener.

