### PR TITLE
Update a few dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,6 @@ dependencies = [
  "static_assertions_next",
  "tempfile",
  "thiserror 1.0.61",
- "uuid",
 ]
 
 [[package]]
@@ -5717,10 +5716,6 @@ name = "uuid"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
-dependencies = [
- "getrandom 0.3.1",
- "serde",
-]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2151,7 +2151,6 @@ dependencies = [
  "serde",
  "serde_json",
  "stable-hash 0.3.4",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,7 +2075,6 @@ dependencies = [
  "parity-wasm",
  "semver",
  "serde_yaml",
- "uuid",
  "wasm-instrument",
  "wasmtime",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1983,7 +1983,6 @@ dependencies = [
  "serde_yaml",
  "tower 0.4.13 (git+https://github.com/tower-rs/tower.git)",
  "tower-test",
- "uuid",
  "wiremock",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.2.4"
+version = "2.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe8e2e68695bd615d7e4f3227c0727b151330d3e253b525086c348d055d5e"
+checksum = "04001f23ba8843dc315804fa324000376084dfb1c30794ff68dd279e6e5696d5"
 dependencies = [
  "bigdecimal 0.3.1",
  "bitflags 2.6.0",
@@ -1212,7 +1212,6 @@ dependencies = [
  "pq-sys",
  "r2d2",
  "serde_json",
- "uuid",
 ]
 
 [[package]]
@@ -1229,18 +1228,18 @@ dependencies = [
 
 [[package]]
 name = "diesel-dynamic-schema"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71eda9b13a55533594231b0763c36bc21058ccb82ed17eaeb41b3cbb897c1bb1"
+checksum = "061bbe2d02508364c50153226524b7fc224f56031a5e927b0bc5f1f2b48de6a6"
 dependencies = [
  "diesel",
 ]
 
 [[package]]
 name = "diesel_derives"
-version = "2.2.1"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59de76a222c2b8059f789cbe07afbfd8deb8c31dd0bc2a21f85e256c1def8259"
+checksum = "e7f2c3de51e2ba6bf2a648285696137aaf0f5f487bcbea93972fe8a364e131a4"
 dependencies = [
  "diesel_table_macro_syntax",
  "dsl_auto_type",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1929,7 +1929,6 @@ dependencies = [
  "serde",
  "tiny-keccak 1.5.0",
  "tonic-build",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 anyhow = "1.0"
-async-graphql = { version = "7.0.15", features = ["chrono", "uuid"] }
+async-graphql = { version = "7.0.15", features = ["chrono"] }
 async-graphql-axum = "7.0.15"
 axum = "0.8.1"
 chrono = "0.4.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,18 +47,10 @@ chrono = "0.4.38"
 bs58 = "0.5.1"
 clap = { version = "4.5.4", features = ["derive", "env"] }
 derivative = "2.2.0"
-diesel = { version = "2.2.4", features = [
-    "postgres",
-    "serde_json",
-    "numeric",
-    "r2d2",
-    "chrono",
-    "uuid",
-    "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
-] }
+diesel = { version = "2.2.7", features = ["postgres", "serde_json", "numeric", "r2d2", "chrono", "i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }
 diesel-derive-enum = { version = "2.1.0", features = ["postgres"] }
-diesel-dynamic-schema = { version = "0.2.1", features = ["postgres"] }
-diesel_derives = "2.1.4"
+diesel-dynamic-schema = { version = "0.2.3", features = ["postgres"] }
+diesel_derives = "2.2.3"
 diesel_migrations = "2.1.0"
 graph = { path = "./graph" }
 graph-core = { path = "./core" }

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -22,7 +22,6 @@ graph-runtime-derive = { path = "../../runtime/derive" }
 
 [dev-dependencies]
 base64 = "0"
-uuid = { version = "1.15.1", features = ["v4"] }
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/chain/ethereum/src/network.rs
+++ b/chain/ethereum/src/network.rs
@@ -325,7 +325,6 @@ mod tests {
         url::Url,
     };
     use std::sync::Arc;
-    use uuid::Uuid;
 
     use crate::{EthereumAdapter, EthereumAdapterTrait, ProviderEthRpcMetrics, Transport};
 
@@ -679,18 +678,14 @@ mod tests {
     #[tokio::test]
     async fn eth_adapter_selection_multiple_adapters() {
         let logger = Logger::root(Discard, o!());
-        let unavailable_provider = Uuid::new_v4().to_string();
-        let error_provider = Uuid::new_v4().to_string();
-        let no_error_provider = Uuid::new_v4().to_string();
+        let unavailable_provider = "unavailable-provider";
+        let error_provider = "error-provider";
+        let no_error_provider = "no-error-provider";
 
         let mock_registry = Arc::new(MetricsRegistry::mock());
         let metrics = Arc::new(EndpointMetrics::new(
             logger,
-            &[
-                unavailable_provider.clone(),
-                error_provider.clone(),
-                no_error_provider.clone(),
-            ],
+            &[unavailable_provider, error_provider, no_error_provider],
             mock_registry.clone(),
         ));
         let logger = graph::log::logger(true);
@@ -718,7 +713,7 @@ mod tests {
         ];
 
         // Set errors
-        metrics.report_for_test(&ProviderName::from(error_provider.clone()), false);
+        metrics.report_for_test(&ProviderName::from(error_provider), false);
 
         let mut no_retest_adapters = vec![];
         let mut always_retest_adapters = vec![];
@@ -796,18 +791,14 @@ mod tests {
     #[tokio::test]
     async fn eth_adapter_selection_single_adapter() {
         let logger = Logger::root(Discard, o!());
-        let unavailable_provider = Uuid::new_v4().to_string();
-        let error_provider = Uuid::new_v4().to_string();
-        let no_error_provider = Uuid::new_v4().to_string();
+        let unavailable_provider = "unavailable-provider";
+        let error_provider = "error-provider";
+        let no_error_provider = "no-error-provider";
 
         let mock_registry = Arc::new(MetricsRegistry::mock());
         let metrics = Arc::new(EndpointMetrics::new(
             logger,
-            &[
-                unavailable_provider,
-                error_provider.clone(),
-                no_error_provider.clone(),
-            ],
+            &[unavailable_provider, error_provider, no_error_provider],
             mock_registry.clone(),
         ));
         let chain_id: Word = "chain_id".into();
@@ -815,7 +806,7 @@ mod tests {
         let provider_metrics = Arc::new(ProviderEthRpcMetrics::new(mock_registry.clone()));
 
         // Set errors
-        metrics.report_for_test(&ProviderName::from(error_provider.clone()), false);
+        metrics.report_for_test(&ProviderName::from(error_provider), false);
 
         let mut no_retest_adapters = vec![];
         no_retest_adapters.push(EthereumNetworkAdapter {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,5 +23,4 @@ anyhow = "1.0"
 
 [dev-dependencies]
 tower-test = { git = "https://github.com/tower-rs/tower.git" }
-uuid = { version = "1.15.1", features = ["v4"] }
 wiremock = "0.6.1"

--- a/core/src/polling_monitor/ipfs_service.rs
+++ b/core/src/polling_monitor/ipfs_service.rs
@@ -104,7 +104,6 @@ mod test {
     use graph::log::discard;
     use graph::tokio;
     use tower::ServiceExt;
-    use uuid::Uuid;
     use wiremock::matchers as m;
     use wiremock::Mock;
     use wiremock::MockServer;
@@ -114,7 +113,11 @@ mod test {
 
     #[tokio::test]
     async fn cat_file_in_folder() {
-        let random_bytes = Uuid::new_v4().as_bytes().to_vec();
+        let random_bytes = "One morning, when Gregor Samsa woke \
+          from troubled dreams, he found himself transformed in his bed \
+          into a horrible vermin"
+            .as_bytes()
+            .to_vec();
         let ipfs_file = ("dir/file.txt", random_bytes.clone());
 
         let add_resp = add_files_to_local_ipfs_node_for_testing([ipfs_file])

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -11,7 +11,6 @@ graph = { path = "../../graph" }
 bs58 = "0.4.0"
 graph-runtime-derive = { path = "../derive" }
 semver = "1.0.23"
-uuid = { version = "1.15.1", features = ["v4"] }
 anyhow = "1.0"
 never = "0.1"
 

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -26,7 +26,6 @@ postgres-openssl = "0.5.0"
 rand = "0.8.4"
 serde = { workspace = true }
 serde_json = { workspace = true }
-uuid = { version = "1.15.1", features = ["v4"] }
 stable-hash_legacy = { git = "https://github.com/graphprotocol/stable-hash", branch = "old", package = "stable-hash" }
 anyhow = "1.0.86"
 git-testament = "0.2.5"


### PR DESCRIPTION
These changes are mostly housekeeping and update some of our dependencies and/or remove the use of some like `uuid` which can be easily replaced in a few places with atomic counters.