### PR TITLE
enhance err msg for source subgraph manifest resolution in composition

### DIFF
--- a/store/test-store/tests/chain/ethereum/manifest.rs
+++ b/store/test-store/tests/chain/ethereum/manifest.rs
@@ -1852,7 +1852,8 @@ specVersion: 1.3.0
                 assert!(matches!(e, SubgraphManifestResolveError::ResolveError(_)));
                 let error_msg = e.to_string();
                 println!("{}", error_msg);
-                assert!(error_msg.contains("Nested subgraph data sources are not supported."));
+                assert!(error_msg
+                    .contains("Nested subgraph data sources [SubgraphSource] are not supported."));
             }
         }
     })


### PR DESCRIPTION
When getting error messages in cli when deploying composition subgraph, the err msg doesn't exactly point the source subgraph deployment id which is giving error. 
This PR solves this issue.