### PR TITLE
Subgraph Composition: Option to force rpc to fetch block ptrs

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -1018,10 +1018,12 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
             ChainClient::Firehose(endpoints) => {
                 let endpoint = endpoints.endpoint().await?;
                 let block = endpoint
-                    .get_block_by_number::<codec::Block>(ptr.number as u64, &self.logger)
+                    .get_block_by_number_with_retry::<codec::Block>(ptr.number as u64, &self.logger)
                     .await
-                    .map_err(|e| anyhow!("Failed to fetch block from firehose: {}", e))?;
-
+                    .context(format!(
+                        "Failed to fetch block {} from firehose",
+                        ptr.number
+                    ))?;
                 Ok(block.hash() == ptr.hash)
             }
             ChainClient::Rpc(adapter) => {

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -789,7 +789,7 @@ async fn fetch_unique_blocks_from_cache(
             "Loading {} block(s) not in the block cache",
             missing_blocks.len()
         );
-        debug!(logger, "Missing blocks {:?}", missing_blocks);
+        trace!(logger, "Missing blocks {:?}", missing_blocks.len());
     }
 
     (blocks, missing_blocks)
@@ -878,6 +878,11 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
                 // even if the firehose is available. If no adapter is available, we will log an error.
                 // And then fallback to the firehose.
                 if ENV_VARS.force_rpc_for_block_ptrs {
+                    trace!(
+                        logger,
+                        "Loading blocks from RPC (force_rpc_for_block_ptrs is set)";
+                        "block_numbers" => format!("{:?}", block_numbers)
+                    );
                     match self.eth_adapters.cheapest_with(&self.capabilities).await {
                         Ok(adapter) => {
                             match load_blocks_with_rpc(

--- a/chain/ethereum/src/env.rs
+++ b/chain/ethereum/src/env.rs
@@ -91,7 +91,7 @@ pub struct EnvVars {
     /// This is a comma separated list of chain ids for which the gas field will not be set
     /// when calling `eth_call`.
     pub eth_call_no_gas: Vec<String>,
-    /// Set by the flag `GRAPH_ETHEREUM_FORCE_RPC_FOR_BLOCK_PTRS`. Off by default.
+    /// Set by the flag `GRAPH_ETHEREUM_FORCE_RPC_FOR_BLOCK_PTRS`. On by default.
     /// When enabled, forces the use of RPC instead of Firehose for loading block pointers by numbers.
     /// This is used in composable subgraphs. Firehose can be slow for loading block pointers by numbers.
     pub force_rpc_for_block_ptrs: bool,

--- a/chain/ethereum/src/env.rs
+++ b/chain/ethereum/src/env.rs
@@ -197,6 +197,6 @@ struct Inner {
     genesis_block_number: u64,
     #[envconfig(from = "GRAPH_ETH_CALL_NO_GAS", default = "421613,421614")]
     eth_call_no_gas: String,
-    #[envconfig(from = "GRAPH_ETHEREUM_FORCE_RPC_FOR_BLOCK_PTRS", default = "false")]
+    #[envconfig(from = "GRAPH_ETHEREUM_FORCE_RPC_FOR_BLOCK_PTRS", default = "true")]
     force_rpc_for_block_ptrs: EnvVarBoolean,
 }

--- a/chain/ethereum/src/env.rs
+++ b/chain/ethereum/src/env.rs
@@ -91,6 +91,10 @@ pub struct EnvVars {
     /// This is a comma separated list of chain ids for which the gas field will not be set
     /// when calling `eth_call`.
     pub eth_call_no_gas: Vec<String>,
+    /// Set by the flag `GRAPH_ETHEREUM_FORCE_RPC_FOR_BLOCK_PTRS`. Off by default.
+    /// When enabled, forces the use of RPC instead of Firehose for loading block pointers by numbers.
+    /// This is used in composable subgraphs. Firehose can be slow for loading block pointers by numbers.
+    pub force_rpc_for_block_ptrs: bool,
 }
 
 // This does not print any values avoid accidentally leaking any sensitive env vars
@@ -141,6 +145,7 @@ impl From<Inner> for EnvVars {
                 .filter(|s| !s.is_empty())
                 .map(str::to_string)
                 .collect(),
+            force_rpc_for_block_ptrs: x.force_rpc_for_block_ptrs.0,
         }
     }
 }
@@ -192,4 +197,6 @@ struct Inner {
     genesis_block_number: u64,
     #[envconfig(from = "GRAPH_ETH_CALL_NO_GAS", default = "421613,421614")]
     eth_call_no_gas: String,
+    #[envconfig(from = "GRAPH_ETHEREUM_FORCE_RPC_FOR_BLOCK_PTRS", default = "false")]
+    force_rpc_for_block_ptrs: EnvVarBoolean,
 }

--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -247,6 +247,9 @@ pub struct EnvVars {
     /// Set by the environment variable `GRAPH_FIREHOSE_FETCH_BLOCK_TIMEOUT_SECS`.
     /// The default value is 60 seconds.
     pub firehose_block_fetch_timeout: u64,
+    /// Set by the environment variable `GRAPH_FIREHOSE_BLOCK_BATCH_SIZE`.
+    /// The default value is 10.
+    pub firehose_block_batch_size: usize,
 }
 
 impl EnvVars {
@@ -339,6 +342,7 @@ impl EnvVars {
             block_write_capacity: inner.block_write_capacity.0,
             firehose_block_fetch_retry_limit: inner.firehose_block_fetch_retry_limit,
             firehose_block_fetch_timeout: inner.firehose_block_fetch_timeout,
+            firehose_block_batch_size: inner.firehose_block_fetch_batch_size,
         })
     }
 
@@ -506,6 +510,8 @@ struct Inner {
     firehose_block_fetch_retry_limit: usize,
     #[envconfig(from = "GRAPH_FIREHOSE_FETCH_BLOCK_TIMEOUT_SECS", default = "60")]
     firehose_block_fetch_timeout: u64,
+    #[envconfig(from = "GRAPH_FIREHOSE_FETCH_BLOCK_BATCH_SIZE", default = "10")]
+    firehose_block_fetch_batch_size: usize,
 }
 
 #[derive(Clone, Debug)]

--- a/graph/src/firehose/endpoints.rs
+++ b/graph/src/firehose/endpoints.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use futures03::{StreamExt, TryStreamExt};
 use http::uri::{Scheme, Uri};
 use itertools::Itertools;
-use slog::{error, info, Logger};
+use slog::{error, info, trace, Logger};
 use std::{collections::HashMap, fmt::Display, ops::ControlFlow, sync::Arc, time::Duration};
 use tokio::sync::OnceCell;
 use tonic::codegen::InterceptedService;
@@ -451,7 +451,7 @@ impl FirehoseEndpoint {
     where
         M: prost::Message + BlockchainBlock + Default + 'static,
     {
-        debug!(
+        trace!(
             logger,
             "Connecting to firehose to retrieve block for number {}", number;
             "provider" => self.provider.as_str(),

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -441,6 +441,7 @@ pub async fn networks_as_chains(
                     client.clone(),
                     metrics_registry.clone(),
                     chain_store.clone(),
+                    eth_adapters.clone(),
                 );
 
                 let call_cache = chain_store.cheap_clone();


### PR DESCRIPTION
Composable subgraphs need to fetch block ptrs to handle reorgs, when its not in the cache graph-node uses firehose endpoint to fetch the block using a `SingleBlockRequest` but this is currently slower than RPC.
This PR
- Adds an option to force using RPC to fetch block ptrs when an RPC endpoint is available
- Parralize fetching blocks when using firehose
- Added some refactoring in `FirehoseEndpoints` code