### PR TITLE
Copy private data sources in batches

### DIFF
--- a/store/postgres/src/dynds/private.rs
+++ b/store/postgres/src/dynds/private.rs
@@ -331,17 +331,14 @@ struct ManifestIdxMap {
 
 impl ManifestIdxMap {
     fn new(src: &[(i32, String)], dst: &[(i32, String)]) -> Self {
+        let dst_idx_map: HashMap<&String, i32> =
+            HashMap::from_iter(dst.iter().map(|(idx, name)| (name, *idx)));
         let map = src
             .iter()
             .map(|(src_idx, src_name)| {
                 (
                     *src_idx,
-                    (
-                        dst.iter()
-                            .find(|(_, dst_name)| src_name == dst_name)
-                            .map(|(dst_idx, _)| *dst_idx),
-                        src_name.to_string(),
-                    ),
+                    (dst_idx_map.get(src_name).copied(), src_name.to_string()),
                 )
             })
             .collect();

--- a/store/postgres/src/dynds/private.rs
+++ b/store/postgres/src/dynds/private.rs
@@ -389,13 +389,16 @@ impl DsForCopy {
         // unclamp block range if it ends beyond target block
         match self.block_range.1 {
             Bound::Included(block) if block > target_block => self.block_range.1 = Bound::Unbounded,
+            Bound::Excluded(block) if block - 1 > target_block => {
+                self.block_range.1 = Bound::Unbounded
+            }
             _ => { /* use block range as is */ }
         }
         // Translate manifest index
         let src_created = match self.block_range.0 {
             Bound::Included(block) => block,
             Bound::Excluded(block) => block + 1,
-            Bound::Unbounded => i32::MAX,
+            Bound::Unbounded => 0,
         };
         self.idx = map.dst_idx(self.idx, src_nsp, src_created, dst_nsp)?;
         Ok(self)

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -53,7 +53,7 @@ use crate::{
 const BASE_SQL_COLUMNS: [&str; 2] = ["id", "vid"];
 
 /// The maximum number of bind variables that can be used in a query
-const POSTGRES_MAX_PARAMETERS: usize = u16::MAX as usize; // 65535
+pub(crate) const POSTGRES_MAX_PARAMETERS: usize = u16::MAX as usize; // 65535
 
 const SORT_KEY_COLUMN: &str = "sort_key$";
 


### PR DESCRIPTION
Currently, private data sources are copied one-by-one which can be very slow for deployments with huge numbers of data sources (say, 100's of thousands)

This PR changes that so that we copy data sources in bulk