### PR TITLE
display current node when reassigning subgraph

### DIFF
--- a/node/src/manager/commands/deployment/reassign.rs
+++ b/node/src/manager/commands/deployment/reassign.rs
@@ -16,11 +16,24 @@ pub fn run(
     node: &NodeId,
 ) -> Result<()> {
     let deployment = load_deployment(primary_pool.clone(), &deployment)?;
+    let curr_node = deployment.assigned_node(primary_pool.clone())?;
+    let reassign_msg = match &curr_node {
+        Some(curr_node) => format!(
+            "Reassigning deployment {} (was {})",
+            deployment.locator(),
+            curr_node
+        ),
+        None => format!("Reassigning deployment {}", deployment.locator()),
+    };
+    println!("{}", reassign_msg);
 
-    println!("Reassigning deployment {}", deployment.locator());
-
-    let reassign_result =
-        reassign_deployment(primary_pool, notification_sender, &deployment, node)?;
+    let reassign_result = reassign_deployment(
+        primary_pool,
+        notification_sender,
+        &deployment,
+        node,
+        curr_node,
+    )?;
 
     match reassign_result {
         ReassignResult::EmptyResponse => {

--- a/server/graphman/src/resolvers/deployment_mutation/reassign.rs
+++ b/server/graphman/src/resolvers/deployment_mutation/reassign.rs
@@ -14,11 +14,14 @@ pub fn run(
     node: &NodeId,
 ) -> Result<ReassignResult, anyhow::Error> {
     let deployment = load_deployment(ctx.primary_pool.clone(), deployment)?;
+    let curr_node = deployment.assigned_node(ctx.primary_pool.clone())?;
+
     let reassign_result = reassign_deployment(
         ctx.primary_pool.clone(),
         ctx.notification_sender.clone(),
         &deployment,
         &node,
+        curr_node,
     )?;
     Ok(reassign_result)
 }


### PR DESCRIPTION
When reassigning subgraphs, the current assigned node is not displayed. This PR solves this issue.