### PR TITLE
Index creation fixes

### DIFF
--- a/store/postgres/src/copy.rs
+++ b/store/postgres/src/copy.rs
@@ -731,6 +731,7 @@ impl Connection {
                 &table.dst,
                 true,
                 false,
+                true,
             )?;
 
             for (_, sql) in arr {

--- a/store/postgres/src/relational/ddl.rs
+++ b/store/postgres/src/relational/ddl.rs
@@ -408,7 +408,14 @@ impl Table {
         if index_def.is_some() && ENV_VARS.postpone_attribute_index_creation {
             let arr = index_def
                 .unwrap()
-                .indexes_for_table(&self.nsp, &self.name.to_string(), &self, false, false)
+                .indexes_for_table(
+                    &self.nsp,
+                    &self.name.to_string(),
+                    &self,
+                    false,
+                    false,
+                    false,
+                )
                 .map_err(|_| fmt::Error)?;
             for (_, sql) in arr {
                 writeln!(out, "{};", sql).expect("properly formated index statements")

--- a/store/postgres/src/relational/ddl_tests.rs
+++ b/store/postgres/src/relational/ddl_tests.rs
@@ -408,14 +408,28 @@ fn postponed_indexes_with_block_column() {
 
     let dst_nsp = Namespace::new("sgd2".to_string()).unwrap();
     let arr = index_list()
-        .indexes_for_table(&dst_nsp, &table.name.to_string(), &table, true, false)
+        .indexes_for_table(
+            &dst_nsp,
+            &table.name.to_string(),
+            &table,
+            true,
+            false,
+            false,
+        )
         .unwrap();
     assert_eq!(1, arr.len());
     assert!(!arr[0].1.contains(BLOCK_IDX));
     assert!(arr[0].1.contains(ATTR_IDX));
 
     let arr = index_list()
-        .indexes_for_table(&dst_nsp, &table.name.to_string(), &table, false, false)
+        .indexes_for_table(
+            &dst_nsp,
+            &table.name.to_string(),
+            &table,
+            false,
+            false,
+            false,
+        )
         .unwrap();
     assert_eq!(0, arr.len());
 }

--- a/store/postgres/src/relational/ddl_tests.rs
+++ b/store/postgres/src/relational/ddl_tests.rs
@@ -380,6 +380,15 @@ fn postponed_indexes_with_block_column() {
         );
         IndexList { indexes }
     }
+
+    fn cr(index: &str) -> String {
+        format!("create index{}", index)
+    }
+
+    fn cre(index: &str) -> String {
+        format!("create index if not exists{}", index)
+    }
+
     // Names of the two indexes we are interested in. Not the leading space
     // to guard a little against overlapping names
     const BLOCK_IDX: &str = " data_block";
@@ -389,12 +398,12 @@ fn postponed_indexes_with_block_column() {
 
     // Create everything
     let sql = layout.as_ddl(None).unwrap();
-    assert!(sql.contains(BLOCK_IDX));
-    assert!(sql.contains(ATTR_IDX));
+    assert!(sql.contains(&cr(BLOCK_IDX)));
+    assert!(sql.contains(&cr(ATTR_IDX)));
 
     // Defer attribute indexes
     let sql = layout.as_ddl(Some(index_list())).unwrap();
-    assert!(sql.contains(BLOCK_IDX));
+    assert!(sql.contains(&cr(BLOCK_IDX)));
     assert!(!sql.contains(ATTR_IDX));
     // This used to be duplicated
     let count = sql.matches(BLOCK_IDX).count();
@@ -404,7 +413,7 @@ fn postponed_indexes_with_block_column() {
     let sql = table.create_postponed_indexes(vec![], false);
     assert_eq!(1, sql.len());
     assert!(!sql[0].contains(BLOCK_IDX));
-    assert!(sql[0].contains(ATTR_IDX));
+    assert!(sql[0].contains(&cre(ATTR_IDX)));
 
     let dst_nsp = Namespace::new("sgd2".to_string()).unwrap();
     let arr = index_list()
@@ -419,7 +428,7 @@ fn postponed_indexes_with_block_column() {
         .unwrap();
     assert_eq!(1, arr.len());
     assert!(!arr[0].1.contains(BLOCK_IDX));
-    assert!(arr[0].1.contains(ATTR_IDX));
+    assert!(arr[0].1.contains(&cr(ATTR_IDX)));
 
     let arr = index_list()
         .indexes_for_table(

--- a/store/postgres/src/relational/index.rs
+++ b/store/postgres/src/relational/index.rs
@@ -784,7 +784,8 @@ impl IndexList {
         table_name: &String,
         dest_table: &Table,
         postponed: bool,
-        concurrent_if_not_exist: bool,
+        concurrent: bool,
+        if_not_exists: bool,
     ) -> Result<Vec<(Option<String>, String)>, Error> {
         let mut arr = vec![];
         if let Some(vec) = self.indexes.get(table_name) {
@@ -805,7 +806,7 @@ impl IndexList {
                 {
                     if let Ok(sql) = ci
                         .with_nsp(namespace.to_string())?
-                        .to_sql(concurrent_if_not_exist, concurrent_if_not_exist)
+                        .to_sql(concurrent, if_not_exists)
                     {
                         arr.push((ci.name(), sql))
                     }
@@ -829,7 +830,7 @@ impl IndexList {
         let namespace = &layout.catalog.site.namespace;
         for table in layout.tables.values() {
             for (ind_name, create_query) in
-                self.indexes_for_table(namespace, &table.name.to_string(), table, true, true)?
+                self.indexes_for_table(namespace, &table.name.to_string(), table, true, true, true)?
             {
                 if let Some(index_name) = ind_name {
                     let table_name = table.name.clone();

--- a/store/postgres/src/relational/index.rs
+++ b/store/postgres/src/relational/index.rs
@@ -685,7 +685,9 @@ impl CreateIndex {
                         }
                         Expr::Vid => (),
                         Expr::Block => {
-                            return dest_table.immutable;
+                            if !dest_table.immutable {
+                                return false;
+                            }
                         }
                         Expr::Unknown(expression) => {
                             if some_column_contained(


### PR DESCRIPTION
This fixes two issues with postponed index creation:

(1) When the table has a user-supplied `block` column, we created the index on `block$` twice
(2) We did not create postponed indexes on `(<attr>, block$)`