### PR TITLE
Fix a grafting bug

### DIFF
--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -4809,7 +4809,7 @@ impl<'a> QueryFragment<Pg> for CopyEntityBatchQuery<'a> {
     fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
         out.unsafe_to_cache_prepared();
 
-        let has_vid_seq = self.src.object.has_vid_seq();
+        let has_vid_seq = self.dst.object.has_vid_seq();
 
         // Construct a query
         //   insert into {dst}({columns})


### PR DESCRIPTION
When grafting from a spec version bellow 1.3.0 to it the VID insertion criteria was used based on source subgraph rather than the destination one as it should be.