### PR TITLE
Grafting issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1872,6 +1872,7 @@ dependencies = [
  "serde_plain",
  "serde_regex",
  "serde_yaml",
+ "sha2",
  "slog",
  "slog-async",
  "slog-envlogger",

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -48,6 +48,7 @@ serde_derive = { workspace = true }
 serde_json = { workspace = true }
 serde_regex = { workspace = true }
 serde_yaml = { workspace = true }
+sha2 = "0.10.8"
 slog = { version = "2.7.0", features = [
     "release_max_level_trace",
     "max_level_trace",


### PR DESCRIPTION
When grafting from a spec_version before 0.0.6 towards 0.0.6 or above the grafting fails because of the change in the hashing format.