### PR TITLE
Store startup fixes

### DIFF
--- a/graph/src/components/metrics/registry.rs
+++ b/graph/src/components/metrics/registry.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, RwLock};
 
 use prometheus::IntGauge;
 use prometheus::{labels, Histogram, IntCounterVec};
-use slog::info;
+use slog::debug;
 
 use crate::components::metrics::{counter_with_labels, gauge_with_labels};
 use crate::prelude::Collector;
@@ -133,7 +133,7 @@ impl MetricsRegistry {
         let mut result = self.registry.register(collector.clone());
 
         if matches!(result, Err(PrometheusError::AlreadyReg)) {
-            info!(logger, "Resolving duplicate metric registration");
+            debug!(logger, "Resolving duplicate metric registration");
 
             // Since the current metric is a duplicate,
             // we can use it to unregister the previous registration.
@@ -144,7 +144,6 @@ impl MetricsRegistry {
 
         match result {
             Ok(()) => {
-                info!(logger, "Successfully registered a new metric");
                 self.registered_metrics.inc();
             }
             Err(err) => {

--- a/graph/src/components/store/err.rs
+++ b/graph/src/components/store/err.rs
@@ -141,7 +141,7 @@ impl Clone for StoreError {
 }
 
 impl StoreError {
-    fn from_diesel_error(e: &DieselError) -> Option<Self> {
+    pub fn from_diesel_error(e: &DieselError) -> Option<Self> {
         const CONN_CLOSE: &str = "server closed the connection unexpectedly";
         const STMT_TIMEOUT: &str = "canceling statement due to statement timeout";
         let DieselError::DatabaseError(_, info) = e else {

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -655,7 +655,7 @@ pub trait QueryStore: Send + Sync {
         block_hash: &BlockHash,
     ) -> Result<Option<(BlockNumber, Option<u64>, Option<BlockHash>)>, StoreError>;
 
-    fn wait_stats(&self) -> Result<PoolWaitStats, StoreError>;
+    fn wait_stats(&self) -> PoolWaitStats;
 
     /// Find the current state for the subgraph deployment `id` and
     /// return details about it needed for executing queries
@@ -668,7 +668,7 @@ pub trait QueryStore: Send + Sync {
     fn network_name(&self) -> &str;
 
     /// A permit should be acquired before starting query execution.
-    async fn query_permit(&self) -> Result<QueryPermit, StoreError>;
+    async fn query_permit(&self) -> QueryPermit;
 
     /// Report the name of the shard in which the subgraph is stored. This
     /// should only be used for reporting and monitoring
@@ -683,7 +683,7 @@ pub trait QueryStore: Send + Sync {
 #[async_trait]
 pub trait StatusStore: Send + Sync + 'static {
     /// A permit should be acquired before starting query execution.
-    async fn query_permit(&self) -> Result<QueryPermit, StoreError>;
+    async fn query_permit(&self) -> QueryPermit;
 
     fn status(&self, filter: status::Filter) -> Result<Vec<status::Info>, StoreError>;
 

--- a/graph/src/data/query/trace.rs
+++ b/graph/src/data/query/trace.rs
@@ -118,11 +118,8 @@ impl Trace {
         }
     }
 
-    pub fn query_done(&mut self, dur: Duration, permit: &Result<QueryPermit, QueryExecutionError>) {
-        let permit_dur = match permit {
-            Ok(permit) => permit.wait,
-            Err(_) => Duration::from_millis(0),
-        };
+    pub fn query_done(&mut self, dur: Duration, permit: &QueryPermit) {
+        let permit_dur = permit.wait;
         match self {
             Trace::None => { /* nothing to do */ }
             Trace::Root { .. } => {

--- a/graph/src/task_spawn.rs
+++ b/graph/src/task_spawn.rs
@@ -57,10 +57,11 @@ pub fn block_on<T>(f: impl Future03<Output = T>) -> T {
 }
 
 /// Spawns a thread with access to the tokio runtime. Panics if the thread cannot be spawned.
-pub fn spawn_thread(
-    name: impl Into<String>,
-    f: impl 'static + FnOnce() + Send,
-) -> std::thread::JoinHandle<()> {
+pub fn spawn_thread<F, R>(name: impl Into<String>, f: F) -> std::thread::JoinHandle<R>
+where
+    F: 'static + FnOnce() -> R + Send,
+    R: 'static + Send,
+{
     let conf = std::thread::Builder::new().name(name.into());
     let runtime = tokio::runtime::Handle::current();
     conf.spawn(move || {

--- a/graphql/src/execution/resolver.rs
+++ b/graphql/src/execution/resolver.rs
@@ -18,7 +18,7 @@ use super::Query;
 pub trait Resolver: Sized + Send + Sync + 'static {
     const CACHEABLE: bool;
 
-    async fn query_permit(&self) -> Result<QueryPermit, QueryExecutionError>;
+    async fn query_permit(&self) -> QueryPermit;
 
     /// Prepare for executing a query by prefetching as much data as possible
     fn prefetch(

--- a/graphql/src/introspection/resolver.rs
+++ b/graphql/src/introspection/resolver.rs
@@ -356,7 +356,7 @@ impl Resolver for IntrospectionResolver {
     // see `fn as_introspection_context`, so this value is irrelevant.
     const CACHEABLE: bool = false;
 
-    async fn query_permit(&self) -> Result<QueryPermit, QueryExecutionError> {
+    async fn query_permit(&self) -> QueryPermit {
         unreachable!()
     }
 

--- a/graphql/src/runner.rs
+++ b/graphql/src/runner.rs
@@ -143,7 +143,7 @@ where
         )?;
         self.load_manager
             .decide(
-                &store.wait_stats().map_err(QueryExecutionError::from)?,
+                &store.wait_stats(),
                 store.shard(),
                 store.deployment_id(),
                 query.shape_hash,

--- a/graphql/src/store/resolver.rs
+++ b/graphql/src/store/resolver.rs
@@ -256,8 +256,8 @@ impl StoreResolver {
 impl Resolver for StoreResolver {
     const CACHEABLE: bool = true;
 
-    async fn query_permit(&self) -> Result<QueryPermit, QueryExecutionError> {
-        self.store.query_permit().await.map_err(Into::into)
+    async fn query_permit(&self) -> QueryPermit {
+        self.store.query_permit().await
     }
 
     fn prefetch(

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -898,7 +898,7 @@ impl Context {
 
     fn primary_pool(self) -> ConnectionPool {
         let primary = self.config.primary_store();
-        let coord = Arc::new(PoolCoordinator::new(Arc::new(vec![])));
+        let coord = Arc::new(PoolCoordinator::new(&self.logger, Arc::new(vec![])));
         let pool = StoreBuilder::main_pool(
             &self.logger,
             &self.node_id,

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -110,7 +110,7 @@ impl StoreBuilder {
             .collect::<Result<Vec<_>, _>>()
             .expect("connection url's contain enough detail");
         let servers = Arc::new(servers);
-        let coord = Arc::new(PoolCoordinator::new(servers));
+        let coord = Arc::new(PoolCoordinator::new(logger, servers));
 
         let shards: Vec<_> = config
             .stores

--- a/node/src/store_builder.rs
+++ b/node/src/store_builder.rs
@@ -8,7 +8,7 @@ use graph::{
     util::security::SafeDisplay,
 };
 use graph_store_postgres::connection_pool::{
-    ConnectionPool, ForeignServer, PoolCoordinator, PoolName,
+    ConnectionPool, ForeignServer, PoolCoordinator, PoolRole,
 };
 use graph_store_postgres::{
     BlockStore as DieselBlockStore, ChainHeadUpdateListener as PostgresChainHeadUpdateListener,
@@ -224,7 +224,7 @@ impl StoreBuilder {
         coord.create_pool(
             &logger,
             name,
-            PoolName::Main,
+            PoolRole::Main,
             shard.connection.clone(),
             pool_size,
             Some(fdw_pool_size),
@@ -264,7 +264,7 @@ impl StoreBuilder {
                     coord.clone().create_pool(
                         &logger,
                         name,
-                        PoolName::Replica(pool),
+                        PoolRole::Replica(pool),
                         replica.connection.clone(),
                         pool_size,
                         None,

--- a/server/index-node/src/resolver.rs
+++ b/server/index-node/src/resolver.rs
@@ -777,8 +777,8 @@ fn entity_changes_to_graphql(entity_changes: Vec<EntityOperation>) -> r::Value {
 impl<S: Store> Resolver for IndexNodeResolver<S> {
     const CACHEABLE: bool = false;
 
-    async fn query_permit(&self) -> Result<QueryPermit, QueryExecutionError> {
-        self.store.query_permit().await.map_err(Into::into)
+    async fn query_permit(&self) -> QueryPermit {
+        self.store.query_permit().await
     }
 
     fn prefetch(

--- a/store/postgres/src/block_store.rs
+++ b/store/postgres/src/block_store.rs
@@ -319,11 +319,7 @@ impl BlockStore {
     }
 
     pub(crate) async fn query_permit_primary(&self) -> QueryPermit {
-        self.mirror
-            .primary()
-            .query_permit()
-            .await
-            .expect("the primary is never disabled")
+        self.mirror.primary().query_permit().await
     }
 
     pub fn allocate_chain(

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -435,27 +435,27 @@ impl fmt::Debug for ConnectionPool {
     }
 }
 
-/// The name of the pool, mostly for logging, and what purpose it serves.
+/// The role of the pool, mostly for logging, and what purpose it serves.
 /// The main pool will always be called `main`, and can be used for reading
 /// and writing. Replica pools can only be used for reading, and don't
 /// require any setup (migrations etc.)
-pub enum PoolName {
+pub enum PoolRole {
     Main,
     Replica(String),
 }
 
-impl PoolName {
+impl PoolRole {
     fn as_str(&self) -> &str {
         match self {
-            PoolName::Main => "main",
-            PoolName::Replica(name) => name,
+            PoolRole::Main => "main",
+            PoolRole::Replica(name) => name,
         }
     }
 
     fn is_replica(&self) -> bool {
         match self {
-            PoolName::Main => false,
-            PoolName::Replica(_) => true,
+            PoolRole::Main => false,
+            PoolRole::Replica(_) => true,
         }
     }
 }
@@ -504,7 +504,7 @@ impl PoolStateTracker {
 impl ConnectionPool {
     fn create(
         shard_name: &str,
-        pool_name: PoolName,
+        pool_name: PoolRole,
         postgres_url: String,
         pool_size: u32,
         fdw_pool_size: Option<u32>,
@@ -1421,7 +1421,7 @@ impl PoolCoordinator {
         self: Arc<Self>,
         logger: &Logger,
         name: &str,
-        pool_name: PoolName,
+        pool_name: PoolRole,
         postgres_url: String,
         pool_size: u32,
         fdw_pool_size: Option<u32>,

--- a/store/postgres/src/connection_pool.rs
+++ b/store/postgres/src/connection_pool.rs
@@ -1364,11 +1364,6 @@ fn migrate_schema(logger: &Logger, conn: &mut PgConnection) -> Result<MigrationC
     }
 
     let migrations = catalog::migration_count(conn)?;
-    if migrations != old_count {
-        // Reset the query statistics since a schema change makes them not
-        // all that useful. An error here is not serious and can be ignored.
-        conn.batch_execute("select pg_stat_statements_reset()").ok();
-    }
 
     Ok(MigrationCount {
         new: migrations,

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -415,7 +415,7 @@ impl DeploymentStore {
         Ok(conn)
     }
 
-    pub(crate) async fn query_permit(&self, replica: ReplicaId) -> Result<QueryPermit, StoreError> {
+    pub(crate) async fn query_permit(&self, replica: ReplicaId) -> QueryPermit {
         let pool = match replica {
             ReplicaId::Main => &self.pool,
             ReplicaId::ReadOnly(idx) => &self.read_only_pools[idx],
@@ -423,7 +423,7 @@ impl DeploymentStore {
         pool.query_permit().await
     }
 
-    pub(crate) fn wait_stats(&self, replica: ReplicaId) -> Result<PoolWaitStats, StoreError> {
+    pub(crate) fn wait_stats(&self, replica: ReplicaId) -> PoolWaitStats {
         match replica {
             ReplicaId::Main => self.pool.wait_stats(),
             ReplicaId::ReadOnly(idx) => self.read_only_pools[idx].wait_stats(),

--- a/store/postgres/src/primary.rs
+++ b/store/postgres/src/primary.rs
@@ -266,6 +266,13 @@ impl Namespace {
         Namespace(format!("prune{id}"))
     }
 
+    /// A namespace that is not a deployment namespace. This is used for
+    /// special namespaces we use. No checking is done on `s` and the caller
+    /// must ensure it's a valid namespace name
+    pub fn special(s: impl Into<String>) -> Self {
+        Namespace(s.into())
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/store/postgres/src/query_store.rs
+++ b/store/postgres/src/query_store.rs
@@ -112,7 +112,7 @@ impl QueryStoreTrait for QueryStore {
         self.chain_store.block_numbers(block_hashes).await
     }
 
-    fn wait_stats(&self) -> Result<PoolWaitStats, StoreError> {
+    fn wait_stats(&self) -> PoolWaitStats {
         self.store.wait_stats(self.replica_id)
     }
 
@@ -137,7 +137,7 @@ impl QueryStoreTrait for QueryStore {
         &self.site.network
     }
 
-    async fn query_permit(&self) -> Result<QueryPermit, StoreError> {
+    async fn query_permit(&self) -> QueryPermit {
         self.store.query_permit(self.replica_id).await
     }
 

--- a/store/postgres/src/store.rs
+++ b/store/postgres/src/store.rs
@@ -167,8 +167,8 @@ impl StatusStore for Store {
             .await
     }
 
-    async fn query_permit(&self) -> Result<QueryPermit, StoreError> {
+    async fn query_permit(&self) -> QueryPermit {
         // Status queries go to the primary shard.
-        Ok(self.block_store.query_permit_primary().await)
+        self.block_store.query_permit_primary().await
     }
 }

--- a/store/test-store/tests/graphql/introspection.rs
+++ b/store/test-store/tests/graphql/introspection.rs
@@ -53,15 +53,15 @@ impl Resolver for MockResolver {
         Ok(r::Value::Null)
     }
 
-    async fn query_permit(&self) -> Result<QueryPermit, QueryExecutionError> {
+    async fn query_permit(&self) -> QueryPermit {
         let permit = Arc::new(tokio::sync::Semaphore::new(1))
             .acquire_owned()
             .await
             .unwrap();
-        Ok(QueryPermit {
+        QueryPermit {
             permit,
             wait: Duration::from_secs(0),
-        })
+        }
     }
 }
 

--- a/tests/src/config.rs
+++ b/tests/src/config.rs
@@ -210,7 +210,6 @@ impl Config {
         let setup = format!(
             r#"
         create extension pg_trgm;
-        create extension pg_stat_statements;
         create extension btree_gist;
         create extension postgres_fdw;
         grant usage on foreign data wrapper postgres_fdw to "{}";


### PR DESCRIPTION
With multiple nodes, they could race each other and cause database errors.

I've reworked the startup code to be (a) race-proof (I hope) and (b) easier to follow. Any node that wants to run database setup now gets a lock on the primary, and runs all code needed for setup while holding that lock. That way, nodes can't interfere with each other. In the common case, where there are no database changes, be it because of migrations, configuration changes, or code changes that map different tables, the time during which any node holds the lock is very brief. This could be further optimized but let's first see how this performs in practice.