### PR TITLE
store: Do not create aggregate indexes twice

### DIFF
--- a/store/postgres/src/relational/ddl.rs
+++ b/store/postgres/src/relational/ddl.rs
@@ -422,8 +422,9 @@ impl Table {
             }
         } else {
             self.create_attribute_indexes(out)?;
+            self.create_aggregate_indexes(schema, out)?;
         }
-        self.create_aggregate_indexes(schema, out)
+        Ok(())
     }
 
     pub fn exclusion_ddl(&self, out: &mut String) -> fmt::Result {


### PR DESCRIPTION
When index creation was postponed, we would create aggregate indexes twice. They could also be postponed, but we'll leave that for another day.

