### PR TITLE
graph, store: Remove GRAPH_STORE_LAST_ROLLUP_FROM_POI

### DIFF
--- a/graph/src/env/store.rs
+++ b/graph/src/env/store.rs
@@ -129,14 +129,6 @@ pub struct EnvVarsStore {
     pub use_brin_for_all_query_types: bool,
     /// Temporary env var to disable certain lookups in the chain store
     pub disable_block_cache_for_lookup: bool,
-    /// Temporary env var to fall back to the old broken way of determining
-    /// the time of the last rollup from the POI table instead of the new
-    /// way that fixes
-    /// https://github.com/graphprotocol/graph-node/issues/5530 Remove this
-    /// and all code that is dead as a consequence once this has been vetted
-    /// sufficiently, probably after 2024-12-01
-    /// Defaults to `false`, i.e. using the new fixed behavior
-    pub last_rollup_from_poi: bool,
     /// Safety switch to increase the number of columns used when
     /// calculating the chunk size in `InsertQuery::chunk_size`. This can be
     /// used to work around Postgres errors complaining 'number of
@@ -197,7 +189,6 @@ impl TryFrom<InnerStore> for EnvVarsStore {
             create_gin_indexes: x.create_gin_indexes,
             use_brin_for_all_query_types: x.use_brin_for_all_query_types,
             disable_block_cache_for_lookup: x.disable_block_cache_for_lookup,
-            last_rollup_from_poi: x.last_rollup_from_poi,
             insert_extra_cols: x.insert_extra_cols,
             fdw_fetch_size: x.fdw_fetch_size,
         };
@@ -276,8 +267,6 @@ pub struct InnerStore {
     use_brin_for_all_query_types: bool,
     #[envconfig(from = "GRAPH_STORE_DISABLE_BLOCK_CACHE_FOR_LOOKUP", default = "false")]
     disable_block_cache_for_lookup: bool,
-    #[envconfig(from = "GRAPH_STORE_LAST_ROLLUP_FROM_POI", default = "false")]
-    last_rollup_from_poi: bool,
     #[envconfig(from = "GRAPH_STORE_INSERT_EXTRA_COLS", default = "0")]
     insert_extra_cols: usize,
     #[envconfig(from = "GRAPH_STORE_FDW_FETCH_SIZE", default = "1000")]

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -904,20 +904,12 @@ impl DeploymentStore {
         .await
     }
 
-    pub(crate) fn block_time(
-        &self,
-        site: Arc<Site>,
-        block: BlockNumber,
-    ) -> Result<Option<BlockTime>, StoreError> {
+    pub(crate) fn block_time(&self, site: Arc<Site>) -> Result<Option<BlockTime>, StoreError> {
         let store = self.cheap_clone();
 
         let mut conn = self.get_conn()?;
         let layout = store.layout(&mut conn, site.cheap_clone())?;
-        if ENV_VARS.store.last_rollup_from_poi {
-            layout.block_time(&mut conn, block)
-        } else {
-            layout.last_rollup(&mut conn)
-        }
+        layout.last_rollup(&mut conn)
     }
 
     pub(crate) async fn get_proof_of_indexing(

--- a/store/postgres/src/writable.rs
+++ b/store/postgres/src/writable.rs
@@ -95,8 +95,8 @@ impl LastRollup {
         let kind = match (has_aggregations, block) {
             (false, _) => LastRollup::NotNeeded,
             (true, None) => LastRollup::Unknown,
-            (true, Some(block)) => {
-                let block_time = store.block_time(site, block)?;
+            (true, Some(_)) => {
+                let block_time = store.block_time(site)?;
                 block_time
                     .map(|b| LastRollup::Some(b))
                     .unwrap_or(LastRollup::Unknown)
@@ -240,9 +240,7 @@ impl SyncStore {
                 firehose_cursor,
             )?;
 
-            let block_time = self
-                .writable
-                .block_time(self.site.cheap_clone(), block_ptr_to.number)?;
+            let block_time = self.writable.block_time(self.site.cheap_clone())?;
             self.last_rollup.set(block_time)
         })
     }


### PR DESCRIPTION
This flag was only meant as a safety switch in case the fixed behavior caused trouble. Since it's not been needed in several months, it's safe to remove it.

