### PR TITLE
store: Do not use a fdw connection to check active_copies

### DIFF
--- a/store/postgres/src/copy.rs
+++ b/store/postgres/src/copy.rs
@@ -1091,6 +1091,7 @@ impl Connection {
                 W::Err(e) => {
                     // This is a panic in the background task. We need to
                     // cancel all other tasks and return the error
+                    error!(self.logger, "copy worker panicked: {}", e);
                     self.cancel_workers(progress, workers).await;
                     return Err(e);
                 }
@@ -1115,6 +1116,7 @@ impl Connection {
                             return Ok(Status::Cancelled);
                         }
                         (Err(e), _) => {
+                            error!(self.logger, "copy worker had an error: {}", e);
                             self.cancel_workers(progress, workers).await;
                             return Err(e);
                         }


### PR DESCRIPTION
Copying checks the active_copies table through the primary_public.active_copies foreign table to determine whether the copy has been cancelled and it should stop.

With a large number of copies running, that causes a large number of postgres_fdw connections into the primary, which can overwhelm the primary.

Instead, we now pass the connection pool for the primary into the copy code so that it can do this check without involving postgres_fdw.

