### PR TITLE
Async pruning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,6 +724,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size 0.3.0",
 ]
 
 [[package]]
@@ -773,7 +774,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "regex",
- "terminal_size",
+ "terminal_size 0.1.17",
  "unicode-width",
  "winapi",
  "winapi-util",
@@ -5233,6 +5234,16 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ async-graphql-axum = "7.0.15"
 axum = "0.8.1"
 chrono = "0.4.38"
 bs58 = "0.5.1"
-clap = { version = "4.5.4", features = ["derive", "env"] }
+clap = { version = "4.5.4", features = ["derive", "env", "wrap_help"] }
 derivative = "2.2.0"
 diesel = { version = "2.2.7", features = [
     "postgres",

--- a/graph/src/components/store/err.rs
+++ b/graph/src/components/store/err.rs
@@ -7,6 +7,8 @@ use diesel::result::Error as DieselError;
 use thiserror::Error;
 use tokio::task::JoinError;
 
+pub type StoreResult<T> = Result<T, StoreError>;
+
 #[derive(Error, Debug)]
 pub enum StoreError {
     #[error("store error: {0:#}")]

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -12,7 +12,7 @@ pub use entity_cache::{EntityCache, EntityLfuCache, GetScope, ModificationsAndCa
 use slog::Logger;
 
 pub use super::subgraph::Entity;
-pub use err::StoreError;
+pub use err::{StoreError, StoreResult};
 use itertools::Itertools;
 use strum_macros::Display;
 pub use traits::*;

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -1003,6 +1003,9 @@ pub struct PruneRequest {
     pub earliest_block: BlockNumber,
     /// The last block that contains final entities not subject to a reorg
     pub final_block: BlockNumber,
+    /// The first block for which the deployment contained entities when the
+    /// request was made
+    pub first_block: BlockNumber,
     /// The latest block, i.e., the subgraph head
     pub latest_block: BlockNumber,
     /// Use the rebuild strategy when removing more than this fraction of
@@ -1066,6 +1069,7 @@ impl PruneRequest {
             earliest_block,
             final_block,
             latest_block,
+            first_block,
             rebuild_threshold,
             delete_threshold,
         })

--- a/graph/src/env/store.rs
+++ b/graph/src/env/store.rs
@@ -111,6 +111,9 @@ pub struct EnvVarsStore {
     /// blocks) than its history limit. The default value is 1.2 and the
     /// value must be at least 1.01
     pub history_slack_factor: f64,
+    /// For how many prune runs per deployment to keep status information.
+    /// Set by `GRAPH_STORE_HISTORY_KEEP_STATUS`. The default is 5
+    pub prune_keep_history: usize,
     /// How long to accumulate changes into a batch before a write has to
     /// happen. Set by the environment variable
     /// `GRAPH_STORE_WRITE_BATCH_DURATION` in seconds. The default is 300s.
@@ -184,6 +187,7 @@ impl TryFrom<InnerStore> for EnvVarsStore {
             rebuild_threshold: x.rebuild_threshold.0,
             delete_threshold: x.delete_threshold.0,
             history_slack_factor: x.history_slack_factor.0,
+            prune_keep_history: x.prune_keep_status,
             write_batch_duration: Duration::from_secs(x.write_batch_duration_in_secs),
             write_batch_size: x.write_batch_size * 1_000,
             create_gin_indexes: x.create_gin_indexes,
@@ -257,6 +261,8 @@ pub struct InnerStore {
     delete_threshold: ZeroToOneF64,
     #[envconfig(from = "GRAPH_STORE_HISTORY_SLACK_FACTOR", default = "1.2")]
     history_slack_factor: HistorySlackF64,
+    #[envconfig(from = "GRAPH_STORE_HISTORY_KEEP_STATUS", default = "5")]
+    prune_keep_status: usize,
     #[envconfig(from = "GRAPH_STORE_WRITE_BATCH_DURATION", default = "300")]
     write_batch_duration_in_secs: u64,
     #[envconfig(from = "GRAPH_STORE_WRITE_BATCH_SIZE", default = "10000")]

--- a/node/src/manager/commands/prune.rs
+++ b/node/src/manager/commands/prune.rs
@@ -341,14 +341,16 @@ pub async fn status(
         let runs = match runs.len() {
             0 => unreachable!("we checked that runs is not empty"),
             1 => format!("There is only one prune run #{}", runs[0]),
+            2 => format!("Only prune runs #{} and #{} exist", runs[0], runs[1]),
             _ => format!(
-                "Only prune runs #{} up to #{} exist",
+                "Only prune runs #{} and #{} up to #{} exist",
                 runs[0],
+                runs[1],
                 runs.last().unwrap()
             ),
         };
         return Err(anyhow!(
-            "No information about prune run #{run} found for deployment {deployment}. {runs}"
+            "No information about prune run #{run} found for deployment {deployment}.\n  {runs}"
         ));
     };
     println!("prune {deployment} (run #{run})");

--- a/node/src/manager/commands/prune.rs
+++ b/node/src/manager/commands/prune.rs
@@ -16,10 +16,7 @@ use graph::{
 };
 use graph_store_postgres::{ConnectionPool, Store};
 
-use crate::manager::{
-    commands::stats::{abbreviate_table_name, show_stats},
-    deployment::DeploymentSearch,
-};
+use crate::manager::{commands::stats::show_stats, deployment::DeploymentSearch, fmt};
 
 struct Progress {
     start: Instant,
@@ -66,7 +63,7 @@ fn print_batch(
     };
     print!(
         "\r{:<30} | {:>10} | {:>9}s {phase}",
-        abbreviate_table_name(table, 30),
+        fmt::abbreviate(table, 30),
         total_rows,
         elapsed.as_secs()
     );

--- a/node/src/manager/commands/stats.rs
+++ b/node/src/manager/commands/stats.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::manager::deployment::DeploymentSearch;
+use crate::manager::fmt;
 use diesel::r2d2::ConnectionManager;
 use diesel::r2d2::PooledConnection;
 use diesel::PgConnection;
@@ -51,19 +52,6 @@ pub async fn account_like(
     Ok(())
 }
 
-pub fn abbreviate_table_name(table: &str, size: usize) -> String {
-    if table.len() > size {
-        let fragment = size / 2 - 2;
-        let last = table.len() - fragment;
-        let mut table = table.to_string();
-        table.replace_range(fragment..last, "..");
-        let table = table.trim().to_string();
-        table
-    } else {
-        table.to_string()
-    }
-}
-
 pub fn show_stats(
     stats: &[VersionStats],
     account_like: HashSet<String>,
@@ -83,7 +71,7 @@ pub fn show_stats(
     fn print_stats(s: &VersionStats, account_like: bool) {
         println!(
             "{:<26} {:3} | {:>10} | {:>10} | {:>5.1}%",
-            abbreviate_table_name(&s.tablename, 26),
+            fmt::abbreviate(&s.tablename, 26),
             if account_like { "(a)" } else { "   " },
             s.entities,
             s.versions,

--- a/node/src/manager/fmt.rs
+++ b/node/src/manager/fmt.rs
@@ -50,7 +50,20 @@ pub fn human_duration(duration: Duration) -> String {
     } else if duration.num_minutes() < 5 {
         format!("{}s", duration.num_seconds())
     } else {
-        format!("{}m", duration.num_minutes())
+        let minutes = duration.num_minutes();
+        if minutes < 90 {
+            format!("{}m", duration.num_minutes())
+        } else {
+            let hours = minutes / 60;
+            let minutes = minutes % 60;
+            if hours < 24 {
+                format!("{}h {}m", hours, minutes)
+            } else {
+                let days = hours / 24;
+                let hours = hours % 24;
+                format!("{}d {}h {}m", days, hours, minutes)
+            }
+        }
     }
 }
 
@@ -75,4 +88,36 @@ pub fn abbreviate(name: &str, size: usize) -> String {
 pub fn date_time(date: &DateTime<Utc>) -> String {
     let date = DateTime::<Local>::from(*date);
     date.format("%Y-%m-%d %H:%M:%S%Z").to_string()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_human_duration() {
+        let duration = Duration::seconds(1);
+        assert_eq!(human_duration(duration), "1000ms");
+
+        let duration = Duration::seconds(10);
+        assert_eq!(human_duration(duration), "10s");
+
+        let duration = Duration::minutes(5);
+        assert_eq!(human_duration(duration), "5m");
+
+        let duration = Duration::hours(1);
+        assert_eq!(human_duration(duration), "60m");
+
+        let duration = Duration::minutes(100);
+        assert_eq!(human_duration(duration), "1h 40m");
+
+        let duration = Duration::days(1);
+        assert_eq!(human_duration(duration), "1d 0h 0m");
+
+        let duration = Duration::days(1) + Duration::minutes(35);
+        assert_eq!(human_duration(duration), "1d 0h 35m");
+
+        let duration = Duration::days(1) + Duration::minutes(95);
+        assert_eq!(human_duration(duration), "1d 1h 35m");
+    }
 }

--- a/node/src/manager/fmt.rs
+++ b/node/src/manager/fmt.rs
@@ -1,0 +1,78 @@
+use std::time::SystemTime;
+
+use graph::prelude::chrono::{DateTime, Duration, Local, Utc};
+
+pub const NULL: &str = "ø";
+const CHECK: &str = "✓";
+
+pub fn null() -> String {
+    NULL.to_string()
+}
+
+pub fn check() -> String {
+    CHECK.to_string()
+}
+
+pub trait MapOrNull<T> {
+    fn map_or_null<F>(&self, f: F) -> String
+    where
+        F: FnOnce(&T) -> String;
+}
+
+impl<T> MapOrNull<T> for Option<T> {
+    fn map_or_null<F>(&self, f: F) -> String
+    where
+        F: FnOnce(&T) -> String,
+    {
+        self.as_ref()
+            .map(|value| f(value))
+            .unwrap_or_else(|| NULL.to_string())
+    }
+}
+
+/// Return the duration from `start` to `end` formatted using
+/// `human_duration`. Use now if `end` is `None`
+pub fn duration(start: &DateTime<Utc>, end: &Option<DateTime<Utc>>) -> String {
+    let start = *start;
+    let end = *end;
+
+    let end = end.unwrap_or(DateTime::<Utc>::from(SystemTime::now()));
+    let duration = end - start;
+
+    human_duration(duration)
+}
+
+/// Format a duration using ms/s/m as units depending on how long the
+/// duration was
+pub fn human_duration(duration: Duration) -> String {
+    if duration.num_seconds() < 5 {
+        format!("{}ms", duration.num_milliseconds())
+    } else if duration.num_minutes() < 5 {
+        format!("{}s", duration.num_seconds())
+    } else {
+        format!("{}m", duration.num_minutes())
+    }
+}
+
+/// Abbreviate a long name to fit into `size` characters. The abbreviation
+/// is done by replacing the middle of the name with `..`. For example, if
+/// `name` is `foo_bar_baz` and `size` is 10, the result will be
+/// `foo.._baz`. If the name is shorter than `size`, it is returned
+/// unchanged.
+pub fn abbreviate(name: &str, size: usize) -> String {
+    if name.len() > size {
+        let fragment = size / 2 - 2;
+        let last = name.len() - fragment;
+        let mut name = name.to_string();
+        name.replace_range(fragment..last, "..");
+        let table = name.trim().to_string();
+        table
+    } else {
+        name.to_string()
+    }
+}
+
+pub fn date_time(date: &DateTime<Utc>) -> String {
+    let date = DateTime::<Local>::from(*date);
+    date.format("%Y-%m-%d %H:%M:%S%Z").to_string()
+}

--- a/node/src/manager/mod.rs
+++ b/node/src/manager/mod.rs
@@ -8,6 +8,7 @@ pub mod color;
 pub mod commands;
 pub mod deployment;
 mod display;
+pub mod fmt;
 pub mod prompt;
 
 /// A dummy subscription manager that always panics

--- a/store/postgres/migrations/2025-04-08-224710_add_prune_state/down.sql
+++ b/store/postgres/migrations/2025-04-08-224710_add_prune_state/down.sql
@@ -1,0 +1,2 @@
+drop table subgraphs.prune_table_state;
+drop table subgraphs.prune_state;

--- a/store/postgres/migrations/2025-04-08-224710_add_prune_state/up.sql
+++ b/store/postgres/migrations/2025-04-08-224710_add_prune_state/up.sql
@@ -1,0 +1,60 @@
+create table subgraphs.prune_state(
+  -- diesel can't deal with composite primary keys
+  vid            int primary key
+                     generated always as identity,
+
+  -- id of the deployment
+  id             int not null,
+  -- how many times the deployment has been pruned
+  run            int not null,
+
+  -- from PruneRequest
+  first_block    int not null,
+  final_block    int not null,
+  latest_block   int not null,
+  history_blocks int not null,
+
+  started_at     timestamptz not null,
+  finished_at    timestamptz,
+
+  constraint prune_state_id_run_uq unique(id, run)
+);
+
+create table subgraphs.prune_table_state(
+  -- diesel can't deal with composite primary keys
+  vid            int primary key
+                     generated always as identity,
+
+  id             int not null,
+  run            int not null,
+  table_name     text not null,
+  -- 'r' (rebuild) or 'd' (delete)
+  strategy       char not null,
+  phase          text not null,
+
+  start_vid      int8,
+  final_vid      int8,
+  nonfinal_vid   int8,
+  rows           int8,
+
+  next_vid       int8,
+  batch_size     int8,
+
+  started_at     timestamptz,
+  finished_at    timestamptz,
+
+  constraint prune_table_state_id_run_table_name_uq
+    unique(id, run, table_name),
+
+  constraint prune_table_state_strategy_ck
+    check(strategy in ('r', 'd')),
+
+  constraint prune_table_state_phase_ck
+    check(phase in ('queued', 'started', 'copy_final',
+                    'copy_nonfinal', 'delete', 'done')),
+
+  constraint prune_table_state_id_run_fk
+    foreign key(id, run)
+    references subgraphs.prune_state(id, run)
+    on delete cascade
+);

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -85,5 +85,6 @@ pub mod command_support {
     }
     pub use crate::deployment::{on_sync, OnSync};
     pub use crate::primary::Namespace;
+    pub use crate::relational::prune::{Phase, PruneState, PruneTableState, Viewer};
     pub use crate::relational::{Catalog, Column, ColumnType, Layout, SqlName};
 }

--- a/store/postgres/src/pool/mod.rs
+++ b/store/postgres/src/pool/mod.rs
@@ -66,6 +66,8 @@ const SHARDED_TABLES: [(&str, &[&str]); 2] = [
             "subgraph",
             "subgraph_version",
             "subgraph_deployment_assignment",
+            "prune_state",
+            "prune_table_state",
         ],
     ),
 ];

--- a/store/postgres/src/relational.rs
+++ b/store/postgres/src/relational.rs
@@ -16,7 +16,7 @@ mod query_tests;
 
 pub(crate) mod dsl;
 pub(crate) mod index;
-mod prune;
+pub(crate) mod prune;
 mod rollup;
 pub(crate) mod value;
 

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -40,6 +40,7 @@ use crate::{
     deployment::{OnSync, SubgraphHealth},
     primary::{self, DeploymentId, Mirror as PrimaryMirror, Primary, Site},
     relational::{
+        self,
         index::{IndexList, Method},
         Layout,
     },
@@ -1247,6 +1248,16 @@ impl SubgraphStoreInner {
         let store = self.for_site(&site)?;
 
         store.prune(reporter, site, req).await
+    }
+
+    pub async fn prune_viewer(
+        &self,
+        deployment: &DeploymentLocator,
+    ) -> Result<relational::prune::Viewer, StoreError> {
+        let site = self.find_site(deployment.id.into())?;
+        let store = self.for_site(&site)?;
+
+        store.prune_viewer(site).await
     }
 
     pub fn set_history_blocks(


### PR DESCRIPTION
So far, the intial prune of a subgraph had to be done synchronously in a terminal. This PR makes it possible to modify the amount of history a subgraph should keep but have the initial and all subsequent prunes happen in the background.

To that end, this PR changes the `graphman` commands used for pruning. `graphman prune` now has subcommands:
* `graphman prune run` behaves as `graphman prune` did before this PR
* `graphman prune set` just changes how much history a subgraph keeps. The actual pruning happens in the background
* `graphman prune status` shows the details of pruning runs

Most of this PR is concerned with keeping information in the database that is shown by `graphman prune status`. The output of the status command is something like

```
prune Qm...[19] (run #5)
     range: 12834375 - 12835766 (1391 blocks, should keep 500 blocks)
   started: 2025-04-12 18:43:15-07:00
  finished: 2025-04-16 14:39:29-07:00
  duration: 3d 19h 56m

            table              |         status         |   rows   | batch_size  | duration
-------------------------------+------------------------+----------+-------------+---------
circular_buffer                | r/done               ✓ |        8 |         200 |    102ms
financials_daily_snapshot      | d/done               ✓ |      -45 |       20000 |     17ms
poi2$                          | r/copy_final    ( 37%) |       32 |       20000 |  10h 55m
reward_pool_info               | d/done               ✓ |       -4 |       20000 |     17ms
usage_metrics_daily_snapshot   | d/done               ✓ |      -43 |       20000 |     20ms
vault                          | d/done               ✓ |      -62 |        1600 |     43ms
yield_aggregator               | r/done               ✓ |       12 |         200 |     90ms
```

`graph-node` stores the details of the initial pruning run, and then the details of the last ongoing pruning runs.