### PR TITLE
store: Drop the vid sequence with 'cascade'

### DIFF
--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -233,6 +233,7 @@ impl TablePair {
                 query,
                 "select setval('{dst_nsp}.{vid_seq}', nextval('{src_nsp}.{vid_seq}'));"
             )?;
+            writeln!(query, "drop sequence {src_nsp}.{vid_seq} cascade;")?;
         }
 
         writeln!(query, "drop table {src_qname};")?;


### PR DESCRIPTION
Since it is used for the default value, we get an error

```
  sequence sgdNNN.<table>_vid_seq membership in
  replication set default depends on sequence sgdNNN.<table>_vid_seq
```

That makes all pruning by rebuilding tables fail

