### PR TITLE
core, graph, store: Pause failed subgraphs instead of unassigning

### DIFF
--- a/core/src/subgraph/runner.rs
+++ b/core/src/subgraph/runner.rs
@@ -527,7 +527,7 @@ where
         let store = &self.inputs.store;
         if !ENV_VARS.disable_fail_fast && !store.is_deployment_synced() {
             store
-                .unassign_subgraph()
+                .pause_subgraph()
                 .map_err(|e| ProcessingError::Unknown(e.into()))?;
 
             // Use `Canceled` to avoiding setting the subgraph health to failed, an error was

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -395,7 +395,7 @@ pub trait WritableStore: ReadStore + DeploymentCursorTracker {
     /// Cheap, cached operation.
     fn is_deployment_synced(&self) -> bool;
 
-    fn unassign_subgraph(&self) -> Result<(), StoreError>;
+    fn pause_subgraph(&self) -> Result<(), StoreError>;
 
     /// Load the dynamic data sources for the given deployment
     async fn load_dynamic_data_sources(

--- a/store/test-store/tests/graph/entity_cache.rs
+++ b/store/test-store/tests/graph/entity_cache.rs
@@ -141,7 +141,7 @@ impl WritableStore for MockStore {
         unimplemented!()
     }
 
-    fn unassign_subgraph(&self) -> Result<(), StoreError> {
+    fn pause_subgraph(&self) -> Result<(), StoreError> {
         unimplemented!()
     }
 


### PR DESCRIPTION
Unassigning subgraphs has a number of unwanted side-effects, e.g., canceling copies. Pausing is safer alternative to avoid spending cycles on a subgraph we know will not make progress.

