### PR TITLE
Migrate from `ethabi` to `alloy`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,570 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alloy"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2cc5aeb8dfa1e451a49fac87bc4b86c5de40ebea153ed88e83eb92b8151e74"
+dependencies = [
+ "alloy-consensus",
+ "alloy-contract",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-network",
+ "alloy-provider",
+ "alloy-rpc-client",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
+ "alloy-transport",
+ "alloy-transport-http",
+]
+
+[[package]]
+name = "alloy-chains"
+version = "0.1.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28e2652684758b0d9b389d248b209ed9fd9989ef489a550265fe4bb8454fe7eb"
+dependencies = [
+ "alloy-primitives",
+ "num_enum",
+ "strum 0.27.1",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e32ef5c74bbeb1733c37f4ac7f866f8c8af208b7b4265e21af609dcac5bd5e"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-trie",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 1.0.0",
+ "serde",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa13b7b1e1e3fedc42f0728103bfa3b4d566d3d42b606db449504d88dbdbdcf"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-contract"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6180fb232becdea70fad57c63b6967f01f74ab9595671b870f504116dd29de"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "alloy-transport",
+ "futures 0.3.30",
+ "futures-util",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-core"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d8bcce99ad10fe02640cfaec1c6bc809b837c783c1d52906aa5af66e2a196f6"
+dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb8e762aefd39a397ff485bc86df673465c4ad3ec8819cc60833a8a3ba5cdc87"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "const-hex",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow 0.7.9",
+]
+
+[[package]]
+name = "alloy-eip2124"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675264c957689f0fd75f5993a73123c2cc3b5c235a38f5b9037fe6c826bfb2c0"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-eip2930"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "serde",
+]
+
+[[package]]
+name = "alloy-eip7702"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b15b13d38b366d01e818fe8e710d4d702ef7499eacd44926a06171dd9585d0c"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "serde",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5591581ca2ab0b3e7226a4047f9a1bfcf431da1d0cce3752fda609fea3c27e37"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "auto_impl",
+ "c-kzg",
+ "derive_more 1.0.0",
+ "once_cell",
+ "serde",
+ "sha2",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cded3a2d4bd7173f696458c5d4c98c18a628dfcc9f194385e80a486e412e2e0"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "alloy-trie",
+ "serde",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6beff64ad0aa6ad1019a3db26fef565aefeb011736150ab73ed3366c3cfd1b"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "762414662d793d7aaa36ee3af6928b6be23227df1681ce9c039f6f11daadef64"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-network"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be03f2ebc00cf88bd06d3c6caf387dceaa9c7e6b268216779fa68a9bf8ab4e6"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a00ce618ae2f78369918be0c20f620336381502c83b6ed62c2f7b2db27698b0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c77490fe91a0ce933a1f219029521f20fc28c2c0ca95d53fa4da9c00b8d9d4e"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if 1.0.0",
+ "const-hex",
+ "derive_more 2.0.1",
+ "foldhash",
+ "hashbrown 0.15.2",
+ "indexmap 2.9.0",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.8.5",
+ "ruint",
+ "rustc-hash 2.1.1",
+ "serde",
+ "sha3",
+ "tiny-keccak 2.0.2",
+]
+
+[[package]]
+name = "alloy-provider"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbe0a2acff0c4bd1669c71251ce10fc455cbffa1b4d0a817d5ea4ba7e5bb3db7"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-sol-types",
+ "alloy-transport",
+ "alloy-transport-http",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "futures 0.3.30",
+ "futures-utils-wasm",
+ "lru",
+ "parking_lot",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6c1d995bff8d011f7cd6c81820d51825e6e06d6db73914c1630ecf544d83d6"
+dependencies = [
+ "alloy-rlp-derive",
+ "arrayvec 0.7.4",
+ "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40e1ef334153322fd878d07e86af7a529bcb86b2439525920a88eba87bcf943"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b37cc3c7883dc41be1b01460127ad7930466d0a4bb6ba15a02ee34d2745e2d7c"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-transport",
+ "alloy-transport-http",
+ "futures 0.3.30",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f18e68a3882f372e045ddc89eb455469347767d17878ca492cfbac81e71a111"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "318ae46dd12456df42527c3b94c1ae9001e1ceb707f7afe2c7807ac4e49ebad9"
+dependencies = [
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4dbee4d82f8a22dde18c28257bed759afeae7ba73da4a1479a039fd1445d04"
+dependencies = [
+ "alloy-consensus",
+ "alloy-consensus-any",
+ "alloy-eips",
+ "alloy-network-primitives",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-sol-types",
+ "itertools 0.13.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8732058f5ca28c1d53d241e8504620b997ef670315d7c8afab856b3e3b80d945"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f96b3526fdd779a4bd0f37319cfb4172db52a7ac24cdbb8804b72091c18e1701"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve",
+ "k256",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe8f78cd6b7501c7e813a1eb4a087b72d23af51f5bb66d4e948dc840bdd207d8"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand 0.8.5",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10ae8e9a91d328ae954c22542415303919aabe976fe7a92eb06db1b68fd59f2"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83ad5da86c127751bc607c174d6c9fe9b85ef0889a9ca0c641735d77d4f98f26"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck 0.5.0",
+ "indexmap 2.9.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+ "syn-solidity",
+ "tiny-keccak 2.0.2",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3d30f0d3f9ba3b7686f3ff1de9ee312647aac705604417a2f40c604f409a9e"
+dependencies = [
+ "alloy-json-abi",
+ "const-hex",
+ "dunce",
+ "heck 0.5.0",
+ "macro-string",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.101",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
+dependencies = [
+ "serde",
+ "winnow 0.7.9",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43d5e60466a440230c07761aa67671d4719d46f43be8ea6e7ed334d8db4a9ab"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "const-hex",
+ "serde",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a8d762eadce3e9b65eac09879430c6f4fce3736cac3cac123f9b1bf435ddd13"
+dependencies = [
+ "alloy-json-rpc",
+ "base64 0.22.1",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tower 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20819c4cb978fb39ce6ac31991ba90f386d595f922f42ef888b4a18be190713e"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "reqwest",
+ "serde_json",
+ "tower 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a94854e420f07e962f7807485856cde359ab99ab6413883e15235ad996e8b"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "arrayvec 0.7.4",
+ "derive_more 1.0.0",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +710,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.0",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint 0.4.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +850,9 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ascii"
@@ -248,8 +939,8 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "strum",
- "syn 2.0.87",
+ "strum 0.26.3",
+ "syn 2.0.101",
  "thiserror 1.0.61",
 ]
 
@@ -285,7 +976,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -307,7 +998,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -318,7 +1009,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -332,6 +1023,17 @@ name = "atomic_refcell"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
+
+[[package]]
+name = "auto_impl"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "autocfg"
@@ -465,6 +1167,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +1198,12 @@ checksum = "38e2b6c78c06f7288d5e3c3d683bde35a79531127c83b087e5d0d77c974b4b28"
 dependencies = [
  "base64 0.22.1",
 ]
+
+[[package]]
+name = "base64ct"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "beef"
@@ -531,6 +1245,21 @@ checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -603,6 +1332,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "blst"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c79a94619fade3c0b887670333513a67ac28a6a7e653eb260bf0d4103db38d"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +1392,21 @@ version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "c-kzg"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0307f72feab3300336fb803a57134159f6e20139af1357f36c54cb90d8e8928"
+dependencies = [
+ "blst",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "once_cell",
  "serde",
 ]
 
@@ -736,7 +1492,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -776,6 +1532,25 @@ dependencies = [
  "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "const-hex"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0485bab839b018a8f1723fc5391819fea5f8f0f32288ef8a735fd096b6160c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
@@ -967,6 +1742,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1828,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,7 +1901,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1110,7 +1912,21 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1173,6 +1989,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "930c7171c8df9fb1782bdf9b918ed9ed2d33d1d22300abb754f9085bc48bf8e8"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,8 +2028,17 @@ dependencies = [
  "convert_case 0.4.0",
  "proc-macro2",
  "quote",
- "rustc_version",
- "syn 2.0.87",
+ "rustc_version 0.4.0",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl 1.0.0",
 ]
 
 [[package]]
@@ -1212,7 +2047,18 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 2.0.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1224,7 +2070,7 @@ dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
@@ -1257,7 +2103,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1279,7 +2125,7 @@ dependencies = [
  "dsl_auto_type",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1299,7 +2145,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
 dependencies = [
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1330,6 +2176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -1394,7 +2241,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1408,7 +2255,27 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -1416,6 +2283,25 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1472,7 +2358,7 @@ checksum = "d4291f0c7220b67ad15e9d5300ba2f215cee504f0924d60e77c9d1c77e7a69b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1515,7 +2401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
 dependencies = [
  "crunchy",
- "fixed-hash",
+ "fixed-hash 0.7.0",
  "impl-rlp",
  "impl-serde",
  "tiny-keccak 2.0.2",
@@ -1528,10 +2414,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
 dependencies = [
  "ethbloom",
- "fixed-hash",
+ "fixed-hash 0.7.0",
  "impl-rlp",
  "impl-serde",
- "primitive-types",
+ "primitive-types 0.11.1",
  "uint 0.9.5",
 ]
 
@@ -1563,6 +2449,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec 0.7.4",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec 0.7.4",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "firestorm"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1579,6 +2497,18 @@ name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand 0.8.5",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
  "rand 0.8.5",
@@ -1706,7 +2636,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1747,6 +2677,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-utils-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,6 +2712,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1836,9 +2773,15 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
  "time",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "globset"
@@ -1858,6 +2801,7 @@ name = "graph"
 version = "0.36.0"
 dependencies = [
  "Inflector",
+ "alloy",
  "anyhow",
  "async-stream",
  "async-trait",
@@ -1906,7 +2850,7 @@ dependencies = [
  "rand 0.9.1",
  "regex",
  "reqwest",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1977,7 +2921,7 @@ dependencies = [
  "jsonrpc-core",
  "prost",
  "prost-types",
- "semver",
+ "semver 1.0.23",
  "serde",
  "tiny-keccak 1.5.0",
  "tonic-build",
@@ -2011,7 +2955,7 @@ dependencies = [
  "lazy_static",
  "prost",
  "prost-types",
- "semver",
+ "semver 1.0.23",
  "serde",
  "tokio",
  "tonic-build",
@@ -2093,7 +3037,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2105,7 +3049,7 @@ dependencies = [
  "graph-runtime-derive",
  "graph-runtime-wasm",
  "rand 0.9.1",
- "semver",
+ "semver 1.0.23",
  "test-store",
  "wasmtime",
 ]
@@ -2117,13 +3061,12 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bs58 0.4.0",
- "ethabi",
  "graph",
  "graph-runtime-derive",
  "hex",
  "never",
  "parity-wasm",
- "semver",
+ "semver 1.0.23",
  "serde_yaml",
  "wasm-instrument",
  "wasmtime",
@@ -2237,7 +3180,7 @@ dependencies = [
  "proc-macro-utils",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2286,7 +3229,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "diesel",
- "strum",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -2310,6 +3253,17 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -2397,6 +3351,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -2456,6 +3411,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex-literal"
@@ -2822,7 +3780,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3126,12 +4084,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
 ]
 
 [[package]]
@@ -3151,6 +4132,12 @@ name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "libm"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25169bd5913a4b437588a7e3d127cd6e90127b60e0ffbd834a38f1599e016b8"
 
 [[package]]
 name = "libredox"
@@ -3191,6 +4178,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "lru_time_cache"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3203,6 +4199,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "macro-string"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3437,6 +4444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3447,6 +4455,39 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "nybbles"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
+dependencies = [
+ "alloy-rlp",
+ "const-hex",
+ "proptest",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -3535,7 +4576,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3669,7 +4710,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3740,7 +4781,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3754,6 +4795,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -3854,7 +4905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3863,10 +4914,21 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
 dependencies = [
- "fixed-hash",
+ "fixed-hash 0.7.0",
  "impl-codec",
  "impl-rlp",
  "impl-serde",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
+dependencies = [
+ "fixed-hash 0.8.0",
+ "impl-codec",
  "uint 0.9.5",
 ]
 
@@ -3888,6 +4950,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
  "toml_edit 0.21.1",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3928,6 +5012,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.6.0",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3953,7 +5057,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.87",
+ "syn 2.0.101",
  "tempfile",
 ]
 
@@ -3967,7 +5071,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4031,6 +5135,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-xml"
 version = "0.36.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4066,7 +5176,7 @@ dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.1",
  "rustls",
  "slab",
  "thiserror 1.0.61",
@@ -4122,6 +5232,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -4170,6 +5281,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4323,6 +5443,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4347,6 +5477,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruint"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78a46eb779843b2c4f21fac5773e25d6d5b7c8f0922876c91541790d2ca27eef"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "bytes",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types 0.12.2",
+ "proptest",
+ "rand 0.8.5",
+ "rand 0.9.1",
+ "rlp",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4360,9 +5523,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc-hex"
@@ -4372,11 +5535,20 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -4466,6 +5638,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4503,6 +5687,20 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "secp256k1"
@@ -4560,11 +5758,29 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
+dependencies = [
+ "pest",
 ]
 
 [[package]]
@@ -4584,7 +5800,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4673,7 +5889,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4735,6 +5951,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "shellexpand"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4756,6 +5982,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4852,6 +6088,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snafu"
@@ -4871,7 +6110,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4904,6 +6143,16 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "sptr"
@@ -4993,6 +6242,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+dependencies = [
+ "strum_macros 0.27.1",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5002,7 +6260,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5015,7 +6273,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5115,13 +6373,25 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4560533fbd6914b94a8fb5cc803ed6801c3455668db3b810702c57612bac9412"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5147,7 +6417,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5246,6 +6516,7 @@ dependencies = [
  "lazy_static",
  "pretty_assertions",
  "prost-types",
+ "serde_json",
 ]
 
 [[package]]
@@ -5274,7 +6545,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5285,7 +6556,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5296,6 +6567,15 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -5398,7 +6678,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5636,7 +6916,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5765,7 +7045,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5852,6 +7132,12 @@ dependencies = [
  "hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
@@ -5988,6 +7274,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6004,6 +7296,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -6067,7 +7368,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -6101,7 +7402,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6162,7 +7463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
  "indexmap 2.9.0",
- "semver",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -6172,7 +7473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77f1154f1ab868e2a01d9834a805faca7bf8b50d041b4ca714d005d0dab1c50c"
 dependencies = [
  "indexmap 2.9.0",
- "semver",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -6250,7 +7551,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser",
@@ -6438,7 +7739,7 @@ checksum = "f50f51f8d79bfd2aa8e9d9a0ae7c2d02b45fe412e62ff1b87c0c81b07c738231"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6458,6 +7759,20 @@ name = "wasmtime-wmemcheck"
 version = "15.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6060bc082cc32d9a45587c7640e29e3c7b89ada82677ac25d87850aaccb368"
+
+[[package]]
+name = "wasmtimer"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0048ad49a55b9deb3953841fa1fc5858f0efbcb7a18868c899a360269fac1b23"
+dependencies = [
+ "futures 0.3.30",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "wast"
@@ -6867,6 +8182,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wiremock"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6909,7 +8233,7 @@ dependencies = [
  "id-arena",
  "indexmap 2.9.0",
  "log",
- "semver",
+ "semver 1.0.23",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6969,7 +8293,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -6990,7 +8314,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7010,7 +8334,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -7019,6 +8343,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "zerovec"
@@ -7039,7 +8377,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ repository = "https://github.com/graphprotocol/graph-node"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
+alloy = { version = "0.11.1", features = ["dyn-abi", "json-abi"] }
 anyhow = "1.0"
 async-graphql = { version = "7.0.15", features = ["chrono"] }
 async-graphql-axum = "7.0.15"

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1,9 +1,11 @@
 use futures03::{future::BoxFuture, stream::FuturesUnordered};
+use graph::abi;
+use graph::abi::DynSolValueExt;
+use graph::abi::FunctionExt;
 use graph::blockchain::client::ChainClient;
 use graph::blockchain::BlockHash;
 use graph::blockchain::ChainIdentifier;
 use graph::blockchain::ExtendedBlockPtr;
-
 use graph::components::transaction_receipt::LightTransactionReceipt;
 use graph::data::store::ethereum::call;
 use graph::data::store::scalar;
@@ -17,8 +19,6 @@ use graph::futures03::future::try_join_all;
 use graph::futures03::{
     self, compat::Future01CompatExt, FutureExt, StreamExt, TryFutureExt, TryStreamExt,
 };
-use graph::prelude::ethabi::ParamType;
-use graph::prelude::ethabi::Token;
 use graph::prelude::tokio::try_join;
 use graph::prelude::web3::types::U256;
 use graph::slog::o;
@@ -28,8 +28,7 @@ use graph::{
     blockchain::{block_stream::BlockWithTriggers, BlockPtr, IngestorError},
     prelude::{
         anyhow::{self, anyhow, bail, ensure, Context},
-        async_trait, debug, error, ethabi, hex, info, retry, serde_json as json, tiny_keccak,
-        trace, warn,
+        async_trait, debug, error, hex, info, retry, serde_json as json, tiny_keccak, trace, warn,
         web3::{
             self,
             types::{
@@ -664,9 +663,10 @@ impl EthereumAdapter {
 
                         match bytes.len() >= 4 && &bytes[..4] == solidity_revert_function_selector {
                             false => None,
-                            true => ethabi::decode(&[ParamType::String], &bytes[4..])
+                            true => abi::DynSolType::String
+                                .abi_decode(&bytes[4..])
                                 .ok()
-                                .and_then(|tokens| tokens[0].clone().into_string()),
+                                .and_then(|val| val.clone().as_str().map(ToOwned::to_owned)),
                         }
                     };
 
@@ -1550,7 +1550,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
         logger: &Logger,
         inp_call: &ContractCall,
         cache: Arc<dyn EthereumCallCache>,
-    ) -> Result<(Option<Vec<Token>>, call::Source), ContractCallError> {
+    ) -> Result<(Option<Vec<abi::DynSolValue>>, call::Source), ContractCallError> {
         let mut result = self.contract_calls(logger, &[inp_call], cache).await?;
         // unwrap: self.contract_calls returns as many results as there were calls
         Ok(result.pop().unwrap())
@@ -1561,20 +1561,26 @@ impl EthereumAdapterTrait for EthereumAdapter {
         logger: &Logger,
         calls: &[&ContractCall],
         cache: Arc<dyn EthereumCallCache>,
-    ) -> Result<Vec<(Option<Vec<Token>>, call::Source)>, ContractCallError> {
+    ) -> Result<Vec<(Option<Vec<abi::DynSolValue>>, call::Source)>, ContractCallError> {
         fn as_req(
             logger: &Logger,
             call: &ContractCall,
             index: u32,
         ) -> Result<call::Request, ContractCallError> {
             // Emit custom error for type mismatches.
-            for (token, kind) in call
+            for (val, kind) in call
                 .args
                 .iter()
-                .zip(call.function.inputs.iter().map(|p| &p.kind))
+                .zip(call.function.inputs.iter().map(|p| p.selector_type()))
             {
-                if !token.type_check(kind) {
-                    return Err(ContractCallError::TypeError(token.clone(), kind.clone()));
+                let kind: abi::DynSolType = kind.parse().map_err(|err| {
+                    ContractCallError::ABIError(anyhow!(
+                        "failed to parse function input type '{kind}': {err}"
+                    ))
+                })?;
+
+                if !val.type_check(&kind) {
+                    return Err(ContractCallError::TypeError(val.clone(), kind.clone()));
                 }
             }
 
@@ -1582,8 +1588,8 @@ impl EthereumAdapterTrait for EthereumAdapter {
             let req = {
                 let encoded_call = call
                     .function
-                    .encode_input(&call.args)
-                    .map_err(ContractCallError::EncodingError)?;
+                    .abi_encode_input(&call.args)
+                    .map_err(|err| ContractCallError::EncodingError(err.into()))?;
                 call::Request::new(call.address, encoded_call, index)
             };
 
@@ -1601,7 +1607,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
             logger: &Logger,
             resp: call::Response,
             call: &ContractCall,
-        ) -> (Option<Vec<Token>>, call::Source) {
+        ) -> (Option<Vec<abi::DynSolValue>>, call::Source) {
             let call::Response {
                 retval,
                 source,
@@ -1609,7 +1615,7 @@ impl EthereumAdapterTrait for EthereumAdapter {
             } = resp;
             use call::Retval::*;
             match retval {
-                Value(output) => match call.function.decode_output(&output) {
+                Value(output) => match call.function.abi_decode_output(&output) {
                     Ok(tokens) => (Some(tokens), source),
                     Err(e) => {
                         // Decode failures are reverts. The reasoning is that if Solidity fails to
@@ -2664,9 +2670,9 @@ mod tests {
         EthereumBlockWithCalls,
     };
     use graph::blockchain::BlockPtr;
-    use graph::prelude::ethabi::ethereum_types::U64;
     use graph::prelude::tokio::{self};
     use graph::prelude::web3::transports::test::TestTransport;
+    use graph::prelude::web3::types::U64;
     use graph::prelude::web3::types::{Address, Block, Bytes, H256};
     use graph::prelude::web3::Web3;
     use graph::prelude::EthereumCall;

--- a/chain/ethereum/src/ingestor.rs
+++ b/chain/ethereum/src/ingestor.rs
@@ -9,8 +9,8 @@ use graph::{
     blockchain::{BlockHash, BlockIngestor, BlockPtr, IngestorError},
     cheap_clone::CheapClone,
     prelude::{
-        async_trait, error, ethabi::ethereum_types::H256, info, tokio, trace, warn, ChainStore,
-        Error, EthereumBlockWithCalls, LogCode, Logger,
+        async_trait, error, info, tokio, trace, warn, web3::types::H256, ChainStore, Error,
+        EthereumBlockWithCalls, LogCode, Logger,
     },
 };
 use std::{sync::Arc, time::Duration};

--- a/chain/ethereum/src/runtime/abi.rs
+++ b/chain/ethereum/src/runtime/abi.rs
@@ -2,9 +2,9 @@ use super::runtime_adapter::UnresolvedContractCall;
 use crate::trigger::{
     EthereumBlockData, EthereumCallData, EthereumEventData, EthereumTransactionData,
 };
+use graph::abi;
 use graph::{
     prelude::{
-        ethabi,
         web3::types::{Log, TransactionReceipt, H256},
         BigInt,
     },
@@ -37,7 +37,7 @@ impl AscType for AscLogParamArray {
     }
 }
 
-impl ToAscObj<AscLogParamArray> for &[ethabi::LogParam] {
+impl ToAscObj<AscLogParamArray> for &[abi::DynSolParam] {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,
@@ -778,7 +778,7 @@ impl<'a> ToAscObj<AscEthereumCall_0_0_3<AscEthereumTransaction_0_0_6, AscEthereu
     }
 }
 
-impl ToAscObj<AscLogParam> for ethabi::LogParam {
+impl ToAscObj<AscLogParam> for abi::DynSolParam {
     fn to_asc_obj<H: AscHeap + ?Sized>(
         &self,
         heap: &mut H,

--- a/chain/ethereum/src/runtime/runtime_adapter.rs
+++ b/chain/ethereum/src/runtime/runtime_adapter.rs
@@ -7,6 +7,8 @@ use crate::{
 };
 use anyhow::{anyhow, Context, Error};
 use blockchain::HostFn;
+use graph::abi;
+use graph::abi::DynSolValueExt;
 use graph::blockchain::ChainIdentifier;
 use graph::components::subgraph::HostMetrics;
 use graph::data::store::ethereum::call;
@@ -14,6 +16,7 @@ use graph::data::store::scalar::BigInt;
 use graph::data::subgraph::API_VERSION_0_0_9;
 use graph::data_source;
 use graph::data_source::common::{ContractCall, MappingABI};
+use graph::prelude::web3::types::Address;
 use graph::prelude::web3::types::H160;
 use graph::runtime::gas::Gas;
 use graph::runtime::{AscIndexId, IndexForAscTypeId};
@@ -21,10 +24,7 @@ use graph::slog::debug;
 use graph::{
     blockchain::{self, BlockPtr, HostFnCtx},
     cheap_clone::CheapClone,
-    prelude::{
-        ethabi::{self, Address, Token},
-        EthereumCallCache,
-    },
+    prelude::EthereumCallCache,
     runtime::{asc_get, asc_new, AscPtr, HostExportError},
     semver::Version,
     slog::Logger,
@@ -283,20 +283,7 @@ fn eth_call(
     abis: &[Arc<MappingABI>],
     eth_call_gas: Option<u32>,
     metrics: Arc<HostMetrics>,
-) -> Result<Option<Vec<Token>>, HostExportError> {
-    // Helpers to log the result of the call at the end
-    fn tokens_as_string(tokens: &[Token]) -> String {
-        tokens.iter().map(|arg| arg.to_string()).join(", ")
-    }
-
-    fn result_as_string(result: &Result<Option<Vec<Token>>, HostExportError>) -> String {
-        match result {
-            Ok(Some(tokens)) => format!("({})", tokens_as_string(&tokens)),
-            Ok(None) => "none".to_string(),
-            Err(_) => "error".to_string(),
-        }
-    }
-
+) -> Result<Option<Vec<abi::DynSolValue>>, HostExportError> {
     let start_time = Instant::now();
 
     // Obtain the path to the contract ABI
@@ -375,16 +362,26 @@ fn eth_call(
         );
     }
 
-    debug!(logger, "Contract call finished";
-              "address" => format!("0x{:x}", &unresolved_call.contract_address),
-              "contract" => &unresolved_call.contract_name,
-              "signature" => &unresolved_call.function_signature,
-              "args" => format!("[{}]", tokens_as_string(&unresolved_call.function_args)),
-              "time_ms" => format!("{}ms", elapsed.as_millis()),
-              "result" => result_as_string(&result),
-              "block_hash" => block_ptr.hash_hex(),
-              "block_number" => block_ptr.block_number(),
-              "source" => source.to_string());
+    let args_as_string = format!("[{}]", values_to_string(&unresolved_call.function_args));
+
+    let result_as_string = match &result {
+        Ok(Some(values)) => format!("({})", values_to_string(values)),
+        Ok(None) => "none".to_owned(),
+        Err(_err) => "error".to_owned(),
+    };
+
+    debug!(
+        logger, "Contract call finished";
+        "address" => format!("0x{:x}", &unresolved_call.contract_address),
+        "contract" => &unresolved_call.contract_name,
+        "signature" => &unresolved_call.function_signature,
+        "args" => args_as_string,
+        "time_ms" => format!("{}ms", elapsed.as_millis()),
+        "result" => result_as_string,
+        "block_hash" => block_ptr.hash_hex(),
+        "block_number" => block_ptr.block_number(),
+        "source" => source.to_string(),
+    );
 
     result
 }
@@ -395,9 +392,18 @@ pub struct UnresolvedContractCall {
     pub contract_address: Address,
     pub function_name: String,
     pub function_signature: Option<String>,
-    pub function_args: Vec<ethabi::Token>,
+    pub function_args: Vec<abi::DynSolValue>,
 }
 
 impl AscIndexId for AscUnresolvedContractCall {
     const INDEX_ASC_TYPE_ID: IndexForAscTypeId = IndexForAscTypeId::SmartContractCall;
+}
+
+#[inline]
+fn values_to_string(values: &[abi::DynSolValue]) -> String {
+    values
+        .iter()
+        .map(|x| x.to_string())
+        .collect_vec()
+        .join(", ")
 }

--- a/chain/ethereum/src/trigger.rs
+++ b/chain/ethereum/src/trigger.rs
@@ -1,20 +1,20 @@
+use graph::abi;
 use graph::blockchain::MappingTriggerTrait;
 use graph::blockchain::TriggerData;
 use graph::data::subgraph::API_VERSION_0_0_2;
 use graph::data::subgraph::API_VERSION_0_0_6;
 use graph::data::subgraph::API_VERSION_0_0_7;
 use graph::data_source::common::DeclaredCall;
-use graph::prelude::ethabi::ethereum_types::H160;
-use graph::prelude::ethabi::ethereum_types::H256;
-use graph::prelude::ethabi::ethereum_types::U128;
-use graph::prelude::ethabi::ethereum_types::U256;
-use graph::prelude::ethabi::ethereum_types::U64;
-use graph::prelude::ethabi::Address;
-use graph::prelude::ethabi::LogParam;
+use graph::prelude::web3::types::Address;
 use graph::prelude::web3::types::Block;
 use graph::prelude::web3::types::Log;
 use graph::prelude::web3::types::Transaction;
 use graph::prelude::web3::types::TransactionReceipt;
+use graph::prelude::web3::types::H160;
+use graph::prelude::web3::types::H256;
+use graph::prelude::web3::types::U128;
+use graph::prelude::web3::types::U256;
+use graph::prelude::web3::types::U64;
 use graph::prelude::BlockNumber;
 use graph::prelude::BlockPtr;
 use graph::prelude::{CheapClone, EthereumCall};
@@ -47,7 +47,7 @@ pub enum MappingTrigger {
         block: Arc<LightEthereumBlock>,
         transaction: Arc<Transaction>,
         log: Arc<Log>,
-        params: Vec<LogParam>,
+        params: Vec<abi::DynSolParam>,
         receipt: Option<Arc<TransactionReceipt>>,
         calls: Vec<DeclaredCall>,
     },
@@ -55,8 +55,8 @@ pub enum MappingTrigger {
         block: Arc<LightEthereumBlock>,
         transaction: Arc<Transaction>,
         call: Arc<EthereumCall>,
-        inputs: Vec<LogParam>,
-        outputs: Vec<LogParam>,
+        inputs: Vec<abi::DynSolParam>,
+        outputs: Vec<abi::DynSolParam>,
     },
     Block {
         block: Arc<LightEthereumBlock>,
@@ -64,7 +64,7 @@ pub enum MappingTrigger {
 }
 
 impl MappingTriggerTrait for MappingTrigger {
-    fn error_context(&self) -> std::string::String {
+    fn error_context(&self) -> String {
         let transaction_id = match self {
             MappingTrigger::Log { log, .. } => log.transaction_hash,
             MappingTrigger::Call { call, .. } => call.transaction_hash,
@@ -86,13 +86,13 @@ impl std::fmt::Debug for MappingTrigger {
             Log {
                 _transaction: Arc<Transaction>,
                 _log: Arc<Log>,
-                _params: Vec<LogParam>,
+                _params: Vec<abi::DynSolParam>,
             },
             Call {
                 _transaction: Arc<Transaction>,
                 _call: Arc<EthereumCall>,
-                _inputs: Vec<LogParam>,
-                _outputs: Vec<LogParam>,
+                _inputs: Vec<abi::DynSolParam>,
+                _outputs: Vec<abi::DynSolParam>,
             },
             Block,
         }
@@ -544,7 +544,7 @@ impl<'a> EthereumTransactionData<'a> {
 pub struct EthereumEventData<'a> {
     pub block: EthereumBlockData<'a>,
     pub transaction: EthereumTransactionData<'a>,
-    pub params: &'a [LogParam],
+    pub params: &'a [abi::DynSolParam],
     log: &'a Log,
 }
 
@@ -553,7 +553,7 @@ impl<'a> EthereumEventData<'a> {
         block: &'a Block<Transaction>,
         tx: &'a Transaction,
         log: &'a Log,
-        params: &'a [LogParam],
+        params: &'a [abi::DynSolParam],
     ) -> Self {
         EthereumEventData {
             block: EthereumBlockData::from(block),
@@ -588,8 +588,8 @@ impl<'a> EthereumEventData<'a> {
 pub struct EthereumCallData<'a> {
     pub block: EthereumBlockData<'a>,
     pub transaction: EthereumTransactionData<'a>,
-    pub inputs: &'a [LogParam],
-    pub outputs: &'a [LogParam],
+    pub inputs: &'a [abi::DynSolParam],
+    pub outputs: &'a [abi::DynSolParam],
     call: &'a EthereumCall,
 }
 
@@ -598,8 +598,8 @@ impl<'a> EthereumCallData<'a> {
         block: &'a Block<Transaction>,
         transaction: &'a Transaction,
         call: &'a EthereumCall,
-        inputs: &'a [LogParam],
-        outputs: &'a [LogParam],
+        inputs: &'a [abi::DynSolParam],
+        outputs: &'a [abi::DynSolParam],
     ) -> EthereumCallData<'a> {
         EthereumCallData {
             block: EthereumBlockData::from(block),

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+alloy = { workspace = true }
 base64 = "=0.21.7"
 anyhow = "1.0"
 async-trait = "0.1.74"
@@ -26,7 +27,7 @@ chrono = "0.4.38"
 envconfig = "0.11.0"
 Inflector = "0.11.3"
 isatty = "0.1.9"
-reqwest = { version = "0.12.15", features = ["json", "stream", "multipart"] }
+reqwest = { version = "0.12.5", features = ["json", "stream", "multipart"] }
 ethabi = "17.2"
 hex = "0.4.3"
 http0 = { version = "0", package = "http" }

--- a/graph/src/abi/event_ext.rs
+++ b/graph/src/abi/event_ext.rs
@@ -1,0 +1,142 @@
+use alloy::json_abi::Event;
+use alloy::primitives::LogData;
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
+use itertools::Itertools;
+use web3::types::Log;
+
+use crate::abi::DynSolParam;
+
+pub trait EventExt {
+    fn decode_log(&self, log: &Log) -> Result<Vec<DynSolParam>>;
+}
+
+impl EventExt for Event {
+    fn decode_log(&self, log: &Log) -> Result<Vec<DynSolParam>> {
+        let log_data = log_to_log_data(log)?;
+        let decoded_event = alloy::dyn_abi::EventExt::decode_log(self, &log_data, true)?;
+
+        if self.inputs.len() != decoded_event.indexed.len() + decoded_event.body.len() {
+            return Err(anyhow!(
+                "unexpected number of decoded event inputs; expected {}, got {}",
+                self.inputs.len(),
+                decoded_event.indexed.len() + decoded_event.body.len(),
+            ));
+        }
+
+        let decoded_params = decoded_event
+            .indexed
+            .into_iter()
+            .chain(decoded_event.body.into_iter())
+            .enumerate()
+            .map(|(i, value)| DynSolParam {
+                name: self.inputs[i].name.clone(),
+                value,
+            })
+            .collect();
+
+        Ok(decoded_params)
+    }
+}
+
+fn log_to_log_data(log: &Log) -> Result<LogData> {
+    let topics = log
+        .topics
+        .iter()
+        .map(|x| x.to_fixed_bytes().into())
+        .collect_vec();
+
+    let data = log.data.0.clone().into();
+
+    LogData::new(topics, data).context("log has an invalid number of topics")
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::dyn_abi::DynSolValue;
+    use alloy::primitives::U256;
+
+    use super::*;
+
+    fn make_log(topics: &[[u8; 32]], data: Vec<u8>) -> Log {
+        Log {
+            address: [1; 20].into(),
+            topics: topics.iter().map(Into::into).collect(),
+            data: data.into(),
+            block_hash: None,
+            block_number: None,
+            transaction_hash: None,
+            transaction_index: None,
+            log_index: None,
+            transaction_log_index: None,
+            log_type: None,
+            removed: None,
+        }
+    }
+
+    #[test]
+    fn decode_log_no_topic_0() {
+        let event = Event::parse("event X(uint256 indexed a, bytes32 b)").unwrap();
+        let a = U256::from(10).to_be_bytes::<32>();
+        let b = DynSolValue::FixedBytes([10; 32].into(), 32).abi_encode();
+
+        let log = make_log(&[a], b);
+        let err = event.decode_log(&log).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "invalid log topic list length: expected 2 topics, got 1",
+        );
+    }
+
+    #[test]
+    fn decode_log_invalid_topic_0() {
+        let event = Event::parse("event X(uint256 indexed a, bytes32 b)").unwrap();
+        let a = U256::from(10).to_be_bytes::<32>();
+        let b = DynSolValue::FixedBytes([10; 32].into(), 32).abi_encode();
+
+        let log = make_log(&[[0; 32], a], b);
+        let err = event.decode_log(&log).unwrap_err();
+
+        assert!(err.to_string().starts_with("invalid event signature:"));
+    }
+
+    #[test]
+    fn decode_log_success() {
+        let event = Event::parse("event X(uint256 indexed a, bytes32 b)").unwrap();
+        let topic_0 = event.selector().0;
+        let a = U256::from(10).to_be_bytes::<32>();
+        let b = DynSolValue::FixedBytes([10; 32].into(), 32).abi_encode();
+
+        let log = make_log(&[topic_0, a], b);
+        let resp = event.decode_log(&log).unwrap();
+
+        assert_eq!(
+            resp,
+            vec![
+                DynSolParam {
+                    name: "a".to_owned(),
+                    value: DynSolValue::Uint(U256::from(10), 256),
+                },
+                DynSolParam {
+                    name: "b".to_owned(),
+                    value: DynSolValue::FixedBytes([10; 32].into(), 32),
+                }
+            ],
+        );
+    }
+
+    #[test]
+    fn decode_log_too_many_topics() {
+        let event = Event::parse("event X(uint256 indexed a, bytes32 b)").unwrap();
+        let topic_0 = event.selector().0;
+        let a = U256::from(10).to_be_bytes::<32>();
+        let b = DynSolValue::FixedBytes([10; 32].into(), 32).abi_encode();
+
+        let log = make_log(&[topic_0, a, a, a, a], b);
+        let err = event.decode_log(&log).unwrap_err();
+
+        assert_eq!(err.to_string(), "log has an invalid number of topics");
+    }
+}

--- a/graph/src/abi/function_ext.rs
+++ b/graph/src/abi/function_ext.rs
@@ -1,0 +1,303 @@
+use std::borrow::Cow;
+
+use alloy::dyn_abi::DynSolType;
+use alloy::dyn_abi::DynSolValue;
+use alloy::dyn_abi::Specifier;
+use alloy::json_abi::Function;
+use alloy::json_abi::Param;
+use anyhow::anyhow;
+use anyhow::Result;
+use itertools::Itertools;
+
+use crate::abi::DynSolValueExt;
+
+pub trait FunctionExt {
+    /// Returns the signature of this function in the following formats:
+    /// - if the function has no outputs: `$name($($inputs),*)`
+    /// - if the function has outputs: `$name($($inputs),*):($(outputs),*)`
+    ///
+    /// Examples:
+    /// - `functionName()`
+    /// - `functionName():(uint256)`
+    /// - `functionName(bool):(uint256,string)`
+    /// - `functionName(uint256,bytes32):(string,uint256)`
+    fn signature_compat(&self) -> String;
+
+    /// ABI-decodes the given data according to the function's input types.
+    fn abi_decode_input(&self, data: &[u8]) -> Result<Vec<DynSolValue>>;
+
+    /// ABI-decodes the given data according to the function's output types.
+    fn abi_decode_output(&self, data: &[u8]) -> Result<Vec<DynSolValue>>;
+
+    /// ABI-encodes the given values, prefixed by the function's selector, if any.
+    ///
+    /// This behaviour is to ensure consistency with `ethabi`.
+    fn abi_encode_input(&self, values: &[DynSolValue]) -> Result<Vec<u8>>;
+}
+
+impl FunctionExt for Function {
+    fn signature_compat(&self) -> String {
+        let name = &self.name;
+        let inputs = &self.inputs;
+        let outputs = &self.outputs;
+
+        // This is what `alloy` uses internally when creating signatures.
+        const MAX_SOL_TYPE_LEN: usize = 32;
+
+        let mut sig_cap = name.len() + 1 + inputs.len() * MAX_SOL_TYPE_LEN + 1;
+
+        if !outputs.is_empty() {
+            sig_cap = sig_cap + 2 + outputs.len() * MAX_SOL_TYPE_LEN + 1;
+        }
+
+        let mut sig = String::with_capacity(sig_cap);
+
+        sig.push_str(&name);
+        signature_part(&inputs, &mut sig);
+
+        if !outputs.is_empty() {
+            sig.push(':');
+            signature_part(&outputs, &mut sig);
+        }
+
+        sig
+    }
+
+    fn abi_decode_input(&self, data: &[u8]) -> Result<Vec<DynSolValue>> {
+        (self as &dyn alloy::dyn_abi::FunctionExt)
+            .abi_decode_input(data, true)
+            .map_err(Into::into)
+    }
+
+    fn abi_decode_output(&self, data: &[u8]) -> Result<Vec<DynSolValue>> {
+        (self as &dyn alloy::dyn_abi::FunctionExt)
+            .abi_decode_output(data, true)
+            .map_err(Into::into)
+    }
+
+    fn abi_encode_input(&self, values: &[DynSolValue]) -> Result<Vec<u8>> {
+        let inputs = &self.inputs;
+
+        if inputs.len() != values.len() {
+            return Err(anyhow!(
+                "unexpected number of values; expected {}, got {}",
+                inputs.len(),
+                values.len(),
+            ));
+        }
+
+        let mut fixed_values = Vec::with_capacity(values.len());
+
+        for (i, input) in inputs.iter().enumerate() {
+            let ty = input.resolve()?;
+            let val = &values[i];
+
+            fixed_values.push(fix_type_size(&ty, val)?);
+        }
+
+        if fixed_values.iter().all(|x| matches!(x, Cow::Borrowed(_))) {
+            return (self as &dyn alloy::dyn_abi::JsonAbiExt)
+                .abi_encode_input(values)
+                .map_err(Into::into);
+        }
+
+        // Required because of `alloy::dyn_abi::JsonAbiExt::abi_encode_input` API;
+        let owned_fixed_values = fixed_values
+            .into_iter()
+            .map(|x| x.into_owned())
+            .collect_vec();
+
+        (self as &dyn alloy::dyn_abi::JsonAbiExt)
+            .abi_encode_input(&owned_fixed_values)
+            .map_err(Into::into)
+    }
+}
+
+// An efficient way to compute a part of the signature without new allocations.
+fn signature_part(params: &[Param], out: &mut String) {
+    out.push('(');
+
+    match params.len() {
+        0 => {}
+        1 => {
+            params[0].selector_type_raw(out);
+        }
+        n => {
+            params[0].selector_type_raw(out);
+
+            for i in 1..n {
+                out.push(',');
+                params[i].selector_type_raw(out);
+            }
+        }
+    }
+
+    out.push(')');
+}
+
+// Alloy is stricter in type checking than `ehtabi` and requires that the decoded values have
+// exactly the same number of bits / bytes as the type used for checking.
+//
+// This is a problem because in some ASC conversions we lose the original number of bits / bytes
+// if the actual data takes less memory.
+//
+// This method fixes that in a simple but not very cheap way, by encoding the value and trying
+// to decode it again using the given type. The result fixes the number of bits / bytes in the
+// decoded values, so we can use `alloy` methods that have strict type checking internally.
+fn fix_type_size<'a>(ty: &DynSolType, val: &'a DynSolValue) -> Result<Cow<'a, DynSolValue>> {
+    if val.matches(ty) {
+        return Ok(Cow::Borrowed(val));
+    }
+
+    if !val.type_check(ty) {
+        return Err(anyhow!(
+            "invalid value type; expected '{}', got '{:?}'",
+            ty.sol_type_name(),
+            val.sol_type_name(),
+        ));
+    }
+
+    let bytes = val.abi_encode();
+    let new_val = ty.abi_decode(&bytes)?;
+
+    Ok(Cow::Owned(new_val))
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::I256;
+    use alloy::primitives::U256;
+
+    use super::*;
+
+    fn s(f: &str) -> String {
+        Function::parse(f).unwrap().signature_compat()
+    }
+
+    fn u256(u: u64) -> U256 {
+        U256::from(u)
+    }
+
+    fn i256(i: i32) -> I256 {
+        I256::try_from(i).unwrap()
+    }
+
+    #[test]
+    fn signature_compat_no_inputs_no_outputs() {
+        assert_eq!(s("x()"), "x()");
+    }
+
+    #[test]
+    fn signature_compat_one_input_no_outputs() {
+        assert_eq!(s("x(uint256 a)"), "x(uint256)");
+    }
+
+    #[test]
+    fn signature_compat_multiple_inputs_no_outputs() {
+        assert_eq!(s("x(uint256 a, bytes32 b)"), "x(uint256,bytes32)");
+    }
+
+    #[test]
+    fn signature_compat_no_inputs_one_output() {
+        assert_eq!(s("x() returns (uint256)"), "x():(uint256)");
+    }
+
+    #[test]
+    fn signature_compat_no_inputs_multiple_outputs() {
+        assert_eq!(s("x() returns (uint256, bytes32)"), "x():(uint256,bytes32)");
+    }
+
+    #[test]
+    fn signature_compat_multiple_inputs_multiple_outputs() {
+        assert_eq!(
+            s("x(bytes32 a, uint256 b) returns (uint256, bytes32)"),
+            "x(bytes32,uint256):(uint256,bytes32)",
+        );
+    }
+
+    #[test]
+    fn abi_decode_input() {
+        use DynSolValue::{Int, Tuple, Uint};
+
+        let f = Function::parse("x(uint256 a, int256 b)").unwrap();
+        let data = Tuple(vec![Uint(u256(10), 256), Int(i256(-10), 256)]).abi_encode_params();
+        let inputs = f.abi_decode_input(&data).unwrap();
+
+        assert_eq!(inputs, vec![Uint(u256(10), 256), Int(i256(-10), 256)]);
+    }
+
+    #[test]
+    fn abi_decode_output() {
+        use DynSolValue::{Int, Tuple, Uint};
+
+        let f = Function::parse("x() returns (uint256 a, int256 b)").unwrap();
+        let data = Tuple(vec![Uint(u256(10), 256), Int(i256(-10), 256)]).abi_encode_params();
+        let outputs = f.abi_decode_output(&data).unwrap();
+
+        assert_eq!(outputs, vec![Uint(u256(10), 256), Int(i256(-10), 256)]);
+    }
+
+    #[test]
+    fn abi_encode_input_no_values() {
+        let f = Function::parse("x(uint256 a, int256 b)").unwrap();
+        let err = f.abi_encode_input(&[]).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "unexpected number of values; expected 2, got 0",
+        );
+    }
+
+    #[test]
+    fn abi_encode_input_too_many_values() {
+        use DynSolValue::Bool;
+
+        let f = Function::parse("x(uint256 a, int256 b)").unwrap();
+
+        let err = f
+            .abi_encode_input(&[Bool(true), Bool(false), Bool(true)])
+            .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "unexpected number of values; expected 2, got 3",
+        );
+    }
+
+    #[test]
+    fn abi_encode_input_invalid_types() {
+        use DynSolValue::Bool;
+
+        let f = Function::parse("x(uint256 a, int256 b)").unwrap();
+        let err = f.abi_encode_input(&[Bool(true), Bool(false)]).unwrap_err();
+        assert!(err.to_string().starts_with("invalid value type;"));
+    }
+
+    #[test]
+    fn abi_encode_success() {
+        use DynSolValue::{Bool, Uint};
+
+        let f = Function::parse("x(uint256 a, bool b)").unwrap();
+        let a = Uint(u256(10), 256);
+        let b = Bool(true);
+
+        let data = f.abi_encode_input(&[a.clone(), b.clone()]).unwrap();
+        let inputs = f.abi_decode_input(&data[4..]).unwrap();
+
+        assert_eq!(inputs, vec![a, b]);
+    }
+
+    #[test]
+    fn abi_encode_success_with_size_fix() {
+        use DynSolValue::{Int, Uint};
+
+        let f = Function::parse("x(uint256 a, int256 b)").unwrap();
+        let a = Uint(u256(10), 32);
+        let b = Int(i256(-10), 32);
+
+        let data = f.abi_encode_input(&[a, b]).unwrap();
+        let inputs = f.abi_decode_input(&data[4..]).unwrap();
+
+        assert_eq!(inputs, vec![Uint(u256(10), 256), Int(i256(-10), 256)]);
+    }
+}

--- a/graph/src/abi/mod.rs
+++ b/graph/src/abi/mod.rs
@@ -1,0 +1,20 @@
+mod event_ext;
+mod function_ext;
+mod param;
+mod value_ext;
+
+pub use alloy::dyn_abi::DynSolType;
+pub use alloy::dyn_abi::DynSolValue;
+
+pub use alloy::json_abi::Event;
+pub use alloy::json_abi::Function;
+pub use alloy::json_abi::JsonAbi;
+pub use alloy::json_abi::StateMutability;
+
+pub use alloy::primitives::I256;
+pub use alloy::primitives::U256;
+
+pub use self::event_ext::EventExt;
+pub use self::function_ext::FunctionExt;
+pub use self::param::DynSolParam;
+pub use self::value_ext::DynSolValueExt;

--- a/graph/src/abi/param.rs
+++ b/graph/src/abi/param.rs
@@ -1,0 +1,7 @@
+use alloy::dyn_abi::DynSolValue;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DynSolParam {
+    pub name: String,
+    pub value: DynSolValue,
+}

--- a/graph/src/abi/value_ext.rs
+++ b/graph/src/abi/value_ext.rs
@@ -1,0 +1,277 @@
+use alloy::dyn_abi::DynSolType;
+use alloy::dyn_abi::DynSolValue;
+use anyhow::anyhow;
+use anyhow::Result;
+use itertools::Itertools;
+
+pub trait DynSolValueExt {
+    /// Creates a fixed-byte decoded value from a slice.
+    ///
+    /// Fails if the source slice exceeds 32 bytes.
+    fn fixed_bytes_from_slice(s: &[u8]) -> Result<DynSolValue>;
+
+    /// Returns the decoded value as a string.
+    ///
+    /// The resulting string contains no type information.
+    fn to_string(&self) -> String;
+
+    /// Checks whether the value is of the specified type.
+    ///
+    /// For types with additional size information, returns true if the size of the value is less
+    /// than or equal to the size of the specified type.
+    #[must_use]
+    fn type_check(&self, ty: &DynSolType) -> bool;
+}
+
+impl DynSolValueExt for DynSolValue {
+    fn fixed_bytes_from_slice(s: &[u8]) -> Result<Self> {
+        let num_bytes = s.len();
+
+        if num_bytes > 32 {
+            return Err(anyhow!(
+                "input slice must contain a maximum of 32 bytes, got {num_bytes}"
+            ));
+        }
+
+        let mut bytes = [0u8; 32];
+
+        // Access: If `x` is of type `bytesI`, then `x[k]` for `0 <= k < I` returns the `k`th byte.
+        // Ref: <https://docs.soliditylang.org/en/v0.8.28/types.html#fixed-size-byte-arrays>
+        bytes[..num_bytes].copy_from_slice(s);
+
+        Ok(Self::FixedBytes(bytes.into(), num_bytes))
+    }
+
+    fn to_string(&self) -> String {
+        let s = |v: &[Self]| v.iter().map(|x| x.to_string()).collect_vec().join(",");
+
+        // Output format is taken from `ethabi`;
+        // See: <https://docs.rs/ethabi/18.0.0/ethabi/enum.Token.html#impl-Display-for-Token>
+        match self {
+            Self::Bool(v) => v.to_string(),
+            Self::Int(v, _) => format!("{v:x}"),
+            Self::Uint(v, _) => format!("{v:x}"),
+            Self::FixedBytes(v, _) => hex::encode(v),
+            Self::Address(v) => format!("{v:x}"),
+            Self::Function(v) => format!("{v:x}"),
+            Self::Bytes(v) => hex::encode(v),
+            Self::String(v) => v.to_owned(),
+            Self::Array(v) => format!("[{}]", s(v)),
+            Self::FixedArray(v) => format!("[{}]", s(v)),
+            Self::Tuple(v) => format!("({})", s(v)),
+        }
+    }
+
+    fn type_check(&self, ty: &DynSolType) -> bool {
+        match self {
+            Self::Bool(_) => *ty == DynSolType::Bool,
+            Self::Int(_, a) => {
+                if let DynSolType::Int(b) = ty {
+                    b >= a
+                } else {
+                    false
+                }
+            }
+            Self::Uint(_, a) => {
+                if let DynSolType::Uint(b) = ty {
+                    b >= a
+                } else {
+                    false
+                }
+            }
+            Self::FixedBytes(_, a) => {
+                if let DynSolType::FixedBytes(b) = ty {
+                    b >= a
+                } else {
+                    false
+                }
+            }
+            Self::Address(_) => *ty == DynSolType::Address,
+            Self::Function(_) => *ty == DynSolType::Function,
+            Self::Bytes(_) => *ty == DynSolType::Bytes,
+            Self::String(_) => *ty == DynSolType::String,
+            Self::Array(values) => {
+                if let DynSolType::Array(ty) = ty {
+                    values.iter().all(|x| x.type_check(ty))
+                } else {
+                    false
+                }
+            }
+            Self::FixedArray(values) => {
+                if let DynSolType::FixedArray(ty, size) = ty {
+                    *size == values.len() && values.iter().all(|x| x.type_check(ty))
+                } else {
+                    false
+                }
+            }
+            Self::Tuple(values) => {
+                if let DynSolType::Tuple(types) = ty {
+                    types.len() == values.len()
+                        && values
+                            .iter()
+                            .enumerate()
+                            .all(|(i, x)| x.type_check(&types[i]))
+                } else {
+                    false
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::I256;
+    use alloy::primitives::U256;
+
+    use super::*;
+
+    #[test]
+    fn fixed_bytes_from_slice_empty_slice() {
+        let val = DynSolValue::fixed_bytes_from_slice(&[]).unwrap();
+        let bytes = [0; 32];
+
+        assert_eq!(val, DynSolValue::FixedBytes(bytes.into(), 0));
+    }
+
+    #[test]
+    fn fixed_bytes_from_slice_one_byte() {
+        let val = DynSolValue::fixed_bytes_from_slice(&[10]).unwrap();
+        let mut bytes = [0; 32];
+        bytes[0] = 10;
+
+        assert_eq!(val, DynSolValue::FixedBytes(bytes.into(), 1));
+    }
+
+    #[test]
+    fn fixed_bytes_from_slice_multiple_bytes() {
+        let val = DynSolValue::fixed_bytes_from_slice(&[10, 20, 30]).unwrap();
+        let mut bytes = [0; 32];
+        bytes[0] = 10;
+        bytes[1] = 20;
+        bytes[2] = 30;
+
+        assert_eq!(val, DynSolValue::FixedBytes(bytes.into(), 3));
+    }
+
+    #[test]
+    fn fixed_bytes_from_slice_max_bytes() {
+        let val = DynSolValue::fixed_bytes_from_slice(&[10; 32]).unwrap();
+        let bytes = [10; 32];
+
+        assert_eq!(val, DynSolValue::FixedBytes(bytes.into(), 32));
+    }
+
+    #[test]
+    fn fixed_bytes_from_slice_too_many_bytes() {
+        DynSolValue::fixed_bytes_from_slice(&[10; 33]).unwrap_err();
+    }
+
+    #[test]
+    fn to_string() {
+        use DynSolValue::*;
+
+        assert_eq!(Bool(false).to_string(), "false");
+        assert_eq!(Bool(true).to_string(), "true");
+
+        assert_eq!(
+            Int(I256::try_from(-10).unwrap(), 256).to_string(),
+            "fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6",
+        );
+
+        assert_eq!(Uint(U256::from(10), 256).to_string(), "a");
+
+        assert_eq!(
+            FixedBytes([10; 32].into(), 32).to_string(),
+            "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a",
+        );
+
+        assert_eq!(
+            Address([10; 20].into()).to_string(),
+            "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a",
+        );
+
+        assert_eq!(
+            Function([10; 24].into()).to_string(),
+            "0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a",
+        );
+
+        assert_eq!(Bytes(vec![10, 20, 30]).to_string(), "0a141e");
+
+        assert_eq!(
+            String("one two three".to_owned()).to_string(),
+            "one two three"
+        );
+
+        assert_eq!(
+            Array(vec![String("one".to_owned()), String("two".to_owned())]).to_string(),
+            "[one,two]",
+        );
+
+        assert_eq!(
+            FixedArray(vec![String("one".to_owned()), String("two".to_owned())]).to_string(),
+            "[one,two]"
+        );
+
+        assert_eq!(
+            Tuple(vec![String("one".to_owned()), String("two".to_owned())]).to_string(),
+            "(one,two)"
+        );
+    }
+
+    #[test]
+    fn type_check() {
+        use DynSolType as T;
+        use DynSolValue::*;
+
+        assert!(Bool(true).type_check(&T::Bool));
+        assert!(!Bool(true).type_check(&T::Int(256)));
+
+        assert!(!Int(I256::try_from(-10).unwrap(), 32).type_check(&T::Int(24)));
+        assert!(Int(I256::try_from(-10).unwrap(), 32).type_check(&T::Int(32)));
+        assert!(Int(I256::try_from(-10).unwrap(), 32).type_check(&T::Int(256)));
+        assert!(!Int(I256::try_from(-10).unwrap(), 32).type_check(&T::Uint(256)));
+
+        assert!(!Uint(U256::from(10), 32).type_check(&T::Uint(24)));
+        assert!(Uint(U256::from(10), 32).type_check(&T::Uint(32)));
+        assert!(Uint(U256::from(10), 32).type_check(&T::Uint(256)));
+        assert!(!Uint(U256::from(10), 32).type_check(&T::FixedBytes(32)));
+
+        assert!(!FixedBytes([0; 32].into(), 16).type_check(&T::FixedBytes(8)));
+        assert!(FixedBytes([0; 32].into(), 16).type_check(&T::FixedBytes(16)));
+        assert!(FixedBytes([0; 32].into(), 16).type_check(&T::FixedBytes(32)));
+        assert!(!FixedBytes([0; 32].into(), 32).type_check(&T::Address));
+
+        assert!(Address([0; 20].into()).type_check(&T::Address));
+        assert!(!Address([0; 20].into()).type_check(&T::Function));
+
+        assert!(Function([0; 24].into()).type_check(&T::Function));
+        assert!(!Function([0; 24].into()).type_check(&T::Bytes));
+
+        assert!(Bytes(vec![0, 0, 0]).type_check(&T::Bytes));
+        assert!(!Bytes(vec![0, 0, 0]).type_check(&T::String));
+
+        assert!(String("".to_owned()).type_check(&T::String));
+        assert!(!String("".to_owned()).type_check(&T::Array(Box::new(T::Bool))));
+
+        assert!(Array(vec![Bool(true)]).type_check(&T::Array(Box::new(T::Bool))));
+        assert!(!Array(vec![Bool(true)]).type_check(&T::Array(Box::new(T::String))));
+        assert!(!Array(vec![Bool(true)]).type_check(&T::FixedArray(Box::new(T::Bool), 1)));
+
+        assert!(!FixedArray(vec![String("".to_owned())])
+            .type_check(&T::FixedArray(Box::new(T::Bool), 1)));
+        assert!(!FixedArray(vec![Bool(true), Bool(false)])
+            .type_check(&T::FixedArray(Box::new(T::Bool), 1)));
+        assert!(FixedArray(vec![Bool(true), Bool(false)])
+            .type_check(&T::FixedArray(Box::new(T::Bool), 2)));
+        assert!(!FixedArray(vec![Bool(true), Bool(false)])
+            .type_check(&T::FixedArray(Box::new(T::Bool), 3)));
+        assert!(!FixedArray(vec![Bool(true), Bool(false)])
+            .type_check(&T::Tuple(vec![T::Bool, T::Bool])));
+
+        assert!(!Tuple(vec![Bool(true), Bool(false)]).type_check(&T::Tuple(vec![T::Bool])));
+        assert!(Tuple(vec![Bool(true), Bool(false)]).type_check(&T::Tuple(vec![T::Bool, T::Bool])));
+        assert!(!Tuple(vec![Bool(true)]).type_check(&T::Tuple(vec![T::Bool, T::Bool])));
+        assert!(!Tuple(vec![Bool(true)]).type_check(&T::Bool));
+    }
+}

--- a/graph/src/cheap_clone.rs
+++ b/graph/src/cheap_clone.rs
@@ -118,4 +118,4 @@ cheap_clone_is_copy!(
     &'static str,
     std::time::Duration
 );
-cheap_clone_is_copy!(ethabi::Address);
+cheap_clone_is_copy!(web3::types::Address);

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -1133,7 +1133,7 @@ pub struct CachedEthereumCall {
     pub block_ptr: BlockPtr,
 
     /// The address to the called contract.
-    pub contract_address: ethabi::Address,
+    pub contract_address: web3::types::Address,
 
     /// The encoded return value of this call.
     pub return_value: Vec<u8>,

--- a/graph/src/data/store/ethereum.rs
+++ b/graph/src/data/store/ethereum.rs
@@ -104,7 +104,7 @@ pub mod call {
     /// on the call's return value
     #[derive(Debug, Clone, CheapClone)]
     pub struct Request {
-        pub address: ethabi::Address,
+        pub address: web3::types::Address,
         pub encoded_call: Arc<Bytes>,
         /// The index is set by the caller and is used to identify the
         /// request in related data structures that the caller might have
@@ -112,7 +112,7 @@ pub mod call {
     }
 
     impl Request {
-        pub fn new(address: ethabi::Address, encoded_call: Vec<u8>, index: u32) -> Self {
+        pub fn new(address: web3::types::Address, encoded_call: Vec<u8>, index: u32) -> Self {
             Request {
                 address,
                 encoded_call: Arc::new(Bytes::from(encoded_call)),

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -37,8 +37,11 @@ pub mod env;
 
 pub mod ipfs;
 
+pub mod abi;
+
 /// Wrapper for spawning tasks that abort on panic, which is our default.
 mod task_spawn;
+
 pub use task_spawn::{
     block_on, spawn, spawn_allow_panic, spawn_blocking, spawn_blocking_allow_panic, spawn_thread,
 };
@@ -81,7 +84,6 @@ pub mod prelude {
     pub use chrono;
     pub use diesel;
     pub use envconfig;
-    pub use ethabi;
     pub use hex;
     pub use isatty;
     pub use lazy_static::lazy_static;

--- a/runtime/test/src/common.rs
+++ b/runtime/test/src/common.rs
@@ -1,4 +1,3 @@
-use ethabi::Contract;
 use graph::blockchain::BlockTime;
 use graph::components::store::DeploymentLocator;
 use graph::components::subgraph::SharedProofOfIndexing;
@@ -82,7 +81,7 @@ fn mock_host_exports(
 fn mock_abi() -> MappingABI {
     MappingABI {
         name: "mock_abi".to_string(),
-        contract: Contract::load(
+        contract: serde_json::from_str(
             r#"[
             {
                 "inputs": [
@@ -93,8 +92,7 @@ fn mock_abi() -> MappingABI {
                 ],
                 "type": "constructor"
             }
-        ]"#
-            .as_bytes(),
+        ]"#,
         )
         .unwrap(),
     }

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 
 [dependencies]
 async-trait = "0.1.50"
-ethabi = "17.2"
 hex = "0.4.3"
 graph = { path = "../../graph" }
 bs58 = "0.4.0"

--- a/runtime/wasm/src/asc_abi/class.rs
+++ b/runtime/wasm/src/asc_abi/class.rs
@@ -1,5 +1,4 @@
-use ethabi;
-
+use graph::abi;
 use graph::{
     data::store::{self, scalar::Timestamp},
     runtime::{
@@ -535,21 +534,25 @@ pub enum EthereumValueKind {
     FixedArray,
     Array,
     Tuple,
+    Function,
 }
 
 impl EthereumValueKind {
-    pub(crate) fn get_kind(token: &ethabi::Token) -> Self {
-        match token {
-            ethabi::Token::Address(_) => EthereumValueKind::Address,
-            ethabi::Token::FixedBytes(_) => EthereumValueKind::FixedBytes,
-            ethabi::Token::Bytes(_) => EthereumValueKind::Bytes,
-            ethabi::Token::Int(_) => EthereumValueKind::Int,
-            ethabi::Token::Uint(_) => EthereumValueKind::Uint,
-            ethabi::Token::Bool(_) => EthereumValueKind::Bool,
-            ethabi::Token::String(_) => EthereumValueKind::String,
-            ethabi::Token::FixedArray(_) => EthereumValueKind::FixedArray,
-            ethabi::Token::Array(_) => EthereumValueKind::Array,
-            ethabi::Token::Tuple(_) => EthereumValueKind::Tuple,
+    pub(crate) fn get_kind(value: &abi::DynSolValue) -> Self {
+        use graph::abi::DynSolValue;
+
+        match value {
+            DynSolValue::Bool(_) => Self::Bool,
+            DynSolValue::Int(_, _) => Self::Int,
+            DynSolValue::Uint(_, _) => Self::Uint,
+            DynSolValue::FixedBytes(_, _) => Self::FixedBytes,
+            DynSolValue::Address(_) => Self::Address,
+            DynSolValue::Function(_) => Self::Function,
+            DynSolValue::Bytes(_) => Self::Bytes,
+            DynSolValue::String(_) => Self::String,
+            DynSolValue::Array(_) => Self::Array,
+            DynSolValue::FixedArray(_) => Self::FixedArray,
+            DynSolValue::Tuple(_) => Self::Tuple,
         }
     }
 }

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -99,8 +99,8 @@ mod data {
     use graph::blockchain::{Block, BlockHash};
     use graph::data::store::scalar::Bytes;
     use graph::internal_error;
-    use graph::prelude::ethabi::ethereum_types::H160;
     use graph::prelude::transaction_receipt::LightTransactionReceipt;
+    use graph::prelude::web3::types::H160;
     use graph::prelude::web3::types::H256;
     use graph::prelude::{
         serde_json as json, BlockNumber, BlockPtr, CachedEthereumCall, Error, StoreError,

--- a/store/test-store/Cargo.toml
+++ b/store/test-store/Cargo.toml
@@ -19,3 +19,4 @@ prost-types = { workspace = true }
 [dev-dependencies]
 hex = "0.4.3"
 pretty_assertions = "1.4.1"
+serde_json = { workspace = true }

--- a/store/test-store/tests/postgres/store.rs
+++ b/store/test-store/tests/postgres/store.rs
@@ -15,7 +15,6 @@ use graph::data::subgraph::*;
 use graph::{
     blockchain::DataSource,
     components::store::{BlockStore as _, EntityFilter, EntityOrder, EntityQuery, StatusStore},
-    prelude::ethabi::Contract,
 };
 use graph::{data::store::scalar, semver::Version};
 use graph::{entity, prelude::*};
@@ -1059,19 +1058,18 @@ fn mock_data_source() -> graph_chain_ethereum::DataSource {
 fn mock_abi() -> MappingABI {
     MappingABI {
         name: "mock_abi".to_string(),
-        contract: Contract::load(
+        contract: serde_json::from_str(
             r#"[
-            {
-                "inputs": [
-                    {
-                        "name": "a",
-                        "type": "address"
-                    }
-                ],
-                "type": "constructor"
-            }
-        ]"#
-            .as_bytes(),
+                {
+                    "inputs": [
+                        {
+                            "name": "a",
+                            "type": "address"
+                        }
+                    ],
+                    "type": "constructor"
+                }
+            ]"#,
         )
         .unwrap(),
     }

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -34,8 +34,8 @@ use graph::http_body_util::Full;
 use graph::hyper::body::Bytes;
 use graph::hyper::Request;
 use graph::ipfs::IpfsClient;
-use graph::prelude::ethabi::ethereum_types::H256;
 use graph::prelude::serde_json::{self, json};
+use graph::prelude::web3::types::H256;
 use graph::prelude::{
     async_trait, lazy_static, q, r, ApiVersion, BigInt, BlockNumber, DeploymentHash,
     GraphQlRunner as _, IpfsResolver, LoggerFactory, NodeId, QueryError,

--- a/tests/tests/runner_tests.rs
+++ b/tests/tests/runner_tests.rs
@@ -16,8 +16,8 @@ use graph::env::{EnvVars, TEST_WITH_NO_REORG};
 use graph::ipfs;
 use graph::ipfs::test_utils::add_files_to_local_ipfs_node_for_testing;
 use graph::object;
-use graph::prelude::ethabi::ethereum_types::H256;
 use graph::prelude::web3::types::Address;
+use graph::prelude::web3::types::H256;
 use graph::prelude::{
     hex, CheapClone, DeploymentHash, SubgraphAssignmentProvider, SubgraphName, SubgraphStore,
 };


### PR DESCRIPTION
This PR replaces the https://github.com/graphprotocol/graph-node/pull/5692. The original PR cannot be rebased because of the signed-commit requirement.