### PR TITLE
graph: IPFS_MAX_ATTEMPTS ani-smap mechanism env var

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -86,11 +86,11 @@ those.
   may use (in bytes, defaults to 256MB).
 - `GRAPH_MAX_IPFS_CACHE_SIZE`: maximum number of files cached (defaults to 50).
 - `GRAPH_MAX_IPFS_CACHE_FILE_SIZE`: maximum size of each cached file (in bytes, defaults to 1MiB).
-- `GRAPH_IPFS_REQUEST_LIMIT`: Limits the number of requests per second to IPFS for file data sources.
-- `GRAPH_IPFS_MAX_ATTEMPTS`: Safety mechanism to prevent infinite spamming
-  of IPFS servers in the event of logical or unhandled deterministic
-  error (default: 100 000)
-  Defaults to 100.
+- `GRAPH_IPFS_REQUEST_LIMIT`: Limits the number of requests per second to IPFS for file data sources. Defaults to 100.
+- `GRAPH_IPFS_MAX_ATTEMPTS`: This limits the IPFS retry requests in case of a
+  file not found or logical issue working as a safety mechanism to
+  prevent infinite spamming of IPFS servers and network congestion
+  (default: 100 000).
 
 ## GraphQL
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -87,6 +87,9 @@ those.
 - `GRAPH_MAX_IPFS_CACHE_SIZE`: maximum number of files cached (defaults to 50).
 - `GRAPH_MAX_IPFS_CACHE_FILE_SIZE`: maximum size of each cached file (in bytes, defaults to 1MiB).
 - `GRAPH_IPFS_REQUEST_LIMIT`: Limits the number of requests per second to IPFS for file data sources.
+- `GRAPH_IPFS_MAX_ATTEMPTS`: Safety mechanism to prevent infinite spamming
+  of IPFS servers in the event of logical or unhandled deterministic
+  error (default: 100 000)
   Defaults to 100.
 
 ## GraphQL

--- a/graph/src/env/mappings.rs
+++ b/graph/src/env/mappings.rs
@@ -53,6 +53,10 @@ pub struct EnvVarsMapping {
     ///
     /// Set by the environment variable `GRAPH_IPFS_REQUEST_LIMIT`. Defaults to 100.
     pub ipfs_request_limit: u16,
+    /// Limit of max IPFS attempts to retrieve a file.
+    ///
+    /// Set by the environment variable `GRAPH_IPFS_MAX_ATTEMPTS`. Defaults to 100000.
+    pub ipfs_max_attempts: usize,
 
     /// Set by the flag `GRAPH_ALLOW_NON_DETERMINISTIC_IPFS`. Off by
     /// default.
@@ -94,6 +98,7 @@ impl From<InnerMappingHandlers> for EnvVarsMapping {
             max_ipfs_map_file_size: x.max_ipfs_map_file_size.0,
             max_ipfs_file_bytes: x.max_ipfs_file_bytes.0,
             ipfs_request_limit: x.ipfs_request_limit,
+            ipfs_max_attempts: x.ipfs_max_attempts,
             allow_non_deterministic_ipfs: x.allow_non_deterministic_ipfs.0,
             disable_declared_calls: x.disable_declared_calls.0,
             store_errors_are_nondeterministic: x.store_errors_are_nondeterministic.0,
@@ -127,6 +132,8 @@ pub struct InnerMappingHandlers {
     max_ipfs_file_bytes: WithDefaultUsize<usize, { 25 * 1024 * 1024 }>,
     #[envconfig(from = "GRAPH_IPFS_REQUEST_LIMIT", default = "100")]
     ipfs_request_limit: u16,
+    #[envconfig(from = "GRAPH_IPFS_MAX_ATTEMPTS", default = "100000")]
+    ipfs_max_attempts: usize,
     #[envconfig(from = "GRAPH_ALLOW_NON_DETERMINISTIC_IPFS", default = "false")]
     allow_non_deterministic_ipfs: EnvVarBoolean,
     #[envconfig(from = "GRAPH_DISABLE_DECLARED_CALLS", default = "false")]

--- a/graph/src/ipfs/retry_policy.rs
+++ b/graph/src/ipfs/retry_policy.rs
@@ -3,12 +3,9 @@ use std::time::Duration;
 use slog::Logger;
 
 use crate::ipfs::error::IpfsError;
+use crate::prelude::*;
 use crate::util::futures::retry;
 use crate::util::futures::RetryConfig;
-
-/// This is a safety mechanism to prevent infinite spamming of IPFS servers
-/// in the event of logical or unhandled deterministic errors.
-const DEFAULT_MAX_ATTEMPTS: usize = 10_0000;
 
 /// The default maximum delay between retries.
 const DEFAULT_MAX_DELAY: Duration = Duration::from_secs(60);
@@ -35,7 +32,7 @@ impl RetryPolicy {
         logger: &Logger,
     ) -> RetryConfig<O, IpfsError> {
         retry(operation_name, logger)
-            .limit(DEFAULT_MAX_ATTEMPTS)
+            .limit(ENV_VARS.mappings.ipfs_max_attempts)
             .max_delay(DEFAULT_MAX_DELAY)
             .when(move |result: &Result<O, IpfsError>| match result {
                 Ok(_) => false,


### PR DESCRIPTION
This PR changes the hardcoded DEFAULT_MAX_ATTEMPTS to a configurable env var GRAPH_NODE_IPFS_MAX_ATTEMPTS to avoid spamming the IPFS on deterministic errors