### PR TITLE
gnd: Support deploying multiple subgraphs when using dev mode

### DIFF
--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -102,7 +102,7 @@ impl<I: SubgraphInstanceManager> SubgraphAssignmentProviderTrait for SubgraphAss
 
         self.instance_manager
             .cheap_clone()
-            .start_subgraph(loc, raw, stop_block)
+            .start_subgraph(loc, raw, stop_block, Some(link_resolver))
             .await;
 
         Ok(())

--- a/core/src/subgraph/provider.rs
+++ b/core/src/subgraph/provider.rs
@@ -74,6 +74,7 @@ impl<I: SubgraphInstanceManager> SubgraphAssignmentProviderTrait for SubgraphAss
         &self,
         loc: DeploymentLocator,
         stop_block: Option<BlockNumber>,
+        link_resolver_override: Option<Arc<dyn LinkResolver>>,
     ) -> Result<(), SubgraphAssignmentProviderError> {
         let logger = self.logger_factory.subgraph_logger(&loc);
 
@@ -86,8 +87,12 @@ impl<I: SubgraphInstanceManager> SubgraphAssignmentProviderTrait for SubgraphAss
             ));
         }
 
-        let file_bytes = self
-            .link_resolver
+        let link_resolver = match link_resolver_override {
+            Some(link_resolver) => link_resolver,
+            None => self.link_resolver.clone(),
+        };
+
+        let file_bytes = link_resolver
             .cat(&logger, &loc.hash.to_ipfs_link())
             .await
             .map_err(SubgraphAssignmentProviderError::ResolveError)?;

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -479,7 +479,7 @@ async fn start_subgraph(
     trace!(logger, "Start subgraph");
 
     let start_time = Instant::now();
-    let result = provider.start(deployment.clone(), None).await;
+    let result = provider.start(deployment.clone(), None, None).await;
 
     debug!(
         logger,

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -278,6 +278,7 @@ where
         start_block_override: Option<BlockPtr>,
         graft_block_override: Option<BlockPtr>,
         history_blocks: Option<i32>,
+        link_resolver_override: Option<Arc<dyn LinkResolver>>,
     ) -> Result<DeploymentLocator, SubgraphRegistrarError> {
         // We don't have a location for the subgraph yet; that will be
         // assigned when we deploy for real. For logging purposes, make up a
@@ -286,9 +287,10 @@ where
             .logger_factory
             .subgraph_logger(&DeploymentLocator::new(DeploymentId(0), hash.clone()));
 
+        let link_resolver = link_resolver_override.unwrap_or_else(|| self.resolver.clone());
+
         let raw: serde_yaml::Mapping = {
-            let file_bytes = self
-                .resolver
+            let file_bytes = link_resolver
                 .cat(&logger, &hash.to_ipfs_link())
                 .await
                 .map_err(|e| {
@@ -323,7 +325,7 @@ where
                     node_id,
                     debug_fork,
                     self.version_switching_mode,
-                    &self.resolver,
+                    &link_resolver,
                     history_blocks,
                 )
                 .await?
@@ -341,7 +343,7 @@ where
                     node_id,
                     debug_fork,
                     self.version_switching_mode,
-                    &self.resolver,
+                    &link_resolver,
                     history_blocks,
                 )
                 .await?
@@ -359,7 +361,7 @@ where
                     node_id,
                     debug_fork,
                     self.version_switching_mode,
-                    &self.resolver,
+                    &link_resolver,
                     history_blocks,
                 )
                 .await?
@@ -377,7 +379,7 @@ where
                     node_id,
                     debug_fork,
                     self.version_switching_mode,
-                    &self.resolver,
+                    &link_resolver,
                     history_blocks,
                 )
                 .await?

--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -32,7 +32,7 @@ pub struct SubgraphRegistrar<P, S, SM> {
     logger: Logger,
     logger_factory: LoggerFactory,
     resolver: Arc<dyn LinkResolver>,
-    provider: Arc<P>,
+    pub provider: Arc<P>,
     store: Arc<S>,
     subscription_manager: Arc<SM>,
     chains: Arc<BlockchainMap>,

--- a/graph/src/components/subgraph/instance_manager.rs
+++ b/graph/src/components/subgraph/instance_manager.rs
@@ -1,4 +1,4 @@
-use crate::prelude::BlockNumber;
+use crate::prelude::{BlockNumber, LinkResolver};
 use std::sync::Arc;
 
 use crate::components::store::DeploymentLocator;
@@ -15,6 +15,7 @@ pub trait SubgraphInstanceManager: Send + Sync + 'static {
         deployment: DeploymentLocator,
         manifest: serde_yaml::Mapping,
         stop_block: Option<BlockNumber>,
+        link_resolver_override: Option<Arc<dyn LinkResolver>>,
     );
     async fn stop_subgraph(&self, deployment: DeploymentLocator);
 }

--- a/graph/src/components/subgraph/provider.rs
+++ b/graph/src/components/subgraph/provider.rs
@@ -9,6 +9,7 @@ pub trait SubgraphAssignmentProvider: Send + Sync + 'static {
         &self,
         deployment: DeploymentLocator,
         stop_block: Option<BlockNumber>,
+        link_resolver_override: Option<Arc<dyn LinkResolver>>,
     ) -> Result<(), SubgraphAssignmentProviderError>;
     async fn stop(
         &self,

--- a/graph/src/components/subgraph/registrar.rs
+++ b/graph/src/components/subgraph/registrar.rs
@@ -45,6 +45,7 @@ pub trait SubgraphRegistrar: Send + Sync + 'static {
         start_block_block: Option<BlockPtr>,
         graft_block_override: Option<BlockPtr>,
         history_blocks: Option<i32>,
+        link_resolver_override: Option<Arc<dyn LinkResolver>>,
     ) -> Result<DeploymentLocator, SubgraphRegistrarError>;
 
     async fn remove_subgraph(&self, name: SubgraphName) -> Result<(), SubgraphRegistrarError>;

--- a/node/src/bin/dev.rs
+++ b/node/src/bin/dev.rs
@@ -7,10 +7,11 @@ use graph::{
     components::link_resolver::FileLinkResolver,
     env::EnvVars,
     log::logger,
+    slog::info,
     tokio::{self, sync::mpsc},
 };
 use graph_node::{
-    dev::{helpers::DevModeContext, watcher::watch_subgraph_dir},
+    dev::{helpers::DevModeContext, watcher::watch_subgraphs},
     launcher,
     opt::Opt,
 };
@@ -39,9 +40,17 @@ pub struct DevOpt {
     #[clap(
         long,
         help = "The location of the subgraph manifest file.",
-        default_value = "./build/subgraph.yaml"
+        default_value = "./build/subgraph.yaml",
+        value_delimiter = ','
     )]
-    pub manifest: String,
+    pub manifests: Vec<String>,
+
+    #[clap(
+        long,
+        help = "The location of the database directory.",
+        default_value = "./build"
+    )]
+    pub database_dir: String,
 
     #[clap(
         long,
@@ -63,7 +72,7 @@ pub struct DevOpt {
 }
 
 /// Builds the Graph Node options from DevOpt
-fn build_args(dev_opt: &DevOpt, db_url: &str, manifest_path: &str) -> Result<Opt> {
+fn build_args(dev_opt: &DevOpt, db_url: &str) -> Result<Opt> {
     let mut args = vec!["gnd".to_string()];
 
     if !dev_opt.ipfs.is_empty() {
@@ -76,38 +85,12 @@ fn build_args(dev_opt: &DevOpt, db_url: &str, manifest_path: &str) -> Result<Opt
         args.push(dev_opt.ethereum_rpc.join(","));
     }
 
-    let path = Path::new(manifest_path);
-    let file_name = path
-        .file_name()
-        .context("Invalid manifest path: no file name component")?
-        .to_str()
-        .context("Invalid file name")?;
-
-    args.push("--subgraph".to_string());
-    args.push(file_name.to_string());
-
     args.push("--postgres-url".to_string());
     args.push(db_url.to_string());
 
     let opt = Opt::parse_from(args);
 
     Ok(opt)
-}
-
-/// Validates the manifest file exists and returns the build directory
-fn get_build_dir(manifest_path_str: &str) -> Result<std::path::PathBuf> {
-    let manifest_path = Path::new(manifest_path_str);
-
-    if !manifest_path.exists() {
-        anyhow::bail!("Subgraph manifest file not found at {}", manifest_path_str);
-    }
-
-    let dir = manifest_path
-        .parent()
-        .context("Failed to get parent directory of manifest")?;
-
-    dir.canonicalize()
-        .context("Failed to canonicalize build directory path")
 }
 
 async fn run_graph_node(opt: Opt, ctx: Option<DevModeContext>) -> Result<()> {
@@ -122,29 +105,29 @@ async fn main() -> Result<()> {
     env_logger::init();
     let dev_opt = DevOpt::parse();
 
-    let build_dir = get_build_dir(&dev_opt.manifest)?;
+    let database_dir = Path::new(&dev_opt.database_dir);
+
+    let logger = logger(true);
+
+    info!(logger, "Starting Graph Node Dev");
+    info!(logger, "Database directory: {}", database_dir.display());
 
     let db = PgTempDBBuilder::new()
-        .with_data_dir_prefix(build_dir.clone())
+        .with_data_dir_prefix(database_dir)
         .with_initdb_param("-E", "UTF8")
         .with_initdb_param("--locale", "C")
         .start_async()
         .await;
 
     let (tx, rx) = mpsc::channel(1);
-    let opt = build_args(&dev_opt, &db.connection_uri(), &dev_opt.manifest)?;
-    let file_link_resolver = Arc::new(FileLinkResolver::with_base_dir(&build_dir));
+    let opt = build_args(&dev_opt, &db.connection_uri())?;
+    let file_link_resolver = Arc::new(FileLinkResolver::with_base_dir(database_dir));
 
     let ctx = DevModeContext {
         watch: dev_opt.watch,
         file_link_resolver,
         updates_rx: rx,
     };
-
-    let subgraph = opt.subgraph.clone().unwrap();
-
-    // Set up logger
-    let logger = logger(opt.debug);
 
     // Run graph node
     graph::spawn(async move {
@@ -153,14 +136,8 @@ async fn main() -> Result<()> {
 
     if dev_opt.watch {
         graph::spawn_blocking(async move {
-            watch_subgraph_dir(
-                &logger,
-                build_dir,
-                subgraph,
-                vec!["pgtemp-*".to_string()],
-                tx,
-            )
-            .await;
+            let _ =
+                watch_subgraphs(&logger, dev_opt.manifests, vec!["pgtemp-*".to_string()], tx).await;
         });
     }
 

--- a/node/src/dev/helpers.rs
+++ b/node/src/dev/helpers.rs
@@ -55,6 +55,7 @@ async fn deploy_subgraph(
             start_block,
             None,
             None,
+            None,
         )
         .await
         .and_then(|locator| {

--- a/node/src/dev/helpers.rs
+++ b/node/src/dev/helpers.rs
@@ -1,43 +1,67 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
 use graph::components::link_resolver::FileLinkResolver;
 use graph::prelude::{
-    BlockPtr, DeploymentHash, NodeId, SubgraphRegistrarError, SubgraphStore as SubgraphStoreTrait,
+    BlockPtr, DeploymentHash, NodeId, SubgraphRegistrar as SubgraphRegistrarTrait,
+    SubgraphRegistrarError, SubgraphStore as SubgraphStoreTrait,
 };
 use graph::slog::{error, info, Logger};
 use graph::tokio::sync::mpsc::Receiver;
 use graph::{
     components::store::DeploymentLocator,
-    prelude::{SubgraphName, SubgraphRegistrar},
+    prelude::{SubgraphAssignmentProvider as SubgraphAssignmentProviderTrait, SubgraphName},
 };
-use graph_store_postgres::SubgraphStore;
+use graph_core::{SubgraphAssignmentProvider, SubgraphInstanceManager, SubgraphRegistrar};
+use graph_store_postgres::{SubgraphStore, SubscriptionManager};
+
+type SubgraphRegistrarType = SubgraphRegistrar<
+    SubgraphAssignmentProvider<SubgraphInstanceManager<SubgraphStore>>,
+    SubgraphStore,
+    SubscriptionManager,
+>;
+
+pub struct DevSubgraph {
+    pub hash: DeploymentHash,
+    pub name: SubgraphName,
+    pub build_dir: PathBuf,
+}
 
 pub struct DevModeContext {
     pub watch: bool,
     pub file_link_resolver: Arc<FileLinkResolver>,
-    pub updates_rx: Receiver<(DeploymentHash, SubgraphName)>,
+    pub updates_rx: Receiver<DevSubgraph>,
 }
 
 /// Cleanup a subgraph
 /// This is used to remove a subgraph before redeploying it when using the watch flag
-fn cleanup_dev_subgraph(
+async fn cleanup_dev_subgraph(
     logger: &Logger,
     subgraph_store: &SubgraphStore,
-    name: &SubgraphName,
-    locator: &DeploymentLocator,
+    subgraph_registrar: &Arc<SubgraphRegistrarType>,
+    subgraph: &DevSubgraph,
 ) -> Result<()> {
-    info!(logger, "Removing subgraph"; "name" => name.to_string(), "id" => locator.id.to_string(), "hash" => locator.hash.to_string());
-    subgraph_store.remove_subgraph(name.clone())?;
-    subgraph_store.unassign_subgraph(locator)?;
-    subgraph_store.remove_deployment(locator.id.into())?;
-    info!(logger, "Subgraph removed"; "name" => name.to_string(), "id" => locator.id.to_string(), "hash" => locator.hash.to_string());
+    let hash = subgraph.hash.clone();
+    let locator = subgraph_store.active_locator(&hash)?;
+
+    if let Some(locator) = locator {
+        info!(logger, "Removing subgraph"; "name" => subgraph.name.to_string(), "id" => locator.id.to_string(), "hash" => hash.to_string());
+
+        subgraph_registrar.provider.stop(locator.clone()).await?;
+        subgraph_store.remove_subgraph(subgraph.name.clone())?;
+        subgraph_store.unassign_subgraph(&locator)?;
+        subgraph_store.remove_deployment(locator.id.into())?;
+
+        info!(logger, "Subgraph removed"; "name" => subgraph.name.to_string(), "id" => locator.id.to_string(), "hash" => hash.to_string());
+    }
+
     Ok(())
 }
 
 async fn deploy_subgraph(
     logger: &Logger,
-    subgraph_registrar: Arc<impl SubgraphRegistrar>,
+    subgraph_registrar: &Arc<SubgraphRegistrarType>,
     name: SubgraphName,
     subgraph_id: DeploymentHash,
     node_id: NodeId,
@@ -67,28 +91,39 @@ async fn deploy_subgraph(
 pub async fn drop_and_recreate_subgraph(
     logger: &Logger,
     subgraph_store: Arc<SubgraphStore>,
-    subgraph_registrar: Arc<impl SubgraphRegistrar>,
-    name: SubgraphName,
-    subgraph_id: DeploymentHash,
+    subgraph_registrar: Arc<SubgraphRegistrarType>,
     node_id: NodeId,
-    hash: DeploymentHash,
+    dev_subgraph: DevSubgraph,
 ) -> Result<DeploymentLocator> {
-    let locator = subgraph_store.active_locator(&hash)?;
-    if let Some(locator) = locator.clone() {
-        cleanup_dev_subgraph(logger, &subgraph_store, &name, &locator)?;
-    }
+    let name = dev_subgraph.name.clone();
+    let hash = dev_subgraph.hash.clone();
 
-    deploy_subgraph(
+    let link_resolver = Arc::new(FileLinkResolver::with_base_dir(
+        dev_subgraph.build_dir.clone(),
+    ));
+
+    cleanup_dev_subgraph(logger, &subgraph_store, &subgraph_registrar, &dev_subgraph).await?;
+
+    let locator = deploy_subgraph(
         logger,
-        subgraph_registrar,
-        name,
-        subgraph_id,
+        &subgraph_registrar,
+        name.clone(),
+        hash.clone(),
         node_id,
         None,
         None,
     )
     .await
-    .map_err(|e| anyhow::anyhow!("Failed to deploy subgraph: {}", e))
+    .map_err(|e| anyhow::anyhow!("Failed to deploy subgraph: {}", e))?;
+
+    info!(logger, "Starting subgraph"; "name" => name.to_string(), "id" => hash.to_string(), "locator" => locator.to_string());
+    subgraph_registrar
+        .provider
+        .start(locator.clone(), None, Some(link_resolver))
+        .await?;
+    info!(logger, "Subgraph started"; "name" => name.to_string(), "id" => hash.to_string(), "locator" => locator.to_string());
+
+    Ok(locator)
 }
 
 /// Watch for subgraph updates, drop and recreate them
@@ -97,19 +132,21 @@ pub async fn drop_and_recreate_subgraph(
 pub async fn watch_subgraph_updates(
     logger: &Logger,
     subgraph_store: Arc<SubgraphStore>,
-    subgraph_registrar: Arc<impl SubgraphRegistrar>,
+    subgraph_registrar: Arc<SubgraphRegistrarType>,
     node_id: NodeId,
-    mut rx: Receiver<(DeploymentHash, SubgraphName)>,
+    mut rx: Receiver<DevSubgraph>,
 ) {
-    while let Some((hash, name)) = rx.recv().await {
+    while let Some(dev_subgraph) = rx.recv().await {
+        let name = dev_subgraph.name.clone();
+        let hash = dev_subgraph.hash.clone();
+        let build_dir = dev_subgraph.build_dir.clone();
+
         let res = drop_and_recreate_subgraph(
             logger,
             subgraph_store.clone(),
             subgraph_registrar.clone(),
-            name.clone(),
-            hash.clone(),
             node_id.clone(),
-            hash.clone(),
+            dev_subgraph,
         )
         .await;
 
@@ -117,6 +154,7 @@ pub async fn watch_subgraph_updates(
             error!(logger, "Failed to drop and recreate subgraph";
                 "name" => name.to_string(),
                 "hash" => hash.to_string(),
+                "build_dir" => format!("{}", build_dir.display()),
                 "error" => e.to_string()
             );
         }

--- a/node/src/dev/watcher.rs
+++ b/node/src/dev/watcher.rs
@@ -1,28 +1,102 @@
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use graph::prelude::{DeploymentHash, SubgraphName};
-use graph::slog::{error, info, Logger};
+use graph::slog::{self, error, info, Logger};
 use graph::tokio::sync::mpsc::Sender;
 use notify::{recommended_watcher, Event, RecursiveMode, Watcher};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::Duration;
 
 const WATCH_DELAY: Duration = Duration::from_secs(5);
 
+/// Maps manifest files to their parent directories and returns a mapping of deployment hashes to directories
+fn deployment_hash_to_dir(
+    manifests: Vec<String>,
+    logger: &Logger,
+) -> BTreeMap<DeploymentHash, PathBuf> {
+    let mut hash_to_dir = BTreeMap::new();
+
+    for manifest in manifests {
+        info!(logger, "Validating manifest: {}", manifest);
+        let manifest_path = Path::new(&manifest);
+        let manifest_path = match manifest_path.canonicalize() {
+            Ok(canon_path) => canon_path,
+            Err(e) => {
+                error!(
+                    logger,
+                    "Failed to canonicalize path for manifest {}: {}", manifest, e
+                );
+                continue;
+            }
+        };
+
+        let dir = match manifest_path.parent() {
+            Some(parent) => match parent.canonicalize() {
+                Ok(canon_path) => canon_path,
+                Err(e) => {
+                    error!(
+                        logger,
+                        "Failed to canonicalize path for manifest {}: {}", manifest, e
+                    );
+                    continue;
+                }
+            },
+            None => {
+                error!(
+                    logger,
+                    "Failed to get parent directory for manifest: {}", manifest
+                );
+                continue;
+            }
+        };
+
+        info!(logger, "Watching manifest: {}", manifest_path.display());
+
+        hash_to_dir.insert(
+            DeploymentHash::new(manifest_path.display().to_string())
+                .expect("Failed to create deployment hash"),
+            dir.to_path_buf(),
+        );
+    }
+
+    hash_to_dir
+}
+
 /// Sets up a watcher for the given directory with optional exclusions.
 /// Exclusions can include glob patterns like "pgtemp-*".
-pub async fn watch_subgraph_dir(
+pub async fn watch_subgraphs(
     logger: &Logger,
-    dir: PathBuf,
-    id: String,
+    manifests: Vec<String>,
     exclusions: Vec<String>,
     sender: Sender<(DeploymentHash, SubgraphName)>,
 ) {
+    let logger = logger.new(slog::o!("component" => ">>>>> Watcher"));
+    info!(logger, "Watching subgraphs: {}", manifests.join(", "));
+    let hash_to_dir = deployment_hash_to_dir(manifests, &logger);
+
+    watch_subgraph_dirs(&logger, hash_to_dir, exclusions, sender).await;
+}
+
+/// Sets up a watcher for the given directories with optional exclusions.
+/// Exclusions can include glob patterns like "pgtemp-*".
+pub async fn watch_subgraph_dirs(
+    logger: &Logger,
+    hash_to_dir: BTreeMap<DeploymentHash, PathBuf>,
+    exclusions: Vec<String>,
+    sender: Sender<(DeploymentHash, SubgraphName)>,
+) {
+    if hash_to_dir.is_empty() {
+        info!(logger, "No directories to watch");
+        return;
+    }
+
     info!(
         logger,
-        "Watching for changes in directory: {}",
-        dir.display()
+        "Watching for changes in {} directories",
+        hash_to_dir.len()
     );
+
     if !exclusions.is_empty() {
         info!(logger, "Excluding patterns: {}", exclusions.join(", "));
     }
@@ -33,7 +107,6 @@ pub async fn watch_subgraph_dir(
     // Create a channel to receive the events
     let (tx, rx) = mpsc::channel();
 
-    // Create a watcher object
     let mut watcher = match recommended_watcher(tx) {
         Ok(w) => w,
         Err(e) => {
@@ -42,28 +115,39 @@ pub async fn watch_subgraph_dir(
         }
     };
 
-    if let Err(e) = watcher.watch(&dir, RecursiveMode::Recursive) {
-        error!(logger, "Error watching directory {}: {}", dir.display(), e);
-        return;
+    for (_, dir) in hash_to_dir.iter() {
+        if let Err(e) = watcher.watch(dir, RecursiveMode::Recursive) {
+            error!(logger, "Error watching directory {}: {}", dir.display(), e);
+            std::process::exit(1);
+        }
+        info!(logger, "Watching directory: {}", dir.display());
     }
 
-    let watch_dir = dir.clone();
-    let watch_exclusion_set = exclusion_set.clone();
+    // Process file change events
+    process_file_events(logger, rx, &exclusion_set, &hash_to_dir, sender).await;
+}
 
+/// Processes file change events and triggers redeployments
+async fn process_file_events(
+    logger: &Logger,
+    rx: mpsc::Receiver<Result<Event, notify::Error>>,
+    exclusion_set: &GlobSet,
+    hash_to_dir: &BTreeMap<DeploymentHash, PathBuf>,
+    sender: Sender<(DeploymentHash, SubgraphName)>,
+) {
     loop {
-        let first_event = match rx.recv() {
-            Ok(Ok(e)) if should_process_event(&e, &watch_dir, &watch_exclusion_set) => Some(e),
+        // Wait for an event
+        let event = match rx.recv() {
+            Ok(Ok(e)) => e,
             Ok(_) => continue,
             Err(_) => break,
         };
 
-        if first_event.is_none() {
+        if !is_relevant_event(&event, hash_to_dir, exclusion_set) {
             continue;
         }
 
-        // Once we receive an event, wait for a short period of time to allow for multiple events to be received
-        // This is because running graph build writes multiple files at once
-        // Which triggers multiple events, we only need to react to it once
+        // Once we receive an event, wait for a short period to batch multiple related events
         let start = std::time::Instant::now();
         while start.elapsed() < WATCH_DELAY {
             match rx.try_recv() {
@@ -73,12 +157,44 @@ pub async fn watch_subgraph_dir(
             }
         }
 
+        // Redeploy all subgraphs
+        redeploy_all_subgraphs(logger, hash_to_dir, &sender).await;
+    }
+}
+
+/// Checks if an event is relevant for any of the watched directories
+fn is_relevant_event(
+    event: &Event,
+    watched_dirs: &BTreeMap<DeploymentHash, PathBuf>,
+    exclusion_set: &GlobSet,
+) -> bool {
+    for path in event.paths.iter() {
+        for dir in watched_dirs.values() {
+            if path.starts_with(dir) && should_process_event(event, dir, exclusion_set) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Redeploys all subgraphs in the order defined by the BTreeMap
+async fn redeploy_all_subgraphs(
+    logger: &Logger,
+    hash_to_dir: &BTreeMap<DeploymentHash, PathBuf>,
+    sender: &Sender<(DeploymentHash, SubgraphName)>,
+) {
+    info!(logger, "File change detected, redeploying all subgraphs");
+    let mut count = 0;
+    for id in hash_to_dir.keys() {
         let _ = sender
             .send((
-                DeploymentHash::new(id.clone()).unwrap(),
-                SubgraphName::new("test").unwrap(),
+                id.clone(),
+                SubgraphName::new(format!("subgraph-{}", count))
+                    .expect("Failed to create subgraph name"),
             ))
             .await;
+        count += 1;
     }
 }
 

--- a/node/src/launcher.rs
+++ b/node/src/launcher.rs
@@ -352,6 +352,7 @@ fn build_graphql_server(
 pub async fn run(opt: Opt, env_vars: Arc<EnvVars>, dev_ctx: Option<DevModeContext>) {
     // Set up logger
     let logger = logger(opt.debug);
+    let is_dev_mode = dev_ctx.is_some();
 
     // Log version information
     info!(
@@ -536,12 +537,14 @@ pub async fn run(opt: Opt, env_vars: Arc<EnvVars>, dev_ctx: Option<DevModeContex
             ipfs_service,
         );
 
-        graph::spawn(
-            subgraph_registrar
-                .start()
-                .map_err(|e| panic!("failed to initialize subgraph provider {}", e))
-                .compat(),
-        );
+        if !is_dev_mode {
+            graph::spawn(
+                subgraph_registrar
+                    .start()
+                    .map_err(|e| panic!("failed to initialize subgraph provider {}", e))
+                    .compat(),
+            );
+        }
 
         // Start admin JSON-RPC server.
         let json_rpc_server = JsonRpcServer::serve(

--- a/node/src/launcher.rs
+++ b/node/src/launcher.rs
@@ -253,6 +253,7 @@ fn deploy_subgraph_from_flag(
                     start_block,
                     None,
                     None,
+                    None,
                 )
                 .await
         }

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -213,6 +213,7 @@ pub async fn run(
         None,
         None,
         None,
+        None,
     )
     .await?;
 

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -218,7 +218,7 @@ pub async fn run(
 
     let locator = locate(subgraph_store.as_ref(), &hash)?;
 
-    SubgraphAssignmentProvider::start(subgraph_provider.as_ref(), locator, Some(stop_block))
+    SubgraphAssignmentProvider::start(subgraph_provider.as_ref(), locator, Some(stop_block), None)
         .await?;
 
     loop {

--- a/server/json-rpc/src/lib.rs
+++ b/server/json-rpc/src/lib.rs
@@ -133,6 +133,7 @@ impl<R: SubgraphRegistrar> ServerState<R> {
                 None,
                 None,
                 params.history_blocks,
+                None,
             )
             .await
         {

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -614,6 +614,7 @@ pub async fn setup_inner<C: Blockchain>(
         None,
         graft_block,
         None,
+        None,
     )
     .await
     .expect("failed to create subgraph version");

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -285,7 +285,7 @@ impl TestContext {
         self.provider.stop(self.deployment.clone()).await.unwrap();
 
         self.provider
-            .start(self.deployment.clone(), Some(stop_block.number))
+            .start(self.deployment.clone(), Some(stop_block.number), None)
             .await
             .expect("unable to start subgraph");
 
@@ -306,7 +306,7 @@ impl TestContext {
         self.provider.stop(self.deployment.clone()).await.unwrap();
 
         self.provider
-            .start(self.deployment.clone(), None)
+            .start(self.deployment.clone(), None, None)
             .await
             .expect("unable to start subgraph");
 

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -228,6 +228,7 @@ impl TestContext {
                 tp,
                 deployment_status_metric,
                 true,
+                None,
             )
             .await
             .unwrap()
@@ -259,6 +260,7 @@ impl TestContext {
                 tp,
                 deployment_status_metric,
                 true,
+                None,
             )
             .await
             .unwrap()


### PR DESCRIPTION
 Supporting multiple subgraphs in dev mode is a bit tricky since FileLinkResolver needs a base dir, this works well for a single subgraph since we can scope the resolver to the build directory of that subgraph, but when there are multiple subgraphs, we need to set the base_dir of the FileLinkResolver dynamically. This PR implements the mechanisms for that.
 
 This is done by using a `link_resolver_override` thats passed upto the subgraph runner which switches to using it when available.