### PR TITLE
Kill and retry pruning batch operations

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -226,10 +226,10 @@ those.
   copying or grafting should take. This limits how long transactions for
   such long running operations will be, and therefore helps control bloat
   in other tables. Value is in seconds and defaults to 180s.
-- `GRAPH_STORE_BATCH_TIMEOUT`: How long a batch operation during copying or
-  grafting is allowed to take at most. This is meant to guard against
-  batches that are catastrophically big and should be set to a small
-  multiple of `GRAPH_STORE_BATCH_TARGET_DURATION`, like 10 times that
+- `GRAPH_STORE_BATCH_TIMEOUT`: How long a batch operation during copying,
+  grafting, or pruning is allowed to take at most. This is meant to guard
+  against batches that are catastrophically big and should be set to a
+  small multiple of `GRAPH_STORE_BATCH_TARGET_DURATION`, like 10 times that
   value, and needs to be at least 2 times that value when set. If this
   timeout is hit, the batch size is reset to 1 so we can be sure that
   batches stay below `GRAPH_STORE_BATCH_TARGET_DURATION` and the smaller

--- a/store/postgres/src/copy.rs
+++ b/store/postgres/src/copy.rs
@@ -65,7 +65,7 @@ const ACCEPTABLE_REPLICATION_LAG: Duration = Duration::from_secs(30);
 const REPLICATION_SLEEP: Duration = Duration::from_secs(10);
 
 lazy_static! {
-    static ref STATEMENT_TIMEOUT: Option<String> = ENV_VARS
+    pub(crate) static ref BATCH_STATEMENT_TIMEOUT: Option<String> = ENV_VARS
         .store
         .batch_timeout
         .map(|duration| format!("set local statement_timeout={}", duration.as_millis()));
@@ -792,7 +792,7 @@ impl CopyTableWorker {
                     }
 
                     match conn.transaction(|conn| {
-                        if let Some(timeout) = STATEMENT_TIMEOUT.as_ref() {
+                        if let Some(timeout) = BATCH_STATEMENT_TIMEOUT.as_ref() {
                             conn.batch_execute(timeout)?;
                         }
                         self.table.copy_batch(conn)

--- a/store/postgres/src/vid_batcher.rs
+++ b/store/postgres/src/vid_batcher.rs
@@ -209,9 +209,9 @@ impl VidBatcher {
     /// The function returns the time it took to process the batch and the
     /// result of `f`. If the batcher is finished, `f` will not be called,
     /// and `None` will be returned as its result.
-    pub fn step<F, T>(&mut self, mut f: F) -> Result<(Duration, Option<T>), StoreError>
+    pub fn step<F, T>(&mut self, f: F) -> Result<(Duration, Option<T>), StoreError>
     where
-        F: FnMut(i64, i64) -> Result<T, StoreError>,
+        F: FnOnce(i64, i64) -> Result<T, StoreError>,
     {
         if self.finished() {
             return Ok((Duration::from_secs(0), None));


### PR DESCRIPTION
Uses the same timeout as copying. If a prune operation now takes longer than `GRAPH_STORE_BATCH_TIMEOUT` it is aborted and retried with a batch size of 1
