### PR TITLE
Improve how pruning estimates how much of a table will be removed

### DIFF
--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -928,13 +928,12 @@ pub struct VersionStats {
     pub ratio: f64,
     /// The last block to which this table was pruned
     pub last_pruned_block: Option<BlockNumber>,
-    /// Histograms for the lower and upper bounds of the block ranges in
+    /// Histograms for the upper bounds of the block ranges in
     /// this table. Each histogram bucket contains roughly the same number
     /// of rows; values might be repeated to achieve that. The vectors are
     /// empty if the table hasn't been analyzed, the subgraph is stored in
     /// Postgres version 16 or lower, or if the table doesn't have a
     /// block_range column.
-    pub block_range_lower: Vec<BlockNumber>,
     pub block_range_upper: Vec<BlockNumber>,
 }
 

--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -928,6 +928,14 @@ pub struct VersionStats {
     pub ratio: f64,
     /// The last block to which this table was pruned
     pub last_pruned_block: Option<BlockNumber>,
+    /// Histograms for the lower and upper bounds of the block ranges in
+    /// this table. Each histogram bucket contains roughly the same number
+    /// of rows; values might be repeated to achieve that. The vectors are
+    /// empty if the table hasn't been analyzed, the subgraph is stored in
+    /// Postgres version 16 or lower, or if the table doesn't have a
+    /// block_range column.
+    pub block_range_lower: Vec<BlockNumber>,
+    pub block_range_upper: Vec<BlockNumber>,
 }
 
 /// What phase of pruning we are working on

--- a/graph/src/env/store.rs
+++ b/graph/src/env/store.rs
@@ -114,6 +114,10 @@ pub struct EnvVarsStore {
     /// For how many prune runs per deployment to keep status information.
     /// Set by `GRAPH_STORE_HISTORY_KEEP_STATUS`. The default is 5
     pub prune_keep_history: usize,
+    /// Temporary switch to disable range bound estimation for pruning.
+    /// Set by `GRAPH_STORE_PRUNE_DISABLE_RANGE_BOUND_ESTIMATION`.
+    /// Defaults to false. Remove after 2025-07-15
+    pub prune_disable_range_bound_estimation: bool,
     /// How long to accumulate changes into a batch before a write has to
     /// happen. Set by the environment variable
     /// `GRAPH_STORE_WRITE_BATCH_DURATION` in seconds. The default is 300s.
@@ -188,6 +192,7 @@ impl TryFrom<InnerStore> for EnvVarsStore {
             delete_threshold: x.delete_threshold.0,
             history_slack_factor: x.history_slack_factor.0,
             prune_keep_history: x.prune_keep_status,
+            prune_disable_range_bound_estimation: x.prune_disable_range_bound_estimation,
             write_batch_duration: Duration::from_secs(x.write_batch_duration_in_secs),
             write_batch_size: x.write_batch_size * 1_000,
             create_gin_indexes: x.create_gin_indexes,
@@ -263,6 +268,11 @@ pub struct InnerStore {
     history_slack_factor: HistorySlackF64,
     #[envconfig(from = "GRAPH_STORE_HISTORY_KEEP_STATUS", default = "5")]
     prune_keep_status: usize,
+    #[envconfig(
+        from = "GRAPH_STORE_PRUNE_DISABLE_RANGE_BOUND_ESTIMATION",
+        default = "false"
+    )]
+    prune_disable_range_bound_estimation: bool,
     #[envconfig(from = "GRAPH_STORE_WRITE_BATCH_DURATION", default = "300")]
     write_batch_duration_in_secs: u64,
     #[envconfig(from = "GRAPH_STORE_WRITE_BATCH_SIZE", default = "10000")]

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -73,7 +73,7 @@ pub use self::subgraph_store::{unused, DeploymentPlacer, Shard, SubgraphStore, P
 pub mod command_support {
     pub mod catalog {
         pub use crate::block_store::primary as block_store;
-        pub use crate::catalog::{account_like, stats};
+        pub use crate::catalog::{account_like, Catalog};
         pub use crate::copy::{copy_state, copy_table_state};
         pub use crate::primary::{
             active_copies, deployment_schemas, ens_names, subgraph, subgraph_deployment_assignment,

--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -267,7 +267,7 @@ impl Layout {
             reporter.finish_analyze_table(table.name.as_str());
             cancel.check_cancel()?;
         }
-        let stats = catalog::stats(conn, &self.site)?;
+        let stats = self.catalog.stats(conn)?;
 
         let analyzed: Vec<_> = tables.iter().map(|table| table.name.as_str()).collect();
         reporter.finish_analyze(&stats, &analyzed);

--- a/store/test-store/tests/postgres/graft.rs
+++ b/store/test-store/tests/postgres/graft.rs
@@ -648,7 +648,6 @@ fn prune() {
                 tablename: USER.to_ascii_lowercase(),
                 ratio: 3.0 / 5.0,
                 last_pruned_block: None,
-                block_range_lower: vec![],
                 block_range_upper: vec![],
             };
             assert_eq!(

--- a/store/test-store/tests/postgres/graft.rs
+++ b/store/test-store/tests/postgres/graft.rs
@@ -648,6 +648,8 @@ fn prune() {
                 tablename: USER.to_ascii_lowercase(),
                 ratio: 3.0 / 5.0,
                 last_pruned_block: None,
+                block_range_lower: vec![],
+                block_range_upper: vec![],
             };
             assert_eq!(
                 Some(strategy),


### PR DESCRIPTION
Pruning can use one of two strategies to get rid of unneeded rows in a table: deleting or rebuilding. Rebuilding is better when we remove more than 50% of a table, otherwise, deletion should be used.

Currently, we estimate how much of a table will be removed by looking at the percentage of historical blocks we prune weighted by the ratio of entity versions to entities. This basically assumes that entity changes are very evenly distributed across blocks. In practice, this leads to serious overestimation of how much of a table will be removed. In one case, the estimate was that 58% of a table would be removed, when in reality only 2% of the table would be removed.

With this change, we use database statistics to improve the estimates which reflect reality much more closely.