### PR TITLE
store: Add explicit locking to a migration

### DIFF
--- a/store/postgres/migrations/2025-05-13-173523_split_subgraph_deployment/up.sql
+++ b/store/postgres/migrations/2025-05-13-173523_split_subgraph_deployment/up.sql
@@ -1,3 +1,12 @@
+
+-- Grab locks on all tables we are going to touch; otherwise, concurrently
+-- running operations might cause deadlocks
+lock table subgraphs.subgraph_deployment in access exclusive mode;
+lock table subgraphs.subgraph_manifest  in access exclusive mode;
+lock table subgraphs.subgraph_error in access exclusive mode;
+lock table subgraphs.table_stats in access exclusive mode;
+lock table subgraphs.copy_state in access exclusive mode;
+
 create table subgraphs.head (
     id                    int4 primary key,
     entity_count          int8 not null,


### PR DESCRIPTION
For this migration, we need to hold all necessary locks before we start making changes, otherwise concurrent operations can cause deadlocks and abort the migration.

