### PR TITLE
Speed up appending changes to a batch

### DIFF
--- a/graph/examples/append_row.rs
+++ b/graph/examples/append_row.rs
@@ -1,0 +1,123 @@
+use std::{collections::HashSet, sync::Arc, time::Instant};
+
+use anyhow::anyhow;
+use clap::Parser;
+use graph::{
+    components::store::write::{EntityModification, RowGroupForPerfTest as RowGroup},
+    data::{
+        store::{Id, Value},
+        subgraph::DeploymentHash,
+        value::Word,
+    },
+    schema::{EntityType, InputSchema},
+};
+use lazy_static::lazy_static;
+use rand::{rng, Rng};
+
+#[derive(Parser)]
+#[clap(
+    name = "append_row",
+    about = "Measure time it takes to append rows to a row group"
+)]
+struct Opt {
+    /// Number of repetitions of the test
+    #[clap(short, long, default_value = "5")]
+    niter: usize,
+    /// Number of rows
+    #[clap(short, long, default_value = "10000")]
+    rows: usize,
+    /// Number of blocks
+    #[clap(short, long, default_value = "300")]
+    blocks: usize,
+    /// Number of ids
+    #[clap(short, long, default_value = "500")]
+    ids: usize,
+}
+
+// A very fake schema that allows us to get the entity types we need
+const GQL: &str = r#"
+      type Thing @entity { id: ID!, count: Int! }
+      type RowGroup @entity { id: ID! }
+      type Entry @entity { id: ID! }
+    "#;
+lazy_static! {
+    static ref DEPLOYMENT: DeploymentHash = DeploymentHash::new("batchAppend").unwrap();
+    static ref SCHEMA: InputSchema = InputSchema::parse_latest(GQL, DEPLOYMENT.clone()).unwrap();
+    static ref THING_TYPE: EntityType = SCHEMA.entity_type("Thing").unwrap();
+    static ref ROW_GROUP_TYPE: EntityType = SCHEMA.entity_type("RowGroup").unwrap();
+    static ref ENTRY_TYPE: EntityType = SCHEMA.entity_type("Entry").unwrap();
+}
+
+pub fn main() -> anyhow::Result<()> {
+    let opt = Opt::parse();
+    let next_block = opt.blocks as f64 / opt.rows as f64;
+    for _ in 0..opt.niter {
+        let ids = (0..opt.ids)
+            .map(|n| Id::String(Word::from(format!("00{n}010203040506"))))
+            .collect::<Vec<_>>();
+        let mut existing: HashSet<Id> = HashSet::new();
+        let mut mods = Vec::new();
+        let mut block = 0;
+        let mut block_pos = Vec::new();
+        for _ in 0..opt.rows {
+            if rng().random_bool(next_block) {
+                block += 1;
+                block_pos.clear();
+            }
+
+            let mut attempt = 0;
+            let pos = loop {
+                if attempt > 20 {
+                    return Err(anyhow!(
+                        "Failed to find a position in 20 attempts. Increase `ids`"
+                    ));
+                }
+                attempt += 1;
+                let pos = rng().random_range(0..opt.ids);
+                if block_pos.contains(&pos) {
+                    continue;
+                }
+                block_pos.push(pos);
+                break pos;
+            };
+            let id = &ids[pos];
+            let data = vec![
+                (Word::from("id"), Value::String(id.to_string())),
+                (Word::from("count"), Value::Int(block as i32)),
+            ];
+            let data = Arc::new(SCHEMA.make_entity(data).unwrap());
+            let md = if existing.contains(id) {
+                EntityModification::Overwrite {
+                    key: THING_TYPE.key(id.clone()),
+                    data,
+                    block,
+                    end: None,
+                }
+            } else {
+                existing.insert(id.clone());
+                EntityModification::Insert {
+                    key: THING_TYPE.key(id.clone()),
+                    data,
+                    block,
+                    end: None,
+                }
+            };
+            mods.push(md);
+        }
+        let mut group = RowGroup::new(THING_TYPE.clone(), false);
+
+        let start = Instant::now();
+        for md in mods {
+            group.append_row(md).unwrap();
+        }
+        let elapsed = start.elapsed();
+        println!(
+            "Adding {} rows with {} ids across {} blocks took {:?}",
+            opt.rows,
+            existing.len(),
+            block,
+            elapsed
+        );
+    }
+    Ok(())
+}

--- a/graph/src/components/store/write.rs
+++ b/graph/src/components/store/write.rs
@@ -501,6 +501,22 @@ impl RowGroup {
     }
 }
 
+pub struct RowGroupForPerfTest(RowGroup);
+
+impl RowGroupForPerfTest {
+    pub fn new(entity_type: EntityType, immutable: bool) -> Self {
+        Self(RowGroup::new(entity_type, immutable))
+    }
+
+    pub fn push(&mut self, emod: EntityModification, block: BlockNumber) -> Result<(), StoreError> {
+        self.0.push(emod, block)
+    }
+
+    pub fn append_row(&mut self, row: EntityModification) -> Result<(), StoreError> {
+        self.0.append_row(row)
+    }
+}
+
 struct ClampsByBlockIterator<'a> {
     position: usize,
     rows: &'a [EntityModification],

--- a/graph/src/env/store.rs
+++ b/graph/src/env/store.rs
@@ -129,6 +129,11 @@ pub struct EnvVarsStore {
     /// is 10_000 which corresponds to 10MB. Setting this to 0 disables
     /// write batching.
     pub write_batch_size: usize,
+    /// Whether to memoize the last operation for each entity in a write
+    /// batch to speed up adding more entities. Set by
+    /// `GRAPH_STORE_WRITE_BATCH_MEMOIZE`. The default is `true`.
+    /// Remove after 2025-07-01 if there have been no issues with it.
+    pub write_batch_memoize: bool,
     /// Whether to create GIN indexes for array attributes. Set by
     /// `GRAPH_STORE_CREATE_GIN_INDEXES`. The default is `false`
     pub create_gin_indexes: bool,
@@ -184,6 +189,7 @@ impl TryFrom<InnerStore> for EnvVarsStore {
             connection_min_idle: x.connection_min_idle,
             connection_idle_timeout: Duration::from_secs(x.connection_idle_timeout_in_secs),
             write_queue_size: x.write_queue_size,
+            write_batch_memoize: x.write_batch_memoize,
             batch_target_duration: Duration::from_secs(x.batch_target_duration_in_secs),
             batch_timeout: x.batch_timeout_in_secs.map(Duration::from_secs),
             batch_workers: x.batch_workers,
@@ -277,6 +283,8 @@ pub struct InnerStore {
     write_batch_duration_in_secs: u64,
     #[envconfig(from = "GRAPH_STORE_WRITE_BATCH_SIZE", default = "10000")]
     write_batch_size: usize,
+    #[envconfig(from = "GRAPH_STORE_WRITE_BATCH_MEMOIZE", default = "true")]
+    write_batch_memoize: bool,
     #[envconfig(from = "GRAPH_STORE_CREATE_GIN_INDEXES", default = "false")]
     create_gin_indexes: bool,
     #[envconfig(from = "GRAPH_STORE_USE_BRIN_FOR_ALL_QUERY_TYPES", default = "false")]


### PR DESCRIPTION
When we finish processing a block, we put all the changes into a `Batch`; that batch in turn is then added to the write queue where it might be combined with already existing batches for earlier blocks. An important aspect of speeding up writes is that block ranges for entities that have changes in several batches in the queue are properly closed before changes are written to the database, making it unnecessary to do that with much slower SQL queries.

The way this was done inside the `Batch` was fairly slow: we kept all changes for entities of a given type in a list, and when we needed to add a new change, we would search the entire list to find the last change for the same entity so we could manipulate the block range of that appropriately.

With this change, we keep a hash map from entity id to most recent change so that looking up those changes doesn't require traversing a list anymore.

The speedup can be seen with the `append_row` example. For example, which is fairly realistic,
```
GRAPH_STORE_WRITE_BATCH_MEMOIZE=false cargo run --release --example append_row -- --ids 4000 -r 9000
```
reports a time of about 110ms to construct the batch, whereas running the same with `GRAPH_STORE_WRITE_BATCH_MEMOIZE=true` takes only about 1.8ms.

