### PR TITLE
chain/ethereum: Use the log_index as the transaction_log_index

### DIFF
--- a/chain/ethereum/src/trigger.rs
+++ b/chain/ethereum/src/trigger.rs
@@ -572,10 +572,13 @@ impl<'a> EthereumEventData<'a> {
     }
 
     pub fn transaction_log_index(&self) -> &U256 {
-        self.log
-            .transaction_log_index
-            .as_ref()
-            .unwrap_or(&U256_DEFAULT)
+        // We purposely use the `log_index` here. Geth does not support
+        // `transaction_log_index`, and subgraphs that use it only care that
+        // it identifies the log, the specific value is not important. Still
+        // this will change the output of subgraphs that use this field.
+        //
+        // This was initially changed in commit b95c6953
+        self.log.log_index.as_ref().unwrap_or(&U256_DEFAULT)
     }
 
     pub fn log_type(&self) -> &Option<String> {


### PR DESCRIPTION
This reverts an inadvertent change that was introduced in PR https://github.com/graphprotocol/graph-node/pull/5867

