### PR TITLE
store: Fix a mistake in how pruning status is reported

### DIFF
--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -828,6 +828,8 @@ mod status {
 
             let values = (
                 pts::phase.eq(Phase::CopyNonfinal),
+                pts::start_vid.eq(range.min),
+                pts::next_vid.eq(range.min),
                 pts::nonfinal_vid.eq(range.max),
             );
             self.update_table_state(conn, table, values)


### PR DESCRIPTION
When we start copying nonfinal entities, we need to reset the start_vid and next_vid. They don't necessarily have a direct connection to the same values for nonfinal entities; e.g., it is possible that the start_vid for nonfinal entities is smaller than the one for final entities.

This change only affects how we report the completion of prune operations; it has no effect on what gets pruned and how.

