### PR TITLE
store: ensure consistent id type in FindRangeQuery SQL output

### DIFF
--- a/tests/integration-tests/source-subgraph/schema.graphql
+++ b/tests/integration-tests/source-subgraph/schema.graphql
@@ -10,3 +10,9 @@ type Block2 @entity(immutable: true) {
   hash: Bytes!
   testMessage: String
 }
+
+type Block3 @entity(immutable: true) {
+  id: Bytes!
+  number: BigInt!
+  testMessage: String
+}

--- a/tests/integration-tests/source-subgraph/src/mapping.ts
+++ b/tests/integration-tests/source-subgraph/src/mapping.ts
@@ -1,5 +1,5 @@
 import { ethereum, log, store } from '@graphprotocol/graph-ts';
-import { Block, Block2 } from '../generated/schema';
+import { Block, Block2, Block3 } from '../generated/schema';
 
 export function handleBlock(block: ethereum.Block): void {
   log.info('handleBlock {}', [block.number.toString()]);
@@ -22,4 +22,10 @@ export function handleBlock(block: ethereum.Block): void {
   blockEntity3.hash = block.hash;
   blockEntity3.testMessage = block.number.toString().concat('-message');
   blockEntity3.save();
+
+  let id4 = block.hash;
+  let blockEntity4 = new Block3(id4);
+  blockEntity4.number = block.number;
+  blockEntity4.testMessage = block.number.toString().concat('-message');
+  blockEntity4.save();
 }

--- a/tests/integration-tests/subgraph-data-sources/schema.graphql
+++ b/tests/integration-tests/subgraph-data-sources/schema.graphql
@@ -4,3 +4,9 @@ type MirrorBlock @entity {
   hash: Bytes!
   testMessage: String
 }
+
+type MirrorBlockBytes @entity {
+  id: Bytes!
+  number: BigInt!
+  testMessage: String
+}

--- a/tests/integration-tests/subgraph-data-sources/src/mapping.ts
+++ b/tests/integration-tests/subgraph-data-sources/src/mapping.ts
@@ -1,6 +1,6 @@
 import { log, store } from '@graphprotocol/graph-ts';
-import { Block, Block2 } from '../generated/subgraph-QmWi3H11QFE2PiWx6WcQkZYZdA5UasaBptUJqGn54MFux5';
-import { MirrorBlock } from '../generated/schema';
+import { Block, Block2, Block3 } from '../generated/subgraph-QmRWTEejPDDwALaquFGm6X2GBbbh5osYDXwCRRkoZ6KQhb';
+import { MirrorBlock, MirrorBlockBytes } from '../generated/schema';
 
 export function handleEntity(block: Block): void {
   let id = block.id;
@@ -18,6 +18,16 @@ export function handleEntity2(block: Block2): void {
   let blockEntity = loadOrCreateMirrorBlock(id);
   blockEntity.number = block.number;
   blockEntity.hash = block.hash;
+  blockEntity.testMessage = block.testMessage;
+
+  blockEntity.save();
+}
+
+export function handleEntity3(block: Block3): void {
+  let id = block.id;
+
+  let blockEntity = new MirrorBlockBytes(id);
+  blockEntity.number = block.number;
   blockEntity.testMessage = block.testMessage;
 
   blockEntity.save();

--- a/tests/integration-tests/subgraph-data-sources/subgraph.yaml
+++ b/tests/integration-tests/subgraph-data-sources/subgraph.yaml
@@ -6,7 +6,7 @@ dataSources:
     name: Contract
     network: test
     source:
-      address: 'QmWi3H11QFE2PiWx6WcQkZYZdA5UasaBptUJqGn54MFux5'
+      address: 'QmRWTEejPDDwALaquFGm6X2GBbbh5osYDXwCRRkoZ6KQhb'
       startBlock: 0
     mapping:
       apiVersion: 0.0.7
@@ -18,4 +18,6 @@ dataSources:
           entity: Block
         - handler: handleEntity2
           entity: Block2
+        - handler: handleEntity3
+          entity: Block3
       file: ./src/mapping.ts


### PR DESCRIPTION
When using subgraph composition and indexing entity of different type `id`, the subgraph wouldn't sync due to the below error
```
UNION types bytea and text cannot be matched
```

This was because the `FindRangeQuery` SQL generator wasn't casting entity IDs to a consistent type, causing `UNION ALL` operations to fail when merging results from subgraphs with different ID types