### PR TITLE
Fix bug where immutable entities bypass memoization index during batch processing

### DIFF
--- a/graph/src/components/store/write.rs
+++ b/graph/src/components/store/write.rs
@@ -446,7 +446,7 @@ impl RowGroup {
         if self.immutable {
             match row {
                 EntityModification::Insert { .. } => {
-                    self.rows.push(row);
+                    self.push_row(row);
                 }
                 EntityModification::Overwrite { .. } | EntityModification::Remove { .. } => {
                     return Err(internal_error!(


### PR DESCRIPTION
Immutable entities were bypassing our memoization indexing system. Here's what was happening:

1. Immutable entities were added directly to the batch rows via `append_row()`
2. This skipped the memoization index that `push_row()` normally maintains
3. When the system later tried to look up these entities, it couldn't find them despite being present in memory
4. This caused `store.get()` to return `None` while the entity existed in cache, triggering assertion panics

#### Solution
Change `append_row()` to use `self.push_row(row)` instead of `self.rows.push(row)` for immutable entity inserts. This ensures they're properly indexed while preserving the intended performance benefits.

```rust
// Before: self.rows.push(row);
// After:  self.push_row(row);
```
