### PR TITLE
Add extensible compression support for RPC requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,6 +1406,7 @@ version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
 dependencies = [
+ "brotli",
  "flate2",
  "futures-core",
  "memchr",
@@ -1868,6 +1884,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]

--- a/chain/ethereum/src/lib.rs
+++ b/chain/ethereum/src/lib.rs
@@ -14,7 +14,7 @@ mod transport;
 pub use self::capabilities::NodeCapabilities;
 pub use self::ethereum_adapter::EthereumAdapter;
 pub use self::runtime::RuntimeAdapter;
-pub use self::transport::Transport;
+pub use self::transport::{Compression, Transport};
 pub use env::ENV_VARS;
 
 pub use buffered_call_cache::BufferedCallCache;

--- a/chain/ethereum/src/network.rs
+++ b/chain/ethereum/src/network.rs
@@ -314,7 +314,7 @@ mod tests {
     use graph::components::network_provider::ProviderManager;
     use graph::components::network_provider::ProviderName;
     use graph::data::value::Word;
-    use graph::endpoint::Compression;
+
     use graph::http::HeaderMap;
     use graph::{
         endpoint::EndpointMetrics,
@@ -325,7 +325,9 @@ mod tests {
     };
     use std::sync::Arc;
 
-    use crate::{EthereumAdapter, EthereumAdapterTrait, ProviderEthRpcMetrics, Transport};
+    use crate::{
+        Compression, EthereumAdapter, EthereumAdapterTrait, ProviderEthRpcMetrics, Transport,
+    };
 
     use super::{EthereumNetworkAdapter, EthereumNetworkAdapters, NodeCapabilities};
 

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -26,7 +26,7 @@ diesel_derives = { workspace = true }
 chrono = "0.4.43"
 envconfig = { workspace = true }
 Inflector = "0.11.3"
-reqwest = { version = "0.12.23", features = ["json", "stream", "multipart", "gzip"] }
+reqwest = { version = "0.12.23", features = ["json", "stream", "multipart", "gzip", "brotli", "deflate"] }
 ethabi = "17.2"
 hex = "0.4.3"
 http0 = { version = "0", package = "http" }

--- a/graph/src/endpoint.rs
+++ b/graph/src/endpoint.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use prometheus::IntCounterVec;
-use serde::{Deserialize, Serialize};
 use slog::{warn, Logger};
 
 use crate::components::network_provider::ProviderName;
@@ -17,16 +16,6 @@ use crate::{components::metrics::MetricsRegistry, data::value::Word};
 /// we require that all the hosts are known ahead of time, this way we can
 /// avoid locking since we don't need to modify the entire struture.
 type ProviderCount = Arc<HashMap<ProviderName, AtomicU64>>;
-
-/// Compression methods for RPC transports
-#[derive(Copy, Clone, Debug, Default, Deserialize, Serialize, PartialEq)]
-pub enum Compression {
-    #[default]
-    #[serde(rename = "none")]
-    None,
-    #[serde(rename = "gzip")]
-    Gzip,
-}
 
 /// This struct represents all the current labels except for the result
 /// which is added separately. If any new labels are necessary they should

--- a/node/resources/tests/full_config.toml
+++ b/node/resources/tests/full_config.toml
@@ -48,7 +48,7 @@ shard = "primary"
 provider = [
   { label = "mainnet-0", url = "http://rpc.mainnet.io", features = ["archive", "traces"] },
   { label = "mainnet-1", details = { type = "web3call", url = "http://rpc.mainnet.io", features = ["archive", "traces"] }},
-  { label = "mainnet-2", details = { type = "web3", url = "http://rpc.mainnet.io", features = ["archive"], compression = "gzip" }},
+  { label = "mainnet-2", details = { type = "web3", url = "http://rpc.mainnet.io", features = ["archive", "compression/gzip"] }},
   { label = "firehose", details = { type = "firehose", url = "http://localhost:9000", features = [] }},
 ]
 

--- a/node/src/chain.rs
+++ b/node/src/chain.rs
@@ -206,12 +206,13 @@ pub async fn create_ethereum_networks_for_chain(
         }
 
         let logger = logger.new(o!("provider" => provider.label.clone()));
+        let compression = web3.compression();
         info!(
             logger,
             "Creating transport";
             "url" => &web3.url,
             "capabilities" => capabilities,
-            "compression" => ?web3.compression
+            "compression" => compression.to_string()
         );
 
         use crate::config::Transport::*;
@@ -224,7 +225,7 @@ pub async fn create_ethereum_networks_for_chain(
                 endpoint_metrics.cheap_clone(),
                 &provider.label,
                 no_eip2718,
-                web3.compression,
+                compression,
             ),
             Ipc => Transport::new_ipc(&web3.url).await,
             Ws => Transport::new_ws(&web3.url).await,


### PR DESCRIPTION
## Summary

Adds configurable compression support for Graph Node's outgoing JSON-RPC requests to upstream providers, supporting gzip, brotli, and deflate methods.

## Goal

Allow node operators to enable compression on a per-provider basis for outgoing RPC requests, reducing bandwidth usage between Graph Node and upstream providers.

## Design

Compression is configured through the existing features array on providers using `compression/gzip`, `compression/brotli`, or `compression/deflate`. A `Compression` enum is used internally to represent the selected method. At most one `compression/*` feature may be set per provider — this is validated at config load time.

## Changes

### Transport layer (`chain/ethereum/src/transport.rs`)
- Added `Compression` enum with `None` (default), `Gzip`, `Brotli`, `Deflate` variants
- `Transport::new_rpc()` accepts a `Compression` parameter and calls the appropriate reqwest builder method

### Config layer (`node/src/config.rs`)
- Added `compression/gzip`, `compression/brotli`, and `compression/deflate` to `PROVIDER_FEATURES`
- Added `compression() -> Compression` on `Web3Provider` that maps features to the enum
- Added validation that at most one `compression/*` feature is present per provider

### Wiring layer (`node/src/chain.rs`)
- Reads `web3.compression()` and passes it to `Transport::new_rpc()`
- Logs the active compression method during transport creation

### Network tests (`chain/ethereum/src/network.rs`)
- Updated all `Transport::new_rpc()` test call sites to use `Compression::None`

### Public exports (`chain/ethereum/src/lib.rs`)
- Exported `Compression` alongside `Transport`

### Dependencies (`graph/Cargo.toml`)
- Added `"gzip"`, `"brotli"`, and `"deflate"` to reqwest features

### ArweaveClient fix (`graph/src/components/link_resolver/arweave.rs`)
- Explicitly disables gzip on the HTTP client. Enabling the reqwest `gzip` feature makes `Client::default()` automatically negotiate gzip, which strips `content-length` headers that ArweaveClient depends on for file size checks.

## Configuration

```toml
features = ["archive", "compression/gzip"]
# or
features = ["archive", "compression/brotli"]
# or
features = ["archive", "compression/deflate"]
```

Omitting any `compression/*` feature means no compression (the default).

### Full example

```toml
[chains.mainnet]
provider = [
  {
    label = "mainnet-rpc",
    details = {
      type = "web3",
      url = "http://rpc.example.com",
      features = ["archive", "compression/brotli"]
    }
  }
]
```

## Test plan

- [x] Unit tests for all compression configuration parsing (gzip, brotli, deflate)
- [x] Mutual exclusivity validation rejects multiple compression features
- [x] ArweaveClient test passes with gzip globally enabled
- [x] `cargo check --release` passes
- [x] `just lint` passes with zero warnings
- [ ] Manual testing with real RPC providers