### PR TITLE
tests: Pin anvil to version 1.2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,10 @@ jobs:
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          # Pinned to specific version since newer versions do not produce
+          # deterministic block hashes. Unpin once that's fixed upstream
+          version: v1.2.3
       - name: Start anvil
         run: anvil --gas-limit 100000000000 --base-fee 1 --block-time 2 --timestamp 1743944919 --port 3021 &
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -20,7 +20,9 @@ services:
       POSTGRES_DB: graph-node
       POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
   anvil:
-    image: ghcr.io/foundry-rs/foundry:stable
+    # Pinned to specific version since newer versions do not produce
+    # deterministic block hashes. Unpin once that's fixed upstream
+    image: ghcr.io/foundry-rs/foundry:v1.2.3
     ports:
       - '3021:8545'
     command: "'anvil --host 0.0.0.0 --gas-limit 100000000000 --base-fee 1 --block-time 2 --timestamp 1743944919 --mnemonic \"test test test test test test test test test test test junk\"'"


### PR DESCRIPTION
It seems that anvil 1.2.3 is the last version to produce deterministic block hashes reliably. The 'grafted' test really needs deterministic block hashes as they influence the PoI which this test checks.

If [this foundry bug](https://github.com/foundry-rs/foundry/issues/9570) gets fixed, we should try again with latest stable foundry.

I spent way too much time trying to work around the nondeterministic block hashes - anything we can do there is way grosser and more brittle than just pinning anvil until upstream is fixed and makes block hashes deterministic.