### PR TITLE
node: pause subgraphs before reassigning in graphman

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6904,7 +6904,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
 dependencies = [
- "windows-link 0.1.1",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -6915,7 +6915,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link 0.1.1",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6924,7 +6924,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link 0.1.1",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7000,7 +7000,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -169,6 +169,14 @@ pub enum Command {
         deployment: DeploymentSearch,
         /// The name of the node that should index the deployment
         node: String,
+        /// Sleep for this many seconds between pausing and reassigning subgraphs
+        #[clap(
+            long,
+            short,
+            default_value = "20",
+            value_parser = parse_duration_in_secs
+        )]
+        sleep: Duration,
     },
     /// Unassign a deployment
     Unassign {
@@ -1230,7 +1238,11 @@ async fn main() -> anyhow::Result<()> {
             let deployment = make_deployment_selector(deployment);
             commands::deployment::unassign::run(primary_pool, notifications_sender, deployment)
         }
-        Reassign { deployment, node } => {
+        Reassign {
+            deployment,
+            node,
+            sleep,
+        } => {
             let notifications_sender = ctx.notification_sender();
             let primary_pool = ctx.primary_pool();
             let deployment = make_deployment_selector(deployment);
@@ -1240,6 +1252,7 @@ async fn main() -> anyhow::Result<()> {
                 notifications_sender,
                 deployment,
                 &node,
+                sleep,
             )
         }
         Pause { deployment } => {


### PR DESCRIPTION
When reassigning subgraph and not pausing, it gives the below error and creates a race condition.
```
Failed to transact block operations: subgraph `Qm.....` has already processed block `xxx`; there are most likely two (or more) nodes indexing this subgraph
```
This PR solves the issue by pausing subgraphs  and waits before reassigning subgraphs.