### PR TITLE
all: Defer getting manifest from IPFS when starting subgraph

### DIFF
--- a/graph/src/components/subgraph/instance_manager.rs
+++ b/graph/src/components/subgraph/instance_manager.rs
@@ -13,7 +13,6 @@ pub trait SubgraphInstanceManager: Send + Sync + 'static {
     async fn start_subgraph(
         self: Arc<Self>,
         deployment: DeploymentLocator,
-        manifest: serde_yaml::Mapping,
         stop_block: Option<BlockNumber>,
     );
     async fn stop_subgraph(&self, deployment: DeploymentLocator);

--- a/node/src/launcher.rs
+++ b/node/src/launcher.rs
@@ -294,12 +294,8 @@ fn build_subgraph_registrar(
     );
 
     // Create IPFS-based subgraph provider
-    let subgraph_provider = IpfsSubgraphAssignmentProvider::new(
-        &logger_factory,
-        link_resolver.clone(),
-        subgraph_instance_manager,
-        sg_count,
-    );
+    let subgraph_provider =
+        IpfsSubgraphAssignmentProvider::new(&logger_factory, subgraph_instance_manager, sg_count);
 
     // Check version switching mode environment variable
     let version_switching_mode = ENV_VARS.subgraph_version_switching_mode;

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -158,7 +158,6 @@ pub async fn run(
     // Create IPFS-based subgraph provider
     let subgraph_provider = Arc::new(IpfsSubgraphAssignmentProvider::new(
         &logger_factory,
-        link_resolver.cheap_clone(),
         subgraph_instance_manager,
         sg_metrics,
     ));

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -574,7 +574,6 @@ pub async fn setup_inner<C: Blockchain>(
     // Create IPFS-based subgraph provider
     let subgraph_provider = Arc::new(IpfsSubgraphAssignmentProvider::new(
         &logger_factory,
-        link_resolver.cheap_clone(),
         subgraph_instance_manager.clone(),
         sg_count,
     ));


### PR DESCRIPTION
The current code in `SubgraphAssignmentProvider.start` fetched the manifest from IPFS before starting a subgraph. But the code calling `start`, ultimately `SubgraphRegistrar.start_assigned_subgraphs` waited for all subgraphs to start successfully before processing assignment events.

That could lead to a situation where a slow IPFS server, even if it was slow for just one subgraph, could keep a node from processing assignment events.

With these changes, interacting with IPFS is deferred to the future that is spawned for running the subgraph so that slow IPFS can slow how long it takes for a subgraph to start, but not the system overall.

