### PR TITLE
Downgrade ubuntu version for gnd build action

### DIFF
--- a/.github/workflows/gnd-binary-build.yml
+++ b/.github/workflows/gnd-binary-build.yml
@@ -12,10 +12,10 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-latest
+            runner: ubuntu-22.04
             asset_name: gnd-linux-x86_64
           - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-24.04-arm
+            runner: ubuntu-22.04
             asset_name: gnd-linux-aarch64
           - target: x86_64-apple-darwin
             runner: macos-13


### PR DESCRIPTION
Previously the workflow was running on Ubuntu 24.04 this caused it to fail with the error on older Linux Machines
```
version `GLIBC_2.38' not found
```