### PR TITLE
Feat/graphman/clear stale call cache

### DIFF
--- a/docs/graphman.md
+++ b/docs/graphman.md
@@ -371,20 +371,26 @@ Inspect all blocks after block `13000000`:
 
 Remove the call cache of the specified chain.
 
-If block numbers are not mentioned in `--from` and `--to`, then all the call cache will be removed.
+Either remove entries in the range `--from` and `--to`, remove stale contracts which have not been accessed for a specified duration `--ttl_days`, or remove the entire cache with `--remove-entire-cache`. Removing the entire cache can reduce indexing performance significantly and should generally be avoided.
 
-USAGE:
-    graphman chain call-cache <CHAIN_NAME> remove [OPTIONS]
+    Usage: graphman chain call-cache <CHAIN_NAME> remove [OPTIONS]
 
-OPTIONS:
+    Options:
+        --remove-entire-cache
+            Remove the entire cache
+
+        --ttl-days <TTL_DAYS>
+            Remove stale contracts based on call_meta table
+
     -f, --from <FROM>
             Starting block number
 
-    -h, --help
-            Print help information
-
     -t, --to <TO>
             Ending block number
+
+    -h, --help
+            Print help (see a summary with '-h')
+
 
 ### DESCRIPTION
 
@@ -404,6 +410,12 @@ the first block number will be used as the starting block number.
 The `to` option is used to specify the ending block number of the block range. In the absence of `to` option,
 the last block number will be used as the ending block number.
 
+#### `--remove-entire-cache`
+The `--remove-entire-cache` option is used to remove the entire call cache of the specified chain.
+
+#### `--ttl-days <TTL_DAYS>`
+The `--ttl-days` option is used to remove stale contracts based on the `call_meta.accessed_at` field. For example, if `--ttl-days` is set to 7, all calls to a contract that has not been accessed in the last 7 days will be removed from the call cache.
+
 ### EXAMPLES
 
 Remove the call cache for all blocks numbered from 10 to 20:
@@ -412,5 +424,9 @@ Remove the call cache for all blocks numbered from 10 to 20:
 
 Remove all the call cache of the specified chain:
 
-    graphman --config config.toml chain call-cache ethereum remove
+    graphman --config config.toml chain call-cache ethereum remove --remove-entire-cache
+
+Remove stale contracts from the call cache that have not been accessed in the last 7 days:
+
+    graphman --config config.toml chain call-cache ethereum remove --ttl-days 7
 

--- a/graph/src/blockchain/mock.rs
+++ b/graph/src/blockchain/mock.rs
@@ -571,6 +571,9 @@ impl ChainStore for MockChainStore {
     async fn clear_call_cache(&self, _from: BlockNumber, _to: BlockNumber) -> Result<(), Error> {
         unimplemented!()
     }
+    async fn clear_stale_call_cache(&self, _ttl_days: i32) -> Result<(), Error> {
+        unimplemented!()
+    }
     fn chain_identifier(&self) -> Result<ChainIdentifier, Error> {
         unimplemented!()
     }

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -598,6 +598,9 @@ pub trait ChainStore: ChainHeadStore {
     /// Clears call cache of the chain for the given `from` and `to` block number.
     async fn clear_call_cache(&self, from: BlockNumber, to: BlockNumber) -> Result<(), Error>;
 
+    /// Clears stale call cache entries for the given TTL in days.
+    async fn clear_stale_call_cache(&self, ttl_days: i32) -> Result<(), Error>;
+
     /// Return the chain identifier for this store.
     fn chain_identifier(&self) -> Result<ChainIdentifier, Error>;
 

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -555,14 +555,18 @@ pub enum ChainCommand {
 pub enum CallCacheCommand {
     /// Remove the call cache of the specified chain.
     ///
-    /// Either remove entries in the range `--from` and `--to`, or remove
-    /// the entire cache with `--remove-entire-cache`. Removing the entire
+    /// Either remove entries in the range `--from` and `--to`,
+    /// remove the cache for contracts that have not been accessed for the specified duration --ttl_days,
+    /// or remove the entire cache with `--remove-entire-cache`. Removing the entire
     /// cache can reduce indexing performance significantly and should
     /// generally be avoided.
     Remove {
         /// Remove the entire cache
         #[clap(long, conflicts_with_all = &["from", "to"])]
         remove_entire_cache: bool,
+        /// Remove the cache for contracts that have not been accessed in the last <TTL_DAYS> days
+        #[clap(long, conflicts_with_all = &["from", "to", "remove-entire-cache"])]
+        ttl_days: Option<i32>,
         /// Starting block number
         #[clap(long, short, conflicts_with = "remove-entire-cache", requires = "to")]
         from: Option<i32>,
@@ -1472,8 +1476,17 @@ async fn main() -> anyhow::Result<()> {
                             from,
                             to,
                             remove_entire_cache,
+                            ttl_days,
                         } => {
                             let chain_store = ctx.chain_store(&chain_name)?;
+                            if let Some(ttl_days) = ttl_days {
+                                return commands::chain::clear_stale_call_cache(
+                                    chain_store,
+                                    ttl_days,
+                                )
+                                .await;
+                            }
+
                             if !remove_entire_cache && from.is_none() && to.is_none() {
                                 bail!("you must specify either --from and --to or --remove-entire-cache");
                             }

--- a/node/src/manager/commands/chain.rs
+++ b/node/src/manager/commands/chain.rs
@@ -81,6 +81,18 @@ pub async fn clear_call_cache(
     Ok(())
 }
 
+pub async fn clear_stale_call_cache(
+    chain_store: Arc<ChainStore>,
+    ttl_days: i32,
+) -> Result<(), Error> {
+    println!(
+        "Removing stale entries from the call cache for `{}`",
+        chain_store.chain
+    );
+    chain_store.clear_stale_call_cache(ttl_days).await?;
+    Ok(())
+}
+
 pub async fn info(
     primary: ConnectionPool,
     store: Arc<BlockStore>,


### PR DESCRIPTION
Partialy addresses https://github.com/graphprotocol/graph-node/issues/4503

What this PR does:
1. Adds a new option `--ttl-days <days>` to the `graphman chain call-cache <chain> remove` command
Executing the command using the `--ttl-days` option, will remove call cache entries for contracts that haven't been accessed within a user-defined number of days
2. Updates the documentation to reflect the new options
3. Adds a test to verify query correctness.

