### PR TITLE
node, gnd: Fix typos in command-line option help strings

### DIFF
--- a/gnd/src/main.rs
+++ b/gnd/src/main.rs
@@ -84,7 +84,7 @@ pub struct DevOpt {
         allow_negative_numbers = false,
         value_name = "NETWORK_NAME:[CAPABILITIES]:URL",
         env = "ETHEREUM_RPC",
-        help = "Ethereum network name (e.g. 'mainnet'), optional comma-seperated capabilities (eg 'full,archive'), and an Ethereum RPC URL, separated by a ':'"
+        help = "Ethereum network name (e.g. 'mainnet'), optional comma-separated capabilities (eg 'full,archive'), and an Ethereum RPC URL, separated by a ':'"
     )]
     pub ethereum_rpc: Vec<String>,
 

--- a/node/src/opt.rs
+++ b/node/src/opt.rs
@@ -82,7 +82,7 @@ pub struct Opt {
         conflicts_with_all = &["ethereum_ws", "ethereum_ipc", "config"],
         value_name="NETWORK_NAME:[CAPABILITIES]:URL",
         env="ETHEREUM_RPC",
-        help= "Ethereum network name (e.g. 'mainnet'), optional comma-seperated capabilities (eg 'full,archive'), and an Ethereum RPC URL, separated by a ':'",
+        help= "Ethereum network name (e.g. 'mainnet'), optional comma-separated capabilities (eg 'full,archive'), and an Ethereum RPC URL, separated by a ':'",
     )]
     pub ethereum_rpc: Vec<String>,
     #[clap(long, allow_negative_numbers = false,
@@ -90,7 +90,7 @@ pub struct Opt {
         conflicts_with_all = &["ethereum_rpc", "ethereum_ipc", "config"],
         value_name="NETWORK_NAME:[CAPABILITIES]:URL",
         env="ETHEREUM_WS",
-        help= "Ethereum network name (e.g. 'mainnet'), optional comma-seperated capabilities (eg 'full,archive`, and an Ethereum WebSocket URL, separated by a ':'",
+        help= "Ethereum network name (e.g. 'mainnet'), optional comma-separated capabilities (eg 'full,archive', and an Ethereum WebSocket URL, separated by a ':'",
     )]
     pub ethereum_ws: Vec<String>,
     #[clap(long,
@@ -99,7 +99,7 @@ pub struct Opt {
         conflicts_with_all = &["ethereum_rpc", "ethereum_ws", "config"],
         value_name="NETWORK_NAME:[CAPABILITIES]:FILE",
         env="ETHEREUM_IPC",
-        help= "Ethereum network name (e.g. 'mainnet'), optional comma-seperated capabilities (eg 'full,archive'), and an Ethereum IPC pipe, separated by a ':'",
+        help= "Ethereum network name (e.g. 'mainnet'), optional comma-separated capabilities (eg 'full,archive'), and an Ethereum IPC pipe, separated by a ':'",
     )]
     pub ethereum_ipc: Vec<String>,
     #[clap(


### PR DESCRIPTION
Fixes typos in command-line option help text: "comma-seperated" -> "comma-separated" and some inconsistencies to improve readability