### PR TITLE
Load the raw subgraph manifests from the store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3176,6 +3176,7 @@ dependencies = [
  "rand 0.9.2",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sqlparser 0.60.0",
  "stable-hash 0.3.4",
  "thiserror 2.0.17",

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,6 @@
+mod subgraph_manifest;
+
 pub mod amp_subgraph;
 pub mod polling_monitor;
-
 pub mod subgraph;
 pub mod subgraph_provider;

--- a/core/src/subgraph_manifest.rs
+++ b/core/src/subgraph_manifest.rs
@@ -1,0 +1,93 @@
+use graph::{
+    cheap_clone::CheapClone as _,
+    components::{
+        link_resolver::{LinkResolver, LinkResolverContext},
+        store::{StoreError, SubgraphStore},
+    },
+    data::subgraph::DeploymentHash,
+};
+use slog::{debug, Logger};
+
+pub(super) async fn load_raw_subgraph_manifest(
+    logger: &Logger,
+    subgraph_store: &dyn SubgraphStore,
+    link_resolver: &dyn LinkResolver,
+    hash: &DeploymentHash,
+) -> Result<serde_yaml::Mapping, Error> {
+    if let Some(raw_manifest) =
+        subgraph_store
+            .raw_manifest(hash)
+            .await
+            .map_err(|e| Error::LoadManifest {
+                hash: hash.cheap_clone(),
+                source: anyhow::Error::from(e),
+            })?
+    {
+        debug!(logger, "Loaded raw manifest from the subgraph store");
+        return Ok(raw_manifest);
+    }
+
+    debug!(logger, "Loading raw manifest using link resolver");
+
+    let link_resolver =
+        link_resolver
+            .for_manifest(&hash.to_string())
+            .map_err(|e| Error::CreateLinkResolver {
+                hash: hash.cheap_clone(),
+                source: e,
+            })?;
+
+    let file_bytes = link_resolver
+        .cat(
+            &LinkResolverContext::new(hash, logger),
+            &hash.to_ipfs_link(),
+        )
+        .await
+        .map_err(|e| Error::LoadManifest {
+            hash: hash.cheap_clone(),
+            source: e,
+        })?;
+
+    let raw_manifest: serde_yaml::Mapping =
+        serde_yaml::from_slice(&file_bytes).map_err(|e| Error::ParseManifest {
+            hash: hash.cheap_clone(),
+            source: e,
+        })?;
+
+    subgraph_store
+        .set_raw_manifest_once(hash, &raw_manifest)
+        .await
+        .map_err(|e| Error::StoreManifest {
+            hash: hash.cheap_clone(),
+            source: e,
+        })?;
+
+    Ok(raw_manifest)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(super) enum Error {
+    #[error("failed to create link resolver for '{hash}': {source:#}")]
+    CreateLinkResolver {
+        hash: DeploymentHash,
+        source: anyhow::Error,
+    },
+
+    #[error("failed to load manifest for '{hash}': {source:#}")]
+    LoadManifest {
+        hash: DeploymentHash,
+        source: anyhow::Error,
+    },
+
+    #[error("failed to parse manifest for '{hash}': {source:#}")]
+    ParseManifest {
+        hash: DeploymentHash,
+        source: serde_yaml::Error,
+    },
+
+    #[error("failed to store manifest for '{hash}': {source:#}")]
+    StoreManifest {
+        hash: DeploymentHash,
+        source: StoreError,
+    },
+}

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -222,17 +222,27 @@ pub trait SubgraphStore: Send + Sync + 'static {
     /// hash. Returns `None` if there is no deployment with that hash
     async fn active_locator(&self, hash: &str) -> Result<Option<DeploymentLocator>, StoreError>;
 
-    /// This migrates subgraphs that existed before the raw_yaml column was added.
-    async fn set_manifest_raw_yaml(
-        &self,
-        hash: &DeploymentHash,
-        raw_yaml: String,
-    ) -> Result<(), StoreError>;
-
     /// Return `true` if the `instrument` flag for the deployment is set.
     /// When this flag is set, indexing of the deployment should log
     /// additional diagnostic information
     async fn instrument(&self, deployment: &DeploymentLocator) -> Result<bool, StoreError>;
+
+    /// Sets the raw subgraph manifest for the given deployment hash, if not previously set.
+    ///
+    /// Returns `Ok(())` regardless of whether the value was updated.
+    async fn set_raw_manifest_once(
+        &self,
+        hash: &DeploymentHash,
+        raw_manifest: &serde_yaml::Mapping,
+    ) -> Result<(), StoreError>;
+
+    /// Returns the raw subgraph manifest for the given deployment hash, if one exists.
+    ///
+    /// Returns `None` if no manifest is found for the specified deployment hash.
+    async fn raw_manifest(
+        &self,
+        hash: &DeploymentHash,
+    ) -> Result<Option<serde_yaml::Mapping>, StoreError>;
 }
 
 #[async_trait]

--- a/node/src/launcher.rs
+++ b/node/src/launcher.rs
@@ -332,6 +332,7 @@ where
     let subgraph_provider = graph_core::subgraph_provider::SubgraphProvider::new(
         &logger_factory,
         sg_count.cheap_clone(),
+        network_store.subgraph_store(),
         link_resolver.cheap_clone(),
         tokio_util::sync::CancellationToken::new(),
         subgraph_instance_managers,

--- a/node/src/manager/commands/run.rs
+++ b/node/src/manager/commands/run.rs
@@ -201,6 +201,7 @@ pub async fn run(
     let subgraph_provider = Arc::new(graph_core::subgraph_provider::SubgraphProvider::new(
         &logger_factory,
         sg_metrics.cheap_clone(),
+        subgraph_store.clone(),
         link_resolver.cheap_clone(),
         cancel_token.clone(),
         subgraph_instance_managers,

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -37,6 +37,7 @@ hex = "0.4.3"
 pretty_assertions = "1.4.1"
 sqlparser = { workspace = true }
 thiserror = { workspace = true }
+serde_yaml.workspace = true
 
 [dev-dependencies]
 clap.workspace = true

--- a/store/postgres/src/deployment_store.rs
+++ b/store/postgres/src/deployment_store.rs
@@ -1894,17 +1894,28 @@ impl DeploymentStore {
         deployment::health(&mut conn, id).await
     }
 
-    pub(crate) async fn set_manifest_raw_yaml(
-        &self,
-        site: Arc<Site>,
-        raw_yaml: String,
-    ) -> Result<(), StoreError> {
-        let mut conn = self.pool.get_permitted().await?;
-        deployment::set_manifest_raw_yaml(&mut conn, &site, &raw_yaml).await
-    }
-
     async fn is_source(&self, site: &Site) -> Result<bool, StoreError> {
         self.primary.is_source(site).await
+    }
+
+    /// Sets the raw subgraph manifest for the given `site`, if not previously set.
+    ///
+    /// Returns `Ok(())` regardless of whether the value was updated.
+    pub(crate) async fn set_raw_manifest_once(
+        &self,
+        site: Arc<Site>,
+        raw_manifest: String,
+    ) -> Result<(), StoreError> {
+        let mut conn = self.pool.get_permitted().await?;
+        deployment::set_raw_manifest_once(&mut conn, &site, &raw_manifest).await
+    }
+
+    /// Returns the raw subgraph manifest for the given `site`, if one exists.
+    ///
+    /// Returns `None` if no manifest is found for this `site`.
+    pub(crate) async fn raw_manifest(&self, site: Arc<Site>) -> Result<Option<String>, StoreError> {
+        let mut conn = self.pool.get_permitted().await?;
+        deployment::load_raw_manifest(&mut conn, &site).await
     }
 }
 

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -589,6 +589,7 @@ pub async fn setup_inner<C: Blockchain>(
     let subgraph_provider = Arc::new(graph_core::subgraph_provider::SubgraphProvider::new(
         &logger_factory,
         sg_count.cheap_clone(),
+        subgraph_store.clone(),
         link_resolver.cheap_clone(),
         tokio_util::sync::CancellationToken::new(),
         subgraph_instance_managers,


### PR DESCRIPTION
This PR updates the subgraph instance managers to use cached versions of the raw subgraph manifests during startup.