### PR TITLE
ci: Do not use nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,6 @@ jobs:
       - name: Setup just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
 
-      - name: Install cargo-nextest
-        uses: baptiste0928/cargo-install@e38323ef017552d7f7af73a3f4db467f278310ed # v3
-        with:
-          crate: cargo-nextest
-          version: ^0.9
-
       - name: Run unit tests
         run: just test-unit --verbose
 
@@ -105,12 +99,6 @@ jobs:
 
       - name: Setup just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
-
-      - name: Install cargo-nextest
-        uses: baptiste0928/cargo-install@e38323ef017552d7f7af73a3f4db467f278310ed # v3
-        with:
-          crate: cargo-nextest
-          version: ^0.9
 
       - name: Install pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
@@ -164,12 +152,6 @@ jobs:
 
       - name: Setup just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3
-
-      - name: Install cargo-nextest
-        uses: baptiste0928/cargo-install@e38323ef017552d7f7af73a3f4db467f278310ed # v3
-        with:
-          crate: cargo-nextest
-          version: ^0.9
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # v1

--- a/justfile
+++ b/justfile
@@ -22,67 +22,33 @@ check-all:
 build *EXTRA_FLAGS:
     cargo build --bin graph-node {{EXTRA_FLAGS}}
 
-# Run all tests (unit and integration)
-test *EXTRA_FLAGS:
+_cargo-test *ARGS:
     #!/usr/bin/env bash
     set -e # Exit on error
 
     # Ensure that the `THEGRAPH_STORE_POSTGRES_DIESEL_URL` environment variable is set.
-    if [ -z "$THEGRAPH_STORE_POSTGRES_DIESEL_URL" ]; then
-        echo "Error: THEGRAPH_STORE_POSTGRES_DIESEL_URL is not set"
+    if [ -z "$THEGRAPH_STORE_POSTGRES_DIESEL_URL" -a -z "$GRAPH_NODE_TEST_CONFIG" ]; then
+        echo "error: Neither THEGRAPH_STORE_POSTGRES_DIESEL_URL nor GRAPH_NODE_TEST_CONFIG is set"
         exit 1
     fi
 
-    if command -v "cargo-nextest" &> /dev/null; then
-        cargo nextest run {{EXTRA_FLAGS}} --workspace
-    else
-        cargo test {{EXTRA_FLAGS}} --workspace -- --nocapture
-    fi
+    cargo test {{ARGS}}
+
+# Run all tests (unit and integration)
+test *EXTRA_FLAGS:
+    @just _cargo-test {{EXTRA_FLAGS}} --workspace -- --nocapture
 
 # Run unit tests
 test-unit *EXTRA_FLAGS:
-    #!/usr/bin/env bash
-    set -e # Exit on error
-
-    # Ensure that the `THEGRAPH_STORE_POSTGRES_DIESEL_URL` environment variable is set.
-    if [ -z "$THEGRAPH_STORE_POSTGRES_DIESEL_URL" ]; then
-        echo "Error: THEGRAPH_STORE_POSTGRES_DIESEL_URL is not set"
-        exit 1
-    fi
-
-    if command -v "cargo-nextest" &> /dev/null; then
-        cargo nextest run {{EXTRA_FLAGS}} --workspace --exclude graph-tests
-    else
-        cargo test {{EXTRA_FLAGS}} --workspace --exclude graph-tests -- --nocapture
-    fi
+    @just _cargo-test {{EXTRA_FLAGS}} --workspace --exclude graph-tests -- --nocapture
 
 # Run runner tests
 test-runner *EXTRA_FLAGS:
-    #!/usr/bin/env bash
-    set -e # Exit on error
-
-    # Ensure that the `THEGRAPH_STORE_POSTGRES_DIESEL_URL` environment variable is set.
-    if [ -z "$THEGRAPH_STORE_POSTGRES_DIESEL_URL" ]; then
-        echo "Error: THEGRAPH_STORE_POSTGRES_DIESEL_URL is not set"
-        exit 1
-    fi
-
-    if command -v "cargo-nextest" &> /dev/null; then
-        cargo nextest run {{EXTRA_FLAGS}} --package graph-tests --test runner_tests
-    else
-        cargo test {{EXTRA_FLAGS}} --package graph-tests --test runner_tests -- --nocapture
-    fi
+    @just _cargo-test {{EXTRA_FLAGS}} --package graph-tests --test runner_tests -- --nocapture
 
 # Run integration tests
 test-integration *EXTRA_FLAGS:
-    #!/usr/bin/env bash
-    set -e # Exit on error
-
-    if command -v "cargo-nextest" &> /dev/null; then
-        cargo nextest run {{EXTRA_FLAGS}} --package graph-tests --test integration_tests
-    else
-        cargo test {{EXTRA_FLAGS}} --package graph-tests --test integration_tests -- --nocapture
-    fi
+    @just _cargo-test {{EXTRA_FLAGS}} --package graph-tests --test integration_tests -- --nocapture
 
 # Clean workspace (cargo clean)
 clean:


### PR DESCRIPTION
Nextest's process-per-test model is not well suited for how our tests work since it requires that database connectiosn are set up for every test in a test suite, rather than just once per suite. Running tests with nextest is actually quite a bit slower than just using `cargo test`

