### PR TITLE
build(deps): Bump tonic and prost related packages to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,9 +1125,9 @@ dependencies = [
 
 [[package]]
 name = "arrow"
-version = "55.0.0"
+version = "57.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3095aaf545942ff5abd46654534f15b03a90fba78299d661e045e5d587222f0d"
+checksum = "4df8bb5b0bd64c0b9bc61317fcc480bad0f00e56d3bc32c69a4c8dada4786bae"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -1146,23 +1146,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "55.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30feb679425110209ae35c3fbf82404a39a4c0436bb3ec36164d8bffed2a4ce4"
+checksum = "288015089e7931843c80ed4032c5274f02b37bcb720c4a42096d50b390e70372"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "chrono",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-array"
-version = "55.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70732f04d285d49054a48b72c54f791bb3424abae92d27aafdf776c98af161c8"
+checksum = "65ca404ea6191e06bf30956394173337fa9c35f445bd447fe6c21ab944e1a23c"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -1170,30 +1170,34 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.15.2",
- "num",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "55.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169b1d5d6cb390dd92ce582b06b23815c7953e9dfaaea75556e89d890d19993d"
+checksum = "36356383099be0151dacc4245309895f16ba7917d79bdb71a7148659c9206c56"
 dependencies = [
  "bytes",
  "half",
- "num",
+ "num-bigint 0.4.6",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "55.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f12eccc3e1c05a766cafb31f6a60a46c2f8efec9b74c6e0648766d30686af8"
+checksum = "9c8e372ed52bd4ee88cc1e6c3859aa7ecea204158ac640b10e187936e7e87074"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
+ "arrow-ord",
  "arrow-schema",
  "arrow-select",
  "atoi",
@@ -1201,15 +1205,15 @@ dependencies = [
  "chrono",
  "half",
  "lexical-core",
- "num",
+ "num-traits",
  "ryu",
 ]
 
 [[package]]
 name = "arrow-csv"
-version = "55.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "012c9fef3f4a11573b2c74aec53712ff9fdae4a95f4ce452d1bbf088ee00f06b"
+checksum = "8e4100b729fe656f2e4fb32bc5884f14acf9118d4ad532b7b33c1132e4dce896"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -1222,21 +1226,22 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "55.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de1ce212d803199684b658fc4ba55fb2d7e87b213de5af415308d2fee3619c2"
+checksum = "bf87f4ff5fc13290aa47e499a8b669a82c5977c6a1fedce22c7f542c1fd5a597"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
  "half",
- "num",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-flight"
-version = "55.0.0"
+version = "57.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e0fad280f41a918d53ba48288a246ff04202d463b3b380fbc0edecdcb52cfd"
+checksum = "f70bb56412a007b0cfc116d15f24dda6adeed9611a213852a004cda20085a3b9"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -1257,26 +1262,28 @@ dependencies = [
  "prost",
  "prost-types",
  "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
 name = "arrow-ipc"
-version = "55.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ea5967e8b2af39aff5d9de2197df16e305f47f404781d3230b2dc672da5d92"
+checksum = "eb3ca63edd2073fcb42ba112f8ae165df1de935627ead6e203d07c99445f2081"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
+ "arrow-select",
  "flatbuffers",
 ]
 
 [[package]]
 name = "arrow-json"
-version = "55.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5709d974c4ea5be96d900c01576c7c0b99705f4a3eec343648cb1ca863988a9c"
+checksum = "a36b2332559d3310ebe3e173f75b29989b4412df4029a26a30cc3f7da0869297"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1286,19 +1293,21 @@ dependencies = [
  "chrono",
  "half",
  "indexmap 2.11.4",
+ "itoa",
  "lexical-core",
  "memchr",
- "num",
- "serde",
+ "num-traits",
+ "ryu",
+ "serde_core",
  "serde_json",
  "simdutf8",
 ]
 
 [[package]]
 name = "arrow-ord"
-version = "55.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6506e3a059e3be23023f587f79c82ef0bcf6d293587e3272d20f2d30b969b5a7"
+checksum = "13c4e0530272ca755d6814218dffd04425c5b7854b87fa741d5ff848bf50aa39"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1309,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "55.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bf7393166beaf79b4bed9bfdf19e97472af32ce5b6b48169d321518a08cae2"
+checksum = "b07f52788744cc71c4628567ad834cadbaeb9f09026ff1d7a4120f69edf7abd3"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1322,29 +1331,29 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "55.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7686986a3bf2254c9fb130c623cdcb2f8e1f15763e7c71c310f0834da3d292"
+checksum = "6bb63203e8e0e54b288d0d8043ca8fa1013820822a27692ef1b78a977d879f2c"
 
 [[package]]
 name = "arrow-select"
-version = "55.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2b45757d6a2373faa3352d02ff5b54b098f5e21dccebc45a21806bc34501e5"
+checksum = "c96d8a1c180b44ecf2e66c9a2f2bbcb8b1b6f14e165ce46ac8bde211a363411b"
 dependencies = [
  "ahash",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-string"
-version = "55.2.0"
+version = "57.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0377d532850babb4d927a06294314b316e23311503ed580ec6ce6a0158f49d40"
+checksum = "a8ad6a81add9d3ea30bf8374ee8329992c7fd246ffd8b7e2f48a3cea5aa0cc9a"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -1352,7 +1361,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "memchr",
- "num",
+ "num-traits",
  "regex",
  "regex-syntax",
 ]
@@ -1414,7 +1423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8725874ecfbf399e071150b8619c4071d7b2b7a2f117e173dddef53c6bdb6bb1"
 dependencies = [
  "async-graphql",
- "axum 0.8.8",
+ "axum",
  "bytes",
  "futures-util",
  "serde_json",
@@ -1599,38 +1608,11 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "axum"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
-dependencies = [
- "async-trait",
- "axum-core 0.4.3",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.0",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 1.0.1",
- "tower 0.4.13",
- "tower-layer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core 0.5.5",
+ "axum-core",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -1641,7 +1623,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1651,33 +1633,13 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tower 0.5.2",
  "tower-layer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.0",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper 0.1.2",
- "tower-layer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1693,7 +1655,7 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tower-layer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
@@ -3733,7 +3695,7 @@ dependencies = [
  "num-traits",
  "object_store",
  "parking_lot",
- "petgraph 0.8.3",
+ "petgraph",
  "portable-atomic",
  "priority-queue",
  "prometheus",
@@ -3768,7 +3730,8 @@ dependencies = [
  "tokio-util 0.7.18",
  "toml 0.9.11+spec-1.1.0",
  "tonic",
- "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
  "url",
  "wasmparser 0.118.2",
  "wiremock",
@@ -3806,7 +3769,7 @@ dependencies = [
  "tiny-keccak 1.5.0",
  "tokio",
  "tokio-stream",
- "tonic-build",
+ "tonic-prost-build",
  "tower 0.5.2",
 ]
 
@@ -3824,7 +3787,7 @@ dependencies = [
  "prost-types",
  "serde",
  "tokio",
- "tonic-build",
+ "tonic-prost-build",
 ]
 
 [[package]]
@@ -4087,7 +4050,7 @@ dependencies = [
  "anyhow",
  "async-graphql",
  "async-graphql-axum",
- "axum 0.8.8",
+ "axum",
  "chrono",
  "diesel",
  "diesel-async",
@@ -5331,12 +5294,6 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -5516,20 +5473,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint 0.4.6",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5576,17 +5519,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-modular"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5599,17 +5531,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
 dependencies = [
  "num-modular",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -5904,16 +5825,6 @@ dependencies = [
  "once_cell",
  "pest",
  "sha2",
-]
-
-[[package]]
-name = "petgraph"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
-dependencies = [
- "fixedbitset",
- "indexmap 2.11.4",
 ]
 
 [[package]]
@@ -6312,9 +6223,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -6322,19 +6233,20 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
- "once_cell",
- "petgraph 0.7.1",
+ "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.114",
  "tempfile",
@@ -6342,9 +6254,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -6355,9 +6267,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
@@ -6405,6 +6317,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+dependencies = [
+ "bitflags 2.9.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -6778,7 +6710,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -6933,9 +6865,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "log",
  "once_cell",
@@ -6989,9 +6921,9 @@ checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.5"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -7775,15 +7707,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 dependencies = [
  "futures-core",
 ]
@@ -8123,12 +8049,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
- "rustls-pki-types",
  "tokio",
 ]
 
@@ -8300,13 +8225,12 @@ checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum 0.7.5",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "flate2",
@@ -8319,14 +8243,13 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
  "rustls-native-certs 0.8.1",
- "rustls-pemfile",
- "socket2 0.5.7",
+ "socket2 0.6.0",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-layer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
@@ -8334,9 +8257,32 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "27aac809edf60b741e2d7db6367214d078856b8a5bff0087e94ff330fb97b6fc"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6c55a2d6a14174563de34409c9f92ff981d006f56da9c6ecd40d9d4a31500b0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4556786613791cfef4ed134aa670b61a85cfcacf71543ef33e8d801abae988f"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -8344,26 +8290,8 @@ dependencies = [
  "prost-types",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util 0.7.18",
- "tower-layer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]
@@ -8378,7 +8306,7 @@ dependencies = [
  "indexmap 2.11.4",
  "pin-project-lite",
  "slab",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tokio",
  "tokio-util 0.7.18",
  "tower-layer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -8397,7 +8325,7 @@ dependencies = [
  "indexmap 2.11.4",
  "pin-project-lite",
  "slab",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tokio",
  "tokio-util 0.7.18",
  "tower-layer 0.3.3 (git+https://github.com/tower-rs/tower.git)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,8 @@ graphman-store = { path = "./core/graphman_store" }
 graphql-tools = "0.5.0"
 itertools = "0.14.0"
 lazy_static = "1.5.0"
-prost = "0.13"
-prost-types = "0.13"
+prost = "0.14"
+prost-types = "0.14"
 redis = { version = "1.0.2", features = [
     "aio",
     "connection-manager",
@@ -94,8 +94,9 @@ tokio = { version = "1.49.0", features = ["full"] }
 tokio-stream = { version = "0.1.18", features = ["sync"] }
 tokio-retry = "0.3.0"
 
-tonic = { version = "0.12.3", features = ["tls-roots", "gzip"] }
-tonic-build = { version = "0.12.3", features = ["prost"] }
+tonic = { version = "0.14", features = ["tls-native-roots", "gzip"] }
+tonic-prost = "0.14"
+tonic-prost-build = "0.14"
 tower-http = { version = "0.6.8", features = ["cors"] }
 tower = { version = "0.5.1", features = ["full"] }
 wasmparser = "0.118.1"
@@ -105,8 +106,8 @@ prometheus = "0.14.0"
 
 # Dependencies related to Amp subgraphs
 ahash = "0.8.11"
-arrow = { version = "=55.0.0" }
-arrow-flight = { version = "=55.0.0", features = ["flight-sql-experimental"] }
+arrow = { version = "=57.0.0" }
+arrow-flight = { version = "=57.0.0", features = ["flight-sql-experimental"] }
 futures = "0.3.31"
 half = "2.7.1"
 indoc = "2.0.7"

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -29,7 +29,7 @@ graph-runtime-derive = { path = "../../runtime/derive" }
 base64 = "0"
 
 [build-dependencies]
-tonic-build = { workspace = true }
+tonic-prost-build = { workspace = true }
 
 [lints]
 workspace = true

--- a/chain/ethereum/build.rs
+++ b/chain/ethereum/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     println!("cargo:rerun-if-changed=proto");
 
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .out_dir("src/protobuf")
         .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(&["proto/ethereum.proto"], &["proto"])

--- a/chain/ethereum/src/protobuf/sf.ethereum.r#type.v2.rs
+++ b/chain/ethereum/src/protobuf/sf.ethereum.r#type.v2.rs
@@ -173,8 +173,7 @@ pub mod block {
 pub struct BlockHeader {
     #[prost(bytes = "vec", tag = "1")]
     pub parent_hash: ::prost::alloc::vec::Vec<u8>,
-    /// Uncle hash of the block, some reference it as `sha3Uncles`, but `sha3`` is badly worded, so we prefer `uncle_hash`, also
-    /// referred as `ommers` in EIP specification.
+    /// Uncle hash of the block, some reference it as `sha3Uncles`, but ```sha3`` is badly worded, so we prefer ```uncle_hash`, also  referred as `ommers\` in EIP specification.
     ///
     /// If the Block containing this `BlockHeader` has been produced using the Proof of Stake
     /// consensus algorithm, this field will actually be constant and set to `0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347`.
@@ -215,7 +214,7 @@ pub struct BlockHeader {
     /// forks are using bigger values to carry special consensus data.
     ///
     /// If the Block containing this `BlockHeader` has been produced using the Proof of Stake
-    /// consensus algorithm, this field is strictly enforced to be <= 32 bytes.
+    /// consensus algorithm, this field is strictly enforced to be \<= 32 bytes.
     #[prost(bytes = "vec", tag = "13")]
     pub extra_data: ::prost::alloc::vec::Vec<u8>,
     /// MixHash is used to prove, when combined with the `nonce` that sufficient amount of computation has been
@@ -231,30 +230,29 @@ pub struct BlockHeader {
     pub nonce: u64,
     /// Hash is the hash of the block which is actually the computation:
     ///
-    ///   Keccak256(rlp([
-    ///     parent_hash,
-    ///     uncle_hash,
-    ///     coinbase,
-    ///     state_root,
-    ///     transactions_root,
-    ///     receipt_root,
-    ///     logs_bloom,
-    ///     difficulty,
-    ///     number,
-    ///     gas_limit,
-    ///     gas_used,
-    ///     timestamp,
-    ///     extra_data,
-    ///     mix_hash,
-    ///     nonce,
-    ///     base_fee_per_gas (to be included only if London fork is active)
-    ///     withdrawals_root (to be included only if Shangai fork is active)
-    ///     blob_gas_used (to be included only if Cancun fork is active)
-    ///     excess_blob_gas (to be included only if Cancun fork is active)
-    ///     parent_beacon_root (to be included only if Cancun fork is active)
-    ///     requests_hash (to be included only if Prague fork is active)
-    ///   ]))
-    ///
+    /// Keccak256(rlp(\[
+    /// parent_hash,
+    /// uncle_hash,
+    /// coinbase,
+    /// state_root,
+    /// transactions_root,
+    /// receipt_root,
+    /// logs_bloom,
+    /// difficulty,
+    /// number,
+    /// gas_limit,
+    /// gas_used,
+    /// timestamp,
+    /// extra_data,
+    /// mix_hash,
+    /// nonce,
+    /// base_fee_per_gas (to be included only if London fork is active)
+    /// withdrawals_root (to be included only if Shangai fork is active)
+    /// blob_gas_used (to be included only if Cancun fork is active)
+    /// excess_blob_gas (to be included only if Cancun fork is active)
+    /// parent_beacon_root (to be included only if Cancun fork is active)
+    /// requests_hash (to be included only if Prague fork is active)
+    /// \]))
     #[prost(bytes = "vec", tag = "16")]
     pub hash: ::prost::alloc::vec::Vec<u8>,
     /// Base fee per gas according to EIP-1559 (e.g. London Fork) rules, only set if London is present/active on the chain.
@@ -293,12 +291,12 @@ pub struct Uint64NestedArray {
     #[prost(message, repeated, tag = "1")]
     pub val: ::prost::alloc::vec::Vec<Uint64Array>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Uint64Array {
     #[prost(uint64, repeated, tag = "1")]
     pub val: ::prost::alloc::vec::Vec<u64>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct BigInt {
     #[prost(bytes = "vec", tag = "1")]
     pub bytes: ::prost::alloc::vec::Vec<u8>,
@@ -405,10 +403,11 @@ pub struct TransactionTrace {
     pub from: ::prost::alloc::vec::Vec<u8>,
     /// Only available in DetailLevel: EXTENDED
     /// Known Issues
-    /// - Version 3:
-    ///     Field not populated. It will be empty.
     ///
-    ///     Fixed in `Version 4`, see <https://docs.substreams.dev/reference-material/chains-and-endpoints/ethereum-data-model> for information about block versions.
+    /// * Version 3:
+    ///   Field not populated. It will be empty.
+    ///
+    ///   Fixed in `Version 4`, see <https://docs.substreams.dev/reference-material/chains-and-endpoints/ethereum-data-model> for information about block versions.
     #[prost(bytes = "vec", tag = "23")]
     pub return_data: ::prost::alloc::vec::Vec<u8>,
     /// Only available in DetailLevel: EXTENDED
@@ -428,7 +427,7 @@ pub struct TransactionTrace {
     /// ## Explanation relevant only for blocks with `DetailLevel: EXTENDED`
     ///
     /// A successful transaction has been recorded to the blockchain's state for calls in it that were successful.
-    /// This means it's possible only a subset of the calls were properly recorded, refer to \[calls[\].state_reverted] field
+    /// This means it's possible only a subset of the calls were properly recorded, refer to \[calls\[\].state_reverted\] field
     /// to determine which calls were reverted.
     ///
     /// A quirks of the Ethereum protocol is that a transaction `FAILED` or `REVERTED` still affects the blockchain's
@@ -594,7 +593,7 @@ pub mod transaction_trace {
 }
 /// AccessTuple represents a list of storage keys for a given contract's address and is used
 /// for AccessList construction.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct AccessTuple {
     #[prost(bytes = "vec", tag = "1")]
     pub address: ::prost::alloc::vec::Vec<u8>,
@@ -613,7 +612,7 @@ pub struct AccessTuple {
 ///
 /// We do extract the 'authority' value from the signature in the message and store it in the 'authority' field for
 /// convenience so you don't need to perform the computation yourself.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SetCodeAuthorization {
     /// Discarded determines if this authorization was skipped due to being invalid. As EIP-7702 states,
     /// if the authorization is invalid (invalid signature, nonce mismatch, etc.) it must be simply
@@ -638,8 +637,8 @@ pub struct SetCodeAuthorization {
     /// Nonce is the nonce of the account that is authorizing delegation mechanism, EIP-7702 rules
     /// states that nonce should be verified using this rule:
     ///
-    /// - Verify the nonce of authority is equal to nonce. In case authority does not exist in the trie,
-    /// verify that nonce is equal to 0.
+    /// * Verify the nonce of authority is equal to nonce. In case authority does not exist in the trie,
+    ///   verify that nonce is equal to 0.
     ///
     /// Read SetCodeAuthorization to know how to recover the `authority` value.
     #[prost(uint64, tag = "3")]
@@ -666,12 +665,12 @@ pub struct SetCodeAuthorization {
 pub struct TransactionReceipt {
     /// State root is an intermediate state_root hash, computed in-between transactions to make
     /// **sure** you could build a proof and point to state in the middle of a block. Geth client
-    /// uses `PostState + root + PostStateOrStatus`` while Parity used `status_code, root...`` this piles
+    /// uses ```PostState + root + PostStateOrStatus`` while Parity used ```status_code, root...\`` this piles
     /// hard forks, see (read the EIPs first):
-    /// - <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-658.md>
     ///
-    /// Moreover, the notion of `Outcome`` in parity, which segregates the two concepts, which are
-    /// stored in the same field `status_code`` can be computed based on such a hack of the `state_root`
+    /// * <https://github.com/ethereum/EIPs/blob/master/EIPS/eip-658.md>
+    ///
+    /// Moreover, the notion of ```Outcome`` in parity, which segregates the two concepts, which are  stored in the same field ```status_code\`` can be computed based on such a hack of the `state_root`
     /// field, following `EIP-658`.
     ///
     /// Before Byzantinium hard fork, this field is always empty.
@@ -701,7 +700,7 @@ pub struct TransactionReceipt {
     #[prost(message, optional, tag = "6")]
     pub blob_gas_price: ::core::option::Option<BigInt>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Log {
     #[prost(bytes = "vec", tag = "1")]
     pub address: ::prost::alloc::vec::Vec<u8>,
@@ -722,8 +721,9 @@ pub struct Log {
     /// that emitted the log has been reverted by the chain.
     ///
     /// Currently, there is two locations where a Log can be obtained:
-    /// - block.transaction_traces\[\].receipt.logs\[\]
-    /// - block.transaction_traces\[\].calls\[\].logs\[\]
+    ///
+    /// * block.transaction_traces\[\].receipt.logs\[\]
+    /// * block.transaction_traces\[\].calls\[\].logs\[\]
     ///
     /// In the `receipt` case, the logs will be populated only when the call
     /// that emitted them has not been reverted by the chain and when in this
@@ -760,9 +760,9 @@ pub struct Call {
     /// Assumes that a 'SetCode' transaction set address `0xA` to delegates to address `0xB`,
     /// then when a call is made to `0xA`, the Call object would have:
     ///
-    /// - caller = <from>
-    /// - address = 0xA
-    /// - address_delegates_to = 0xB
+    /// * caller = <from>
+    /// * address = 0xA
+    /// * address_delegates_to = 0xB
     ///
     /// Again, it's important to emphasize that this field relates to EIP-7702, if the call is
     /// a DELEGATE or CALLCODE type, this field will not be populated and will remain empty.
@@ -780,24 +780,26 @@ pub struct Call {
     #[prost(bytes = "vec", tag = "13")]
     pub return_data: ::prost::alloc::vec::Vec<u8>,
     /// Known Issues
-    /// - Version 3:
-    ///     When call is `CREATE` or `CREATE2`, this field is not populated. A couple of suggestions:
-    ///       1. You can get the contract's code in the `code_changes` field.
-    ///       2. In the root `CREATE` call, you can directly use the `TransactionTrace`'s input field.
     ///
-    ///     Fixed in `Version 4`, see <https://docs.substreams.dev/reference-material/chains-and-endpoints/ethereum-data-model> for information about block versions.
+    /// * Version 3:
+    ///   When call is `CREATE` or `CREATE2`, this field is not populated. A couple of suggestions:
+    ///
+    ///   1. You can get the contract's code in the `code_changes` field.
+    ///   1. In the root `CREATE` call, you can directly use the `TransactionTrace`'s input field.
+    ///   Fixed in `Version 4`, see <https://docs.substreams.dev/reference-material/chains-and-endpoints/ethereum-data-model> for information about block versions.
     #[prost(bytes = "vec", tag = "14")]
     pub input: ::prost::alloc::vec::Vec<u8>,
     /// Indicates whether the call executed code.
     ///
     /// Known Issues
-    /// - Version 3:
-    ///     This may be incorrectly set to `false` for accounts with code handling native value transfers,
-    ///     as well as for certain precompiles with no input.
-    ///     The value is initially set based on `call.type != CREATE && len(call.input) > 0`
-    ///     and later adjusted if the tracer detects an account without code.
     ///
-    ///     Fixed in `Version 4`, see <https://docs.substreams.dev/reference-material/chains-and-endpoints/ethereum-data-model> for information about block versions.
+    /// * Version 3:
+    ///   This may be incorrectly set to `false` for accounts with code handling native value transfers,
+    ///   as well as for certain precompiles with no input.
+    ///   The value is initially set based on `call.type != CREATE && len(call.input) > 0`
+    ///   and later adjusted if the tracer detects an account without code.
+    ///
+    ///   Fixed in `Version 4`, see <https://docs.substreams.dev/reference-material/chains-and-endpoints/ethereum-data-model> for information about block versions.
     #[prost(bool, tag = "15")]
     pub executed_code: bool,
     #[prost(bool, tag = "16")]
@@ -809,10 +811,11 @@ pub struct Call {
         ::prost::alloc::string::String,
     >,
     /// Known Issues
-    /// - Version 3:
-    ///     The data might be not be in order.
     ///
-    ///     Fixed in `Version 4`, see <https://docs.substreams.dev/reference-material/chains-and-endpoints/ethereum-data-model> for information about block versions.
+    /// * Version 3:
+    ///   The data might be not be in order.
+    ///
+    ///   Fixed in `Version 4`, see <https://docs.substreams.dev/reference-material/chains-and-endpoints/ethereum-data-model> for information about block versions.
     #[prost(message, repeated, tag = "21")]
     pub storage_changes: ::prost::alloc::vec::Vec<StorageChange>,
     #[prost(message, repeated, tag = "22")]
@@ -824,18 +827,20 @@ pub struct Call {
     #[prost(message, repeated, tag = "26")]
     pub code_changes: ::prost::alloc::vec::Vec<CodeChange>,
     /// Known Issues
-    /// - Version 3:
-    ///     Some gas changes are not correctly tracked:
-    ///       1. Gas refunded due to data returned to the chain (occurs at the end of a transaction, before buyback).
-    ///       2. Initial gas allocation (0 -> GasLimit) at the start of a call.
-    ///       3. Final gas deduction (LeftOver -> 0) at the end of a call (if applicable).
-    ///     Fixed in `Version 4`, see <https://docs.substreams.dev/reference-material/chains-and-endpoints/ethereum-data-model> for information about block versions.
+    ///
+    /// * Version 3:
+    ///   Some gas changes are not correctly tracked:
+    ///   1. Gas refunded due to data returned to the chain (occurs at the end of a transaction, before buyback).
+    ///   1. Initial gas allocation (0 -> GasLimit) at the start of a call.
+    ///   1. Final gas deduction (LeftOver -> 0) at the end of a call (if applicable).
+    ///      Fixed in `Version 4`, see <https://docs.substreams.dev/reference-material/chains-and-endpoints/ethereum-data-model> for information about block versions.
     #[prost(message, repeated, tag = "28")]
     pub gas_changes: ::prost::alloc::vec::Vec<GasChange>,
     /// In Ethereum, a call can be either:
-    /// - Successful, execution passes without any problem encountered
-    /// - Failed, execution failed, and remaining gas should be consumed
-    /// - Reverted, execution failed, but only gas consumed so far is billed, remaining gas is refunded
+    ///
+    /// * Successful, execution passes without any problem encountered
+    /// * Failed, execution failed, and remaining gas should be consumed
+    /// * Reverted, execution failed, but only gas consumed so far is billed, remaining gas is refunded
     ///
     /// When a call is either `failed` or `reverted`, the `status_failed` field
     /// below is set to `true`. If the status is `reverted`, then both `status_failed`
@@ -858,13 +863,13 @@ pub struct Call {
     /// has a status of `SUCCESS`, the chain might have reverted all the state
     /// changes it performed.
     ///
-    /// ```text
-    ///    Trx 1
-    ///     Call #1 <Failed>
-    ///       Call #2 <Execution Success>
-    ///       Call #3 <Execution Success>
-    ///       |--- Failure here
-    ///     Call #4
+    /// ```text,text
+    ///   Trx 1
+    ///    Call #1 <Failed>
+    ///      Call #2 <Execution Success>
+    ///      Call #3 <Execution Success>
+    ///      |--- Failure here
+    ///    Call #4
     /// ```
     ///
     /// In the transaction above, while Call #2 and Call #3 would have the
@@ -880,34 +885,37 @@ pub struct Call {
     #[prost(bool, tag = "30")]
     pub state_reverted: bool,
     /// Known Issues
-    /// - Version 3:
-    ///     1. The block's global ordinal when the call started executing, refer to
-    ///       \[Block\] documentation for further information about ordinals and total ordering.
-    ///     2. The transaction root call `begin_ordial` is always `0` (also in the GENESIS block), which can cause issues
-    ///       when sorting by this field. To ensure proper execution order, set it as follows:
-    ///       `trx.Calls\[0\].BeginOrdinal = trx.BeginOrdinal`.
     ///
-    ///     Fixed in `Version 4`, see <https://docs.substreams.dev/reference-material/chains-and-endpoints/ethereum-data-model> for information about block versions.
+    /// * Version 3:
+    ///
+    ///   1. The block's global ordinal when the call started executing, refer to
+    ///      \[Block\] documentation for further information about ordinals and total ordering.
+    ///   1. The transaction root call `begin_ordial` is always `0` (also in the GENESIS block), which can cause issues
+    ///      when sorting by this field. To ensure proper execution order, set it as follows:
+    ///      `trx.Calls\[0\].BeginOrdinal = trx.BeginOrdinal`.
+    ///   Fixed in `Version 4`, see <https://docs.substreams.dev/reference-material/chains-and-endpoints/ethereum-data-model> for information about block versions.
     #[prost(uint64, tag = "31")]
     pub begin_ordinal: u64,
     /// Known Issues
-    /// - Version 3:
-    ///     1. The block's global ordinal when the call finished executing, refer to
-    ///      \[Block\] documentation for further information about ordinals and total ordering.
-    ///     2. The root call of the GENESIS block is always `0`. To fix it, you can set it as follows:
-    ///      `rx.Calls\[0\].EndOrdinal = max.Uint64`.
     ///
-    ///     Fixed in `Version 4`, see <https://docs.substreams.dev/reference-material/chains-and-endpoints/ethereum-data-model> for information about block versions.
+    /// * Version 3:
+    ///
+    ///   1. The block's global ordinal when the call finished executing, refer to
+    ///      \[Block\] documentation for further information about ordinals and total ordering.
+    ///   1. The root call of the GENESIS block is always `0`. To fix it, you can set it as follows:
+    ///      `rx.Calls\[0\].EndOrdinal = max.Uint64`.
+    ///   Fixed in `Version 4`, see <https://docs.substreams.dev/reference-material/chains-and-endpoints/ethereum-data-model> for information about block versions.
     #[prost(uint64, tag = "32")]
     pub end_ordinal: u64,
     /// Known Issues
-    /// - Version 4:
-    ///     AccountCreations are NOT SUPPORTED anymore. DO NOT rely on them.
+    ///
+    /// * Version 4:
+    ///   AccountCreations are NOT SUPPORTED anymore. DO NOT rely on them.
     #[deprecated]
     #[prost(message, repeated, tag = "33")]
     pub account_creations: ::prost::alloc::vec::Vec<AccountCreation>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct StorageChange {
     #[prost(bytes = "vec", tag = "1")]
     pub address: ::prost::alloc::vec::Vec<u8>,
@@ -922,7 +930,7 @@ pub struct StorageChange {
     #[prost(uint64, tag = "5")]
     pub ordinal: u64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct BalanceChange {
     /// Address is the address of the account that has changed balance.
     #[prost(bytes = "vec", tag = "1")]
@@ -933,8 +941,8 @@ pub struct BalanceChange {
     ///
     /// If you consume this from a Substreams, you can safely use:
     ///
-    /// ```ignore
-    ///      let old_value = old_value.unwrap_or_default();
+    /// ```text,ignore
+    ///     let old_value = old_value.unwrap_or_default();
     /// ```
     #[prost(message, optional, tag = "2")]
     pub old_value: ::core::option::Option<BigInt>,
@@ -945,8 +953,8 @@ pub struct BalanceChange {
     ///
     /// If you consume this from a Substreams, you can safely use:
     ///
-    /// ```ignore
-    ///      let new_value = new_value.unwrap_or_default();
+    /// ```text,ignore
+    ///     let new_value = new_value.unwrap_or_default();
     /// ```
     #[prost(message, optional, tag = "3")]
     pub new_value: ::core::option::Option<BigInt>,
@@ -1057,7 +1065,7 @@ pub mod balance_change {
         }
     }
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct NonceChange {
     #[prost(bytes = "vec", tag = "1")]
     pub address: ::prost::alloc::vec::Vec<u8>,
@@ -1070,7 +1078,7 @@ pub struct NonceChange {
     #[prost(uint64, tag = "4")]
     pub ordinal: u64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct AccountCreation {
     #[prost(bytes = "vec", tag = "1")]
     pub account: ::prost::alloc::vec::Vec<u8>,
@@ -1079,7 +1087,7 @@ pub struct AccountCreation {
     #[prost(uint64, tag = "2")]
     pub ordinal: u64,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CodeChange {
     #[prost(bytes = "vec", tag = "1")]
     pub address: ::prost::alloc::vec::Vec<u8>,
@@ -1102,7 +1110,7 @@ pub struct CodeChange {
 ///
 /// Hence, we only index some of them, those that are costy like all the calls
 /// one, log events, return data, etc.
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GasChange {
     #[prost(uint64, tag = "1")]
     pub old_value: u64,
@@ -1329,12 +1337,12 @@ pub struct TransactionTraceWithBlockRef {
     #[prost(message, optional, tag = "2")]
     pub block_ref: ::core::option::Option<BlockRef>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct TransactionRefs {
     #[prost(bytes = "vec", repeated, tag = "1")]
     pub hashes: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct BlockRef {
     #[prost(bytes = "vec", tag = "1")]
     pub hash: ::prost::alloc::vec::Vec<u8>,
@@ -1343,7 +1351,7 @@ pub struct BlockRef {
 }
 /// Withdrawal represents a validator withdrawal from the beacon chain to the EVM.
 /// Introduced in EIP-4895 (Shanghai hard fork).
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Withdrawal {
     /// Index is the monotonically increasing identifier of the withdrawal
     #[prost(uint64, tag = "1")]

--- a/chain/near/Cargo.toml
+++ b/chain/near/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [build-dependencies]
-tonic-build = { workspace = true }
+tonic-prost-build = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }

--- a/chain/near/build.rs
+++ b/chain/near/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     println!("cargo:rerun-if-changed=proto");
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .out_dir("src/protobuf")
         .extern_path(".sf.near.codec.v1", "crate::codec::pbcodec")
         .compile_protos(&["proto/near.proto"], &["proto"])

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -73,6 +73,7 @@ url = "2.5.8"
 prometheus = "0.14.0"
 priority-queue = "2.7.0"
 tonic = { workspace = true }
+tonic-prost = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 
@@ -105,7 +106,7 @@ hex-literal = "1.1"
 wiremock = "0.6.5"
 
 [build-dependencies]
-tonic-build = { workspace = true }
+tonic-prost-build = { workspace = true }
 
 [lints]
 workspace = true

--- a/graph/build.rs
+++ b/graph/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     println!("cargo:rerun-if-changed=proto");
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .out_dir("src/firehose")
         .compile_protos(
             &[

--- a/graph/src/amp/schema/generator/entity.rs
+++ b/graph/src/amp/schema/generator/entity.rs
@@ -161,8 +161,9 @@ fn arrow_data_type_to_value_type(
         Struct(_) => return type_not_supported(),
         Union(_, _) => return type_not_supported(),
         Dictionary(_, _) => return type_not_supported(),
-        Decimal128(_, _) => ValueType::BigDecimal,
-        Decimal256(_, _) => ValueType::BigDecimal,
+        Decimal32(_, _) | Decimal64(_, _) | Decimal128(_, _) | Decimal256(_, _) => {
+            ValueType::BigDecimal
+        }
         Map(_, _) => return type_not_supported(),
         RunEndEncoded(_, _) => return type_not_supported(),
     };

--- a/graph/src/firehose/endpoints.rs
+++ b/graph/src/firehose/endpoints.rs
@@ -44,6 +44,16 @@ const LOW_VALUE_THRESHOLD: usize = 10;
 const LOW_VALUE_USED_PERCENTAGE: usize = 50;
 const HIGH_VALUE_USED_PERCENTAGE: usize = 80;
 
+pub trait BlockChainBlockMessage:
+    prost::Message + BlockchainBlock + Default + std::fmt::Debug + 'static
+{
+}
+
+impl<T> BlockChainBlockMessage for T where
+    T: prost::Message + BlockchainBlock + Default + std::fmt::Debug + 'static
+{
+}
+
 #[derive(Debug)]
 pub struct FirehoseEndpoint {
     pub provider: ProviderName,
@@ -411,7 +421,7 @@ impl FirehoseEndpoint {
         logger: &Logger,
     ) -> Result<M, anyhow::Error>
     where
-        M: prost::Message + BlockchainBlock + Default + 'static,
+        M: BlockChainBlockMessage,
     {
         let retry_log_message = format!("get_block_by_ptr for block {}", ptr);
         let endpoint = self.cheap_clone();
@@ -473,7 +483,7 @@ impl FirehoseEndpoint {
         logger: &Logger,
     ) -> Result<M, anyhow::Error>
     where
-        M: prost::Message + BlockchainBlock + Default + 'static,
+        M: BlockChainBlockMessage,
     {
         let retry_log_message = format!("get_block_by_number for block {}", number);
         let endpoint = self.cheap_clone();
@@ -511,7 +521,7 @@ impl FirehoseEndpoint {
         logger: &Logger,
     ) -> Result<Vec<M>, anyhow::Error>
     where
-        M: prost::Message + BlockchainBlock + Default + 'static,
+        M: BlockChainBlockMessage,
     {
         let logger = logger.clone();
         let logger_for_error = logger.clone();

--- a/graph/src/firehose/sf.ethereum.transform.v1.rs
+++ b/graph/src/firehose/sf.ethereum.transform.v1.rs
@@ -2,21 +2,21 @@
 /// CombinedFilter is a combination of "LogFilters" and "CallToFilters"
 ///
 /// It transforms the requested stream in two ways:
-///    1. STRIPPING
-///       The block data is stripped from all transactions that don't
-///       match any of the filters.
 ///
-///    2. SKIPPING
-///       If an "block index" covers a range containing a
-///       block that does NOT match any of the filters, the block will be
-///       skipped altogether, UNLESS send_all_block_headers is enabled
-///       In that case, the block would still be sent, but without any
-///       transactionTrace
+/// 1. STRIPPING
+///    The block data is stripped from all transactions that don't
+///    match any of the filters.
+///
+/// 1. SKIPPING
+///    If an "block index" covers a range containing a
+///    block that does NOT match any of the filters, the block will be
+///    skipped altogether, UNLESS send_all_block_headers is enabled
+///    In that case, the block would still be sent, but without any
+///    transactionTrace
 ///
 /// The SKIPPING feature only applies to historical blocks, because
 /// the "block index" is always produced after the merged-blocks files
 /// are produced. Therefore, the "live" blocks are never filtered out.
-///
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CombinedFilter {
     #[prost(message, repeated, tag = "1")]
@@ -35,11 +35,12 @@ pub struct MultiLogFilter {
     pub log_filters: ::prost::alloc::vec::Vec<LogFilter>,
 }
 /// LogFilter will match calls where *BOTH*
+///
 /// * the contract address that emits the log is one in the provided addresses -- OR addresses list is empty --
 /// * the event signature (topic.0) is one of the provided event_signatures -- OR event_signatures is empty --
 ///
 /// a LogFilter with both empty addresses and event_signatures lists is invalid and will fail.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct LogFilter {
     #[prost(bytes = "vec", repeated, tag = "1")]
     pub addresses: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
@@ -54,11 +55,12 @@ pub struct MultiCallToFilter {
     pub call_filters: ::prost::alloc::vec::Vec<CallToFilter>,
 }
 /// CallToFilter will match calls where *BOTH*
+///
 /// * the contract address (TO) is one in the provided addresses -- OR addresses list is empty --
 /// * the method signature (in 4-bytes format) is one of the provided signatures -- OR signatures is empty --
 ///
 /// a CallToFilter with both empty addresses and signatures lists is invalid and will fail.
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct CallToFilter {
     #[prost(bytes = "vec", repeated, tag = "1")]
     pub addresses: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
@@ -67,23 +69,23 @@ pub struct CallToFilter {
 }
 /// Deprecated: LightBlock is deprecated, replaced by HeaderOnly, note however that the new transform
 /// does not have any transactions traces returned, so it's not a direct replacement.
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct LightBlock {}
 /// HeaderOnly returns only the block's header and few top-level core information for the block. Useful
 /// for cases where no transactions information is required at all.
 ///
 /// The structure that would will have access to after:
 ///
-/// ```ignore
+/// ```text,ignore
 /// Block {
-///   int32 ver = 1;
-///   bytes hash = 2;
-///   uint64 number = 3;
-///   uint64 size = 4;
-///   BlockHeader header = 5;
+/// int32 ver = 1;
+/// bytes hash = 2;
+/// uint64 number = 3;
+/// uint64 size = 4;
+/// BlockHeader header = 5;
 /// }
 /// ```
 ///
 /// Everything else will be empty.
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct HeaderOnly {}

--- a/graph/src/firehose/sf.near.transform.v1.rs
+++ b/graph/src/firehose/sf.near.transform.v1.rs
@@ -7,13 +7,14 @@ pub struct BasicReceiptFilter {
     pub prefix_and_suffix_pairs: ::prost::alloc::vec::Vec<PrefixSuffixPair>,
 }
 /// PrefixSuffixPair applies a logical AND to prefix and suffix when both fields are non-empty.
+///
 /// * {prefix="hello",suffix="world"} will match "hello.world" but not "hello.friend"
 /// * {prefix="hello",suffix=""}      will match both "hello.world" and "hello.friend"
 /// * {prefix="",suffix="world"}      will match both "hello.world" and "good.day.world"
 /// * {prefix="",suffix=""}           is invalid
 ///
 /// Note that the suffix will usually have a TLD, ex: "mydomain.near" or "mydomain.testnet"
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct PrefixSuffixPair {
     #[prost(string, tag = "1")]
     pub prefix: ::prost::alloc::string::String,


### PR DESCRIPTION
In particular, the packages are prost, prost-types, tonic, tonic-prost, and tonic-prost-build.

Unfortunately, this also requires updating arrow to 57.x

It doesn't seem possible to update any of these packages individually, they are all tightly dependent on each other, and attempts at individual updates cause compilation errors.

