### PR TITLE
Fix rewinding the incorrect deployment instance

### DIFF
--- a/node/src/manager/commands/rewind.rs
+++ b/node/src/manager/commands/rewind.rs
@@ -176,12 +176,12 @@ pub async fn run(
 
         match (block_ptr_to, start_block) {
             (Some(block_ptr), _) => {
-                subgraph_store.rewind(loc.hash.clone(), block_ptr).await?;
+                subgraph_store.rewind(loc.id.into(), block_ptr).await?;
                 println!("  ... rewound {}", loc);
             }
             (None, Some(start_block_ptr)) => {
                 subgraph_store
-                    .truncate(loc.hash.clone(), start_block_ptr)
+                    .truncate(loc.id.into(), start_block_ptr)
                     .await?;
                 println!("  ... truncated {}", loc);
             }

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -321,7 +321,7 @@ impl TestContext {
 
     pub async fn rewind(&self, block_ptr_to: BlockPtr) {
         self.store
-            .rewind(self.deployment.hash.clone(), block_ptr_to)
+            .rewind(self.deployment.id.into(), block_ptr_to)
             .await
             .unwrap()
     }


### PR DESCRIPTION
Resolves https://github.com/graphprotocol/graph-node/issues/6088

The Problem:
- Two instances of the same subgraph/deployment exist (one active `sgdXXX`, one not `sgdYYY`).
- Running `graphman rewind sgdYYY ...` to rewind the non-active deployment would incorrectly rewind the active deployment.
- Cause: `SubgraphStore::rewind` and `SubgraphStore::truncate` accept `DeploymentHash` and resolved the hash to the active deployment.

What this PR does:
- Changes `SubgraphStore::rewind` and `SubgraphStore::truncate` to accept and use `DeploymentId`.
- Ensures the code fetches the correct `Site` and `DeploymentStore` for the exact deployment being targeted.
- Keeps original safety checks and error messages.