### PR TITLE
graph, node: Remove the use of atty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1579,17 +1579,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41e67cd8309bbd06cd603a9e693a784ac2e5d1e955f11286e355089fcab3047c"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "auto_impl"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3617,7 +3606,6 @@ dependencies = [
  "async-stream",
  "async-trait",
  "atomic_refcell",
- "atty",
  "base64 0.21.7",
  "bigdecimal 0.1.2",
  "bs58 0.5.1",
@@ -4187,15 +4175,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -26,7 +26,6 @@ diesel_derives = { workspace = true }
 chrono = "0.4.43"
 envconfig = { workspace = true }
 Inflector = "0.11.3"
-atty = "0.2"
 reqwest = { version = "0.12.23", features = ["json", "stream", "multipart"] }
 ethabi = "17.2"
 hex = "0.4.3"

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -78,7 +78,6 @@ pub mod prelude {
     pub use ::anyhow;
     pub use alloy;
     pub use anyhow::{anyhow, Context as _, Error};
-    pub use atty;
     pub use chrono;
     pub use diesel;
     pub use envconfig;

--- a/graph/src/log/mod.rs
+++ b/graph/src/log/mod.rs
@@ -17,12 +17,15 @@ macro_rules! impl_slog_value {
     };
 }
 
-use atty;
 use slog::*;
 use slog_async;
 use slog_envlogger;
 use slog_term::*;
-use std::{fmt, io, result};
+use std::{
+    fmt,
+    io::{self, IsTerminal},
+    result,
+};
 
 use crate::prelude::ENV_VARS;
 
@@ -36,7 +39,7 @@ pub fn logger(show_debug: bool) -> Logger {
 }
 
 pub fn logger_with_levels(show_debug: bool, levels: Option<&str>) -> Logger {
-    let use_color = atty::is(atty::Stream::Stdout);
+    let use_color = io::stdout().is_terminal();
     let decorator = slog_term::TermDecorator::new().build();
     let drain = CustomFormat::new(decorator, use_color).fuse();
     let drain = slog_envlogger::LogBuilder::new(drain)

--- a/node/src/manager/color.rs
+++ b/node/src/manager/color.rs
@@ -1,7 +1,10 @@
-use std::{io, sync::Mutex};
+use std::{
+    io::{self, IsTerminal as _},
+    sync::Mutex,
+};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-use graph::prelude::{atty, lazy_static};
+use graph::prelude::lazy_static;
 
 use super::CmdResult;
 
@@ -27,7 +30,7 @@ impl Terminal {
             "always" => ColorChoice::Always,
             "ansi" => ColorChoice::AlwaysAnsi,
             "auto" => {
-                if atty::is(atty::Stream::Stdout) {
+                if io::stdout().is_terminal() {
                     ColorChoice::Auto
                 } else {
                     ColorChoice::Never


### PR DESCRIPTION
std::io::IsTerminal provides the same functionality.

Fixes https://github.com/graphprotocol/graph-node/issues/6026

