### PR TITLE
ci: move GitHub Actions Linux jobs to Blacksmith runners

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,7 +9,7 @@ on:
     - cron: '0 0 */7 * *'
 jobs:
   security_audit:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   unit-tests:
     name: Run unit tests
-    runs-on: nscloud-ubuntu-22.04-amd64-16x32
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     timeout-minutes: 20
     services:
       ipfs:
@@ -64,7 +64,7 @@ jobs:
 
   runner-tests:
     name: Subgraph Runner integration tests
-    runs-on: nscloud-ubuntu-22.04-amd64-16x32
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     timeout-minutes: 20
     services:
       ipfs:
@@ -117,7 +117,7 @@ jobs:
 
   integration-tests:
     name: Run integration tests
-    runs-on: nscloud-ubuntu-22.04-amd64-16x32
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     timeout-minutes: 20
     services:
       ipfs:
@@ -185,7 +185,7 @@ jobs:
 
   rustfmt:
     name: Check rustfmt style
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 10
     env:
       RUSTFLAGS: "-D warnings"
@@ -201,7 +201,7 @@ jobs:
 
   clippy:
     name: Clippy linting
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 10
     env:
       RUSTFLAGS: "-D warnings"
@@ -223,7 +223,7 @@ jobs:
 
   release-check:
     name: Build in release mode
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2204
     timeout-minutes: 10
     env:
       RUSTFLAGS: "-D warnings"

--- a/.github/workflows/gnd-binary-build.yml
+++ b/.github/workflows/gnd-binary-build.yml
@@ -12,10 +12,10 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-22.04
+            runner: blacksmith-4vcpu-ubuntu-2204
             asset_name: gnd-linux-x86_64
           - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-22.04
+            runner: blacksmith-4vcpu-ubuntu-2204
             asset_name: gnd-linux-aarch64
           - target: x86_64-apple-darwin
             runner: macos-13
@@ -43,7 +43,7 @@ jobs:
           key: ${{ matrix.target }}
 
       - name: Install dependencies (Ubuntu)
-        if: startsWith(matrix.runner, 'ubuntu')
+        if: contains(matrix.runner, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler musl-tools
@@ -111,14 +111,14 @@ jobs:
     name: Create Release
     needs: build
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Setup GitHub CLI
         run: |
-          # GitHub CLI is pre-installed on GitHub-hosted runners
+          # Ensure GitHub CLI is available on the runner image
           gh --version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -151,4 +151,4 @@ jobs:
           # Upload Windows x86_64 asset
           gh release upload $VERSION artifacts/gnd-windows-x86_64.exe/gnd-windows-x86_64.exe.zip --repo $GITHUB_REPOSITORY
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2204
     timeout-minutes: 20
     steps:
       - uses: actions/stale@main


### PR DESCRIPTION
Summary:\n- move Linux jobs in CI, audit, stale, and gnd release workflows to Blacksmith labels\n- keep macOS/Windows jobs on GitHub-hosted runners\n- update Ubuntu matrix predicate in gnd workflow to match Blacksmith label format\n\nValidation:\n- parsed workflow YAML locally\n- checked diff for whitespace/errors