### PR TITLE
Backport #6299: Fix rewinding the incorrect deployment instance

### DIFF
--- a/node/src/manager/commands/rewind.rs
+++ b/node/src/manager/commands/rewind.rs
@@ -171,11 +171,11 @@ pub async fn run(
 
         match (block_ptr_to, start_block) {
             (Some(block_ptr), _) => {
-                subgraph_store.rewind(loc.hash.clone(), block_ptr)?;
+                subgraph_store.rewind(loc.id.into(), block_ptr)?;
                 println!("  ... rewound {}", loc);
             }
             (None, Some(start_block_ptr)) => {
-                subgraph_store.truncate(loc.hash.clone(), start_block_ptr)?;
+                subgraph_store.truncate(loc.id.into(), start_block_ptr)?;
                 println!("  ... truncated {}", loc);
             }
             (None, None) => {

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -21,8 +21,10 @@ use graph::{
             PruneReporter, PruneRequest, SubgraphFork,
         },
     },
-    data::query::QueryTarget,
-    data::subgraph::{schema::DeploymentCreate, status, DeploymentFeatures},
+    data::{
+        query::QueryTarget,
+        subgraph::{schema::DeploymentCreate, status, DeploymentFeatures},
+    },
     internal_error,
     prelude::{
         anyhow, lazy_static, o, web3::types::Address, ApiVersion, BlockNumber, BlockPtr,
@@ -1043,13 +1045,15 @@ impl SubgraphStoreInner {
         join_all(self.stores.values().map(|store| store.vacuum())).await
     }
 
-    pub fn rewind(&self, id: DeploymentHash, block_ptr_to: BlockPtr) -> Result<(), StoreError> {
-        let (store, site) = self.store(&id)?;
+    pub fn rewind(&self, id: DeploymentId, block_ptr_to: BlockPtr) -> Result<(), StoreError> {
+        let site = self.find_site(id)?;
+        let store = self.for_site(&site)?;
         store.rewind(site, block_ptr_to)
     }
 
-    pub fn truncate(&self, id: DeploymentHash, block_ptr_to: BlockPtr) -> Result<(), StoreError> {
-        let (store, site) = self.store(&id)?;
+    pub fn truncate(&self, id: DeploymentId, block_ptr_to: BlockPtr) -> Result<(), StoreError> {
+        let site = self.find_site(id)?;
+        let store = self.for_site(&site)?;
         store.truncate(site, block_ptr_to)
     }
 

--- a/tests/src/fixture/mod.rs
+++ b/tests/src/fixture/mod.rs
@@ -363,7 +363,7 @@ impl TestContext {
 
     pub fn rewind(&self, block_ptr_to: BlockPtr) {
         self.store
-            .rewind(self.deployment.hash.clone(), block_ptr_to)
+            .rewind(self.deployment.id.into(), block_ptr_to)
             .unwrap()
     }
 }


### PR DESCRIPTION
Cherry-pick of #6299 onto v0.41.1 for v0.41.2 patch release. Adapted for sync store on v0.41.1.