### PR TITLE
Backport #6340: Fix missing version on prune rebuild

### DIFF
--- a/graph/src/components/store/mod.rs
+++ b/graph/src/components/store/mod.rs
@@ -1067,7 +1067,9 @@ impl PruneRequest {
             ));
         }
 
-        let earliest_block = latest_block - history_blocks;
+        // We need to add + 1 to `earliset_block` because the lower bound is inclusive
+        // and otherwise we would end up with `history_blocks + 1` blocks of history instead of `history_blocks`
+        let earliest_block = latest_block - history_blocks + 1;
         let final_block = latest_block - reorg_threshold;
 
         Ok(Self {

--- a/store/postgres/src/relational/prune.rs
+++ b/store/postgres/src/relational/prune.rs
@@ -163,7 +163,7 @@ impl TablePair {
         let column_list = self.column_list();
 
         // Determine the last vid that we need to copy
-        let range = VidRange::for_prune(conn, &self.src, final_block + 1, BLOCK_NUMBER_MAX)?;
+        let range = VidRange::for_prune(conn, &self.src, final_block, BLOCK_NUMBER_MAX)?;
         let mut batcher = VidBatcher::load(conn, &self.src.nsp, &self.src, range)?;
         tracker.start_copy_nonfinal(conn, &self.src, range)?;
 


### PR DESCRIPTION
Cherry-pick of #6340 onto v0.41.1 for v0.41.2 patch release. Adapted for sync store on v0.41.1.