### PR TITLE
graph: Avoid unnecessary entity deep clone in as_modifications

### DIFF
--- a/graph/src/components/store/entity_cache.rs
+++ b/graph/src/components/store/entity_cache.rs
@@ -518,12 +518,14 @@ impl EntityCache {
                 }
                 // Entity may have been changed
                 (Some(current), EntityOp::Update(updates)) => {
-                    let mut data = current.as_ref().clone();
-                    data.merge_remove_null_fields(updates)
+                    let mut data =
+                        Arc::try_unwrap(current).unwrap_or_else(|arc| arc.as_ref().clone());
+                    let changed = data
+                        .merge_remove_null_fields(updates)
                         .map_err(|e| key.unknown_attribute(e))?;
                     let data = Arc::new(data);
                     self.current.insert(key.clone(), Some(data.cheap_clone()));
-                    if current != data {
+                    if changed {
                         Some(Overwrite {
                             key,
                             data,


### PR DESCRIPTION
Use Arc::try_unwrap to move the entity out of the Arc without cloning when the refcount is 1 (the common case after remove() from the LFU cache). Also make merge_remove_null_fields return whether it changed anything, replacing the post-merge full entity comparison.

