### PR TITLE
Amp-powered subgraphs: Add runtime endBlock completion check

### DIFF
--- a/core/src/amp_subgraph/runner/mod.rs
+++ b/core/src/amp_subgraph/runner/mod.rs
@@ -127,6 +127,20 @@ where
             }
         }
 
+        // Check if the Amp Flight server has data covering through every data
+        // source's endBlock. This handles the case where endBlock has no entity
+        // data — the persisted block pointer never advances to endBlock, but the
+        // server's latest block confirms all queries have been served.
+        if latest_block >= cx.max_end_block() {
+            cx.metrics.deployment_synced.record(true);
+
+            debug!(cx.logger, "Indexing completed; endBlock reached via server latest block";
+                "latest_block" => latest_block,
+                "max_end_block" => cx.max_end_block()
+            );
+            return Ok(());
+        }
+
         debug!(cx.logger, "Completed indexing iteration";
             "latest_synced_block_ptr" => ?cx.latest_synced_block_ptr()
         );


### PR DESCRIPTION
### Summary

- Add a runtime completion check after the data stream loop that marks indexing as done when the Amp Flight server's latest block reaches or exceeds every data source's `endBlock`.

### Problem

The existing `indexing_completed` check (at the top of the loop) relies on the **persisted block pointer** (`latest_synced_block`) having advanced to `endBlock`. However, if `endBlock` itself contains no entity data, the store's block pointer is never advanced to that block number, and the subgraph never reports as synced – it loops indefinitely waiting for a block pointer that will never be written.

### Solution

After consuming the data stream in each iteration, check whether the Amp Flight server's `latest_block` already covers through `max_end_block()`. If so, mark the deployment as synced and return, bypassing the need for the persisted block pointer to reach `endBlock` exactly. This is safe because the server's latest block confirms all queries through `endBlock` have been served.

### Future Improvements

This will be replaced by persistent completion _(to avoid executing queries on restarts to confirm completion)_ once the Amp-based block cache or the Amp Admin API is integrated into the graph-node.