### PR TITLE
node, store: Remove unused ChainStatus enum.

### DIFF
--- a/node/src/manager/commands/chain.rs
+++ b/node/src/manager/commands/chain.rs
@@ -26,7 +26,6 @@ use graph_store_postgres::add_chain;
 use graph_store_postgres::find_chain;
 use graph_store_postgres::update_chain_name;
 use graph_store_postgres::BlockStore;
-use graph_store_postgres::ChainStatus;
 use graph_store_postgres::ChainStore;
 use graph_store_postgres::PoolCoordinator;
 use graph_store_postgres::ScopedFutureExt;
@@ -254,7 +253,7 @@ pub async fn change_block_cache_shard(
 
             let chain = BlockStore::allocate_chain(conn, &chain_name, &shard, &ident).await?;
 
-            store.add_chain_store(&chain,ChainStatus::Ingestible, true).await?;
+            store.add_chain_store(&chain, true).await?;
 
             // Drop the foreign key constraint on deployment_schemas
             sql_query(

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -37,9 +37,7 @@ use graph::{ensure, internal_error};
 
 use self::recent_blocks_cache::RecentBlocksCache;
 use crate::AsyncPgConnection;
-use crate::{
-    block_store::ChainStatus, chain_head_listener::ChainHeadUpdateSender, pool::ConnectionPool,
-};
+use crate::{chain_head_listener::ChainHeadUpdateSender, pool::ConnectionPool};
 
 /// Our own internal notion of a block
 #[derive(Clone, Debug)]
@@ -2139,7 +2137,6 @@ pub struct ChainStore {
     pool: ConnectionPool,
     pub chain: String,
     pub(crate) storage: data::Storage,
-    status: ChainStatus,
     chain_head_update_sender: ChainHeadUpdateSender,
     // TODO: We currently only use this cache for
     // [`ChainStore::ancestor_block`], but it could very well be expanded to
@@ -2164,7 +2161,6 @@ impl ChainStore {
         logger: Logger,
         chain: String,
         storage: data::Storage,
-        status: ChainStatus,
         chain_head_update_sender: ChainHeadUpdateSender,
         pool: ConnectionPool,
         recent_blocks_cache_capacity: usize,
@@ -2182,7 +2178,6 @@ impl ChainStore {
             pool,
             chain,
             storage,
-            status,
             chain_head_update_sender,
             recent_blocks_cache,
             blocks_by_hash_cache,
@@ -2191,10 +2186,6 @@ impl ChainStore {
             chain_head_ptr_cache,
             chain_head_ptr_herd,
         }
-    }
-
-    pub fn is_ingestible(&self) -> bool {
-        matches!(self.status, ChainStatus::Ingestible)
     }
 
     /// Execute a cached query, avoiding thundering herd for identical requests.

--- a/store/postgres/src/lib.rs
+++ b/store/postgres/src/lib.rs
@@ -56,7 +56,6 @@ pub mod layout_for_tests {
 
 pub use self::block_store::primary::{add_chain, find_chain, update_chain_name};
 pub use self::block_store::BlockStore;
-pub use self::block_store::ChainStatus;
 pub use self::chain_head_listener::ChainHeadUpdateListener;
 pub use self::chain_store::{ChainStore, ChainStoreMetrics, Storage};
 pub use self::detail::DeploymentDetail;


### PR DESCRIPTION
Closes https://github.com/graphprotocol/graph-node/issues/6183

- Removes unused ChainStatus enum
- Changes the shard configuration mismatch log from `error` to `warn`


