### PR TITLE
core, graph, store: Log deployment hashes when removing a subgraph

### DIFF
--- a/core/src/subgraph/registrar.rs
+++ b/core/src/subgraph/registrar.rs
@@ -355,9 +355,12 @@ where
     }
 
     async fn remove_subgraph(&self, name: SubgraphName) -> Result<(), SubgraphRegistrarError> {
-        self.store.clone().remove_subgraph(name.clone()).await?;
+        use itertools::Itertools;
 
-        debug!(self.logger, "Removed subgraph"; "subgraph_name" => name.to_string());
+        let hashes = self.store.clone().remove_subgraph(name.clone()).await?;
+        let hashes = hashes.into_iter().join(", ");
+
+        debug!(self.logger, "Removed subgraph"; "subgraph_name" => name.to_string(), "deployments" => format!("[{}]", hashes));
 
         Ok(())
     }

--- a/graph/src/components/store/traits.rs
+++ b/graph/src/components/store/traits.rs
@@ -104,10 +104,13 @@ pub trait SubgraphStore: Send + Sync + 'static {
     /// subgraph
     async fn create_subgraph(&self, name: SubgraphName) -> Result<String, StoreError>;
 
-    /// Remove a subgraph and all its versions; if deployments that were used
-    /// by this subgraph do not need to be indexed anymore, also remove
+    /// Remove a subgraph and all its versions; if deployments that were
+    /// used by this subgraph do not need to be indexed anymore, also remove
     /// their assignment, but keep the deployments themselves around
-    async fn remove_subgraph(&self, name: SubgraphName) -> Result<(), StoreError>;
+    ///
+    /// Returns the hashes of all deployments that were associated with the
+    /// removed name
+    async fn remove_subgraph(&self, name: SubgraphName) -> Result<Vec<DeploymentHash>, StoreError>;
 
     /// Assign the subgraph with `id` to the node `node_id`. If there is no
     /// assignment for the given deployment, report an error.

--- a/store/postgres/src/subgraph_store.rs
+++ b/store/postgres/src/subgraph_store.rs
@@ -1540,7 +1540,14 @@ impl SubgraphStoreTrait for SubgraphStore {
             .await
     }
 
-    async fn remove_subgraph(&self, name: SubgraphName) -> Result<(), StoreError> {
+    async fn remove_subgraph(&self, name: SubgraphName) -> Result<Vec<DeploymentHash>, StoreError> {
+        let deployments = self
+            .status(status::Filter::SubgraphName(name.to_string()))
+            .await?
+            .into_iter()
+            .filter_map(|info| DeploymentHash::new(info.subgraph).ok())
+            .collect::<Vec<_>>();
+
         let mut pconn = self.primary_conn().await?;
         pconn
             .transaction(|pconn| {
@@ -1552,7 +1559,8 @@ impl SubgraphStoreTrait for SubgraphStore {
                 }
                 .scope_boxed()
             })
-            .await
+            .await?;
+        Ok(deployments)
     }
 
     async fn reassign_subgraph(


### PR DESCRIPTION
Log all the deployment hashes associated with a subgraph name when removing the name

