### PR TITLE
core: Restart store on revert errors to clear poisoned writer

### DIFF
--- a/core/src/subgraph/runner/mod.rs
+++ b/core/src/subgraph/runner/mod.rs
@@ -619,7 +619,7 @@ where
         match action {
             Action::Continue => Ok(RunnerState::AwaitingBlock { block_stream }),
             Action::Restart => Ok(RunnerState::Restarting {
-                reason: RestartReason::DataSourceExpired,
+                reason: RestartReason::StoreError,
             }),
             Action::Stop => Ok(RunnerState::Stopped {
                 reason: StopReason::Canceled,

--- a/core/src/subgraph/runner/state.rs
+++ b/core/src/subgraph/runner/state.rs
@@ -74,8 +74,6 @@ pub enum RunnerState<C: Blockchain> {
 pub enum RestartReason {
     /// New dynamic data source was created that requires filter updates.
     DynamicDataSourceCreated,
-    /// A data source reached its end block.
-    DataSourceExpired,
     /// Store error occurred and store needs to be restarted.
     StoreError,
     /// Possible reorg detected, need to restart to detect it.


### PR DESCRIPTION
#6298 mapped `Action::Restart` from `handle_revert` to `RestartReason::DataSourceExpired`, which skips `store.restart()`. This meant a poisoned writer from a revert error would never be cleared, causing the subgraph to loop indefinitely until process restart.

- Use `RestartReason::StoreError` for revert errors so `store.restart()` is always called (it's a no-op when not poisoned)
- Remove the unused `DataSourceExpired` variant from `RestartReason`
