### PR TITLE
store: Fix TLS regression in diesel-async connection pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4117,6 +4117,7 @@ dependencies = [
  "stable-hash 0.3.4",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-postgres",
  "tokio-stream",
 ]
 

--- a/store/postgres/Cargo.toml
+++ b/store/postgres/Cargo.toml
@@ -24,6 +24,7 @@ lru_time_cache = "0.11"
 postgres = "0.19.1"
 openssl = { version = "0.10.76", features = ["vendored"] }
 postgres-openssl = "0.5.2"
+tokio-postgres = "0.7"
 rand.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/store/postgres/src/pool/manager.rs
+++ b/store/postgres/src/pool/manager.rs
@@ -7,7 +7,7 @@ use deadpool::managed::{Hook, RecycleError, RecycleResult};
 use diesel::IntoSql;
 
 use diesel_async::pooled_connection::{PoolError as DieselPoolError, PoolableConnection};
-use diesel_async::{AsyncConnection, RunQueryDsl};
+use diesel_async::RunQueryDsl;
 use graph::env::ENV_VARS;
 use graph::prelude::error;
 use graph::prelude::AtomicMovingStats;
@@ -17,6 +17,8 @@ use graph::prelude::MetricsRegistry;
 use graph::prelude::PoolWaitStats;
 use graph::slog::info;
 use graph::slog::Logger;
+use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
+use postgres_openssl::MakeTlsConnector;
 
 use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
@@ -100,11 +102,44 @@ impl deadpool::managed::Manager for ConnectionManager {
     type Error = DieselPoolError;
 
     async fn create(&self) -> Result<Self::Type, Self::Error> {
-        let res = diesel_async::AsyncPgConnection::establish(&self.connection_url).await;
-        if let Err(ref e) = res {
-            self.handle_error(e);
-        }
-        res.map_err(DieselPoolError::ConnectionError)
+        // diesel-async's AsyncPgConnection::establish() uses
+        // tokio_postgres::NoTls, which never negotiates TLS. This breaks
+        // connections to any PostgreSQL server that requires encrypted
+        // connections via pg_hba.conf.
+        //
+        // We use postgres-openssl to provide TLS support, with
+        // SslVerifyMode::NONE to match libpq's default sslmode=prefer
+        // behavior: encrypt the connection when the server supports it,
+        // but don't verify the server certificate. tokio-postgres handles
+        // the sslmode parameter from the connection URL to decide whether
+        // TLS is used (disable/prefer/require); we configure how the
+        // handshake behaves.
+        //
+        // Note: tokio-postgres does not support sslmode=verify-ca or
+        // sslmode=verify-full. Certificate verification would require
+        // upstream support in the tokio-postgres URL parser.
+        let tls = make_tls_connector().map_err(|e| {
+            DieselPoolError::ConnectionError(diesel::ConnectionError::BadConnection(
+                e.to_string(),
+            ))
+        })?;
+
+        let (client, conn) =
+            tokio_postgres::connect(&self.connection_url, tls)
+                .await
+                .map_err(|e| {
+                    self.handle_error(&e);
+                    DieselPoolError::ConnectionError(
+                        diesel::ConnectionError::BadConnection(e.to_string()),
+                    )
+                })?;
+
+        diesel_async::AsyncPgConnection::try_from_client_and_connection(client, conn)
+            .await
+            .map_err(|e| {
+                self.handle_error(&e);
+                DieselPoolError::ConnectionError(e)
+            })
     }
 
     async fn recycle(
@@ -247,6 +282,18 @@ impl StateTracker {
             })
         })
     }
+}
+
+/// Build an OpenSSL TLS connector for PostgreSQL connections.
+///
+/// Uses `SslVerifyMode::NONE` (encrypt without certificate verification),
+/// matching libpq's behavior for sslmode=prefer and sslmode=require.
+/// tokio-postgres handles the sslmode URL parameter to decide whether TLS
+/// is actually used (disable/prefer/require).
+fn make_tls_connector() -> Result<MakeTlsConnector, openssl::error::ErrorStack> {
+    let mut builder = SslConnector::builder(SslMethod::tls())?;
+    builder.set_verify(SslVerifyMode::NONE);
+    Ok(MakeTlsConnector::new(builder.build()))
 }
 
 fn brief_error_msg(error: &dyn std::error::Error) -> String {


### PR DESCRIPTION
Warning: vibes ahead

We require ssl verification of database connections. I am not super familiar with the test harness, so unfortunately I don't have any tests to go along with this. That said, I manually tested this and it fixed the issue I was having connecting to our database after upgrading to v0.42.1.


Here's claude's explanation:

The migration from synchronous diesel (r2d2 + PgConnection) to diesel-async (deadpool + AsyncPgConnection) in the "Make the store async" change inadvertently broke TLS support for the database connection pool.

The old code used diesel::r2d2::ConnectionManager<PgConnection> which is backed by libpq (via pq-sys). libpq defaults to sslmode=prefer, meaning it transparently negotiates TLS with the server when available.

The new code uses diesel_async::AsyncPgConnection::establish() which internally calls tokio_postgres::connect() with tokio_postgres::NoTls, meaning TLS is never negotiated regardless of the sslmode parameter in the connection URL. This breaks connections to any PostgreSQL server that requires encrypted connections via pg_hba.conf.

Fix this by replacing AsyncPgConnection::establish() with a manual tokio_postgres::connect() call using postgres-openssl as the TLS connector (with SslVerifyMode::NONE to match libpq's default prefer behavior), then constructing the AsyncPgConnection via try_from_client_and_connection(). This restores the pre-v0.42.0 behavior where connections are encrypted by default.

Note: tokio-postgres does not support sslmode=verify-ca or sslmode=verify-full in its URL parser — only disable, prefer, and require are recognized. Certificate verification would require upstream changes to tokio-postgres.

The openssl and postgres-openssl crates were already dependencies of graph-store-postgres (used by the notification listener). Only tokio-postgres was added as a new direct dependency.

