### PR TITLE
BREAKING: Replace 'geth' naming with a more generic 'rpc'

### DIFF
--- a/chain/ethereum/src/call_helper.rs
+++ b/chain/ethereum/src/call_helper.rs
@@ -59,13 +59,13 @@ const RPC_EXECUTION_ERRORS: &[&str] = &[
     "invalidfeopcode",
 ];
 
-/// Helper that checks if a geth style RPC error message corresponds to a revert.
+/// Helper that checks if a RPC error message corresponds to a revert.
 fn is_rpc_revert_message(message: &str) -> bool {
-    let env_geth_call_errors = ENV_VARS.geth_eth_call_errors.iter();
+    let env_rpc_call_errors = ENV_VARS.rpc_eth_call_errors.iter();
     let mut execution_errors = RPC_EXECUTION_ERRORS
         .iter()
         .copied()
-        .chain(env_geth_call_errors.map(|s| s.as_str()));
+        .chain(env_rpc_call_errors.map(|s| s.as_str()));
     execution_errors.any(|e| message.to_lowercase().contains(e))
 }
 

--- a/chain/ethereum/src/env.rs
+++ b/chain/ethereum/src/env.rs
@@ -13,9 +13,9 @@ lazy_static! {
 pub struct EnvVars {
     /// Additional deterministic errors that have not yet been hardcoded.
     ///
-    /// Set by the environment variable `GRAPH_GETH_ETH_CALL_ERRORS`, separated
+    /// Set by the environment variable `GRAPH_RPC_ETH_CALL_ERRORS`, separated
     /// by `;`.
-    pub geth_eth_call_errors: Vec<String>,
+    pub rpc_eth_call_errors: Vec<String>,
     /// Set by the environment variable `GRAPH_ETH_GET_LOGS_MAX_CONTRACTS`. The
     /// default value is 2000.
     pub get_logs_max_contracts: usize,
@@ -114,8 +114,8 @@ impl From<Inner> for EnvVars {
     fn from(x: Inner) -> Self {
         Self {
             get_logs_max_contracts: x.get_logs_max_contracts,
-            geth_eth_call_errors: x
-                .geth_eth_call_errors
+            rpc_eth_call_errors: x
+                .rpc_eth_call_errors
                 .split(';')
                 .filter(|s| !s.is_empty())
                 .map(str::to_string)
@@ -158,8 +158,8 @@ impl Default for EnvVars {
 
 #[derive(Clone, Debug, Envconfig)]
 struct Inner {
-    #[envconfig(from = "GRAPH_GETH_ETH_CALL_ERRORS", default = "")]
-    geth_eth_call_errors: String,
+    #[envconfig(from = "GRAPH_RPC_ETH_CALL_ERRORS", default = "")]
+    rpc_eth_call_errors: String,
     #[envconfig(from = "GRAPH_ETH_GET_LOGS_MAX_CONTRACTS", default = "2000")]
     get_logs_max_contracts: usize,
 


### PR DESCRIPTION
Resolves https://github.com/graphprotocol/graph-node/issues/6354

This PR renames `GRAPH_GETH_ETH_CALL_ERRORS` env var (and the internal config field) to `GRAPH_RPC_ETH_CALL_ERRORS`. This is a breaking change and should be noted in the release changelog and NEWS.md.

Initally I planned to make both available for a time and log a deprecation message, but after this PR https://github.com/graphprotocol/graph-node/pull/6355, which expanded the error list, I think renaming it right aways should be fine.
