### PR TITLE
chain/ethereum: Include contract address and block number in ABI decode error messages

### DIFF
--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -857,8 +857,10 @@ impl DataSource {
                     .abi_decode_input(&call.input.0[4..])
                     .with_context(|| {
                         format!(
-                            "Generating function inputs for the call {:?} failed, raw input: {}",
+                            "Generating function inputs for the call {:?} failed, contract: {:#x}, block: {}, raw input: 0x{}",
                             &function_abi,
+                            call.to,
+                            call.block_number,
                             hex::encode(&call.input.0)
                         )
                     }) {
@@ -889,8 +891,11 @@ impl DataSource {
                     .abi_decode_output(&call.output.0)
                     .with_context(|| {
                         format!(
-                            "Decoding function outputs for the call {:?} failed, raw output: {}",
+                            "Decoding function outputs for the call {:?} failed, contract: {:#x}, block: {}, input: 0x{}, raw output: 0x{}",
                             &function_abi,
+                            call.to,
+                            call.block_number,
+                            hex::encode(&call.input.0),
                             hex::encode(&call.output.0)
                         )
                     })?;


### PR DESCRIPTION
Closes #3404

When ABI decoding fails for Ethereum call handlers, the error messages only show the function ABI and raw bytes. Adding the contract address and block number makes it easier to correlate failures with specific on-chain calls.

**Changes in `chain/ethereum/src/data_source.rs`:**
- Input decode error: add `call.to` (contract address) and `call.block_number`  
- Output decode error: add `call.to`, `call.block_number`, and raw input bytes