### PR TITLE
 chain/ethereum: Reduce unnecessary eth_getBlockByHash and eth_getBlockByNumber RPC calls

### DIFF
--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -582,6 +582,18 @@ impl Blockchain for Chain {
                 .await
                 .map_err(IngestorError::Unknown),
             ChainClient::Rpc(adapters) => {
+                let cached = self
+                    .chain_store
+                    .cheap_clone()
+                    .block_ptrs_by_numbers(vec![number])
+                    .await
+                    .unwrap_or_default();
+                if let Some(ptrs) = cached.get(&number) {
+                    if ptrs.len() == 1 {
+                        return Ok(BlockPtr::new(ptrs[0].hash.clone(), ptrs[0].number));
+                    }
+                }
+
                 let adapter = adapters
                     .cheapest()
                     .await
@@ -1076,6 +1088,18 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
                 Ok(block.hash() == ptr.hash)
             }
             ChainClient::Rpc(adapter) => {
+                let cached = self
+                    .chain_store
+                    .cheap_clone()
+                    .block_ptrs_by_numbers(vec![ptr.number])
+                    .await
+                    .unwrap_or_default();
+                if let Some(ptrs) = cached.get(&ptr.number) {
+                    if ptrs.len() == 1 {
+                        return Ok(ptrs[0].hash == ptr.hash);
+                    }
+                }
+
                 let adapter = adapter
                     .cheapest()
                     .await

--- a/chain/ethereum/src/chain.rs
+++ b/chain/ethereum/src/chain.rs
@@ -588,10 +588,10 @@ impl Blockchain for Chain {
                     .block_ptrs_by_numbers(vec![number])
                     .await
                     .unwrap_or_default();
-                if let Some(ptrs) = cached.get(&number) {
-                    if ptrs.len() == 1 {
-                        return Ok(BlockPtr::new(ptrs[0].hash.clone(), ptrs[0].number));
-                    }
+                if let Some(ptrs) = cached.get(&number)
+                    && ptrs.len() == 1
+                {
+                    return Ok(BlockPtr::new(ptrs[0].hash.clone(), ptrs[0].number));
                 }
 
                 let adapter = adapters
@@ -1094,10 +1094,10 @@ impl TriggersAdapterTrait<Chain> for TriggersAdapter {
                     .block_ptrs_by_numbers(vec![ptr.number])
                     .await
                     .unwrap_or_default();
-                if let Some(ptrs) = cached.get(&ptr.number) {
-                    if ptrs.len() == 1 {
-                        return Ok(ptrs[0].hash == ptr.hash);
-                    }
+                if let Some(ptrs) = cached.get(&ptr.number)
+                    && ptrs.len() == 1
+                {
+                    return Ok(ptrs[0].hash == ptr.hash);
                 }
 
                 let adapter = adapter
@@ -1285,16 +1285,14 @@ impl TriggersAdapter {
         adapters: &EthereumNetworkAdapters,
         block_ptr: &BlockPtr,
     ) -> Result<Option<EthereumBlock>, Error> {
-        let adapter = adapters.cheapest_with(&self.capabilities).await?;
-
-        let block = adapter
-            .block_by_hash(&self.logger, block_ptr.hash.as_b256())
-            .await?;
-
-        match block {
-            Some(block) => {
+        // Use the cache-aware light block fetch first; it checks recent_blocks_cache
+        // and the DB before falling back to eth_getBlockByHash.
+        let light_block = self.fetch_light_block_with_rpc(adapters, block_ptr).await?;
+        match light_block {
+            Some(light_block) => {
+                let adapter = adapters.cheapest_with(&self.capabilities).await?;
                 let ethereum_block = adapter
-                    .load_full_block(&self.logger, block)
+                    .load_full_block(&self.logger, light_block.inner().clone())
                     .await
                     .map_err(|e| anyhow!("Failed to load full block: {}", e))?;
                 Ok(Some(ethereum_block))


### PR DESCRIPTION
Both eth_getBlockByHash and eth_getBlockByNumber were being called unconditionally in several places, even when the block data was already available in the block cache. With many syncing subgraphs this generates a flood of redundant RPC calls.

This PR makes three methods cache-aware before falling back to RPC:
  * block_pointer_from_number — previously always called eth_getBlockByNumber. Now checks chain_store.block_ptrs_by_numbers first and only falls back to RPC when the block number isn't in the cache or has multiple entries (recorded reorg).
 * is_on_main_chain — same pattern as above. This is called every reconciliation cycle for subgraphs beyond the reorg threshold, so the savings are proportional to the number of syncing subgraphs.
* fetch_full_block_with_rpc — previously called adapter.block_by_hash() directly, bypassing the cache entirely. Now delegates the light block lookup to fetch_light_block_with_rpc, which checks recent_blocks_cache and the DB before making an RPC call. This matters in two cases: when the block is already in the cache as a light block (receipts missing but block data present), and when the block was just populated by the preceding walk_back_ancestor → parent_ptr chain.

No semantic changes — RPC is still the fallback whenever the cache doesn't have a definitive answer.