### PR TITLE
graph: Round BigInt cache weight up to full bytes

### DIFF
--- a/graph/src/util/cache_weight.rs
+++ b/graph/src/util/cache_weight.rs
@@ -140,7 +140,7 @@ impl CacheWeight for BigDecimal {
 
 impl CacheWeight for BigInt {
     fn indirect_weight(&self) -> usize {
-        self.bits() / 8
+        (self.bits() + 7) / 8
     }
 }
 


### PR DESCRIPTION
## Summary

Fix `CacheWeight::indirect_weight` for `BigInt` to use ceiling division when converting the bit length to a byte count (`(bits + 7) / 8`). Integer division by eight previously undercounted values whose bit width is not a multiple of eight.

## Commit convention

Matches project style: `{crate-name}: {description}` (see CLAUDE.md and recent history on `master`).

## Testing

- [ ] `just lint` / `just check --release` (recommended before merge; not run in this environment due to crates.io SSL issues)