### PR TITLE
graph: Remove debug prefix from Timestamp value parse errors

### DIFF
--- a/graph/src/data/store/mod.rs
+++ b/graph/src/data/store/mod.rs
@@ -371,7 +371,7 @@ impl Value {
                         Value::Timestamp(scalar::Timestamp::parse_timestamp(s).map_err(|_| {
                             QueryExecutionError::ValueParseError(
                                 "Timestamp".to_string(),
-                                format!("xxx{}", s),
+                                format!("{}", s),
                             )
                         })?)
                     }


### PR DESCRIPTION
## Summary

Removes an accidental `"xxx"` debug prefix from the `TIMESTAMP_SCALAR` branch of `Value::from_graphql_value`, so `QueryExecutionError::ValueParseError` reports the invalid timestamp string directly (consistent with other scalars).

## Testing

Please run `just lint`, `just check --release`, and relevant unit tests locally before merge.