### PR TITLE
Feat/graphman chain rebuild storage

### DIFF
--- a/docs/graphman.md
+++ b/docs/graphman.md
@@ -8,6 +8,7 @@
 - [Drop](#drop)
 - [Chain Check Blocks](#check-blocks)
 - [Chain Call Cache Remove](#chain-call-cache-remove)
+- [Chain Rebuild Storage](#chain-rebuild-storage)
 
 <a id="info"></a>
 # ⌘ Info
@@ -438,4 +439,70 @@ Remove stale contracts from the call cache that have not been accessed in the la
 
 Remove stale contracts from the call cache that have not been accessed in the last 7 days, limiting the removal to a maximum of 100 contracts:
     graphman --config config.toml chain call-cache ethereum remove --ttl-days 7 --ttl-max-contracts 100
+
+<a id="chain-rebuild-storage"></a>
+# ⌘ Chain Rebuild Storage
+
+### SYNOPSIS
+
+    Rebuild a chain's storage schema and reset head metadata
+
+    If the storage schema is missing, rebuilds it silently.
+    If the storage already exists, prompts for confirmation before
+    dropping and rebuilding it (use --force to skip the prompt).
+
+    USAGE:
+        graphman --config <CONFIG> chain rebuild-storage [OPTIONS] <CHAIN_NAME>
+
+    ARGS:
+        <CHAIN_NAME>    Chain name (must be an existing chain, see 'chain list')
+
+    OPTIONS:
+        -f, --force   Skip confirmation prompt when storage already exists
+        -h, --help    Print help information
+
+### DESCRIPTION
+
+The `chain rebuild-storage` command recovers from a situation where a chain's storage schema
+(e.g. `chain42`) has been dropped or corrupted on the shard but the chain's metadata in
+`public.chains` still exists. This can happen after manual database operations or partial failures.
+
+The command behaves differently depending on the state of the storage:
+
+**Storage missing** (non-destructive): the command silently rebuilds the schema and resets
+head metadata. No confirmation is required.
+
+**Storage exists** (destructive): the command prompts for confirmation before dropping the
+existing schema and rebuilding it from scratch. Use `--force` to skip the prompt.
+
+In both cases, the command performs the following steps in a single transaction:
+
+1. Drops the existing storage schema if present (`DROP SCHEMA IF EXISTS ... CASCADE`).
+2. Upserts the chain's row in `ethereum_networks` on the shard: inserts if missing, or repairs
+   identity metadata (`namespace`, `net_version`, `genesis_block_hash`) and resets head tracking
+   columns (`head_block_hash`, `head_block_number`, `head_block_cursor`) to `NULL` if the row exists.
+3. Rebuilds the storage schema with empty `blocks`, `call_cache`, and `call_meta` tables.
+
+After this, graph-node will treat the chain as freshly added and begin syncing from scratch.
+
+The `public.chains` metadata row is never modified by this command.
+
+### CONSTRAINTS
+
+- The chain must already exist in `public.chains`. This command does not create new chains.
+- Chains using shared storage (`public`) are not supported.
+
+### EXAMPLES
+
+Rebuild missing storage for a chain:
+
+    graphman --config config.toml chain rebuild-storage mainnet
+
+Force-rebuild existing storage (skips confirmation):
+
+    graphman --config config.toml chain rebuild-storage mainnet --force
+
+Check what chains are available:
+
+    graphman --config config.toml chain list
 

--- a/docs/graphman.md
+++ b/docs/graphman.md
@@ -467,6 +467,8 @@ The `chain rebuild-storage` command recovers from a situation where a chain's st
 (e.g. `chain42`) has been dropped or corrupted on the shard but the chain's metadata in
 `public.chains` still exists. This can happen after manual database operations or partial failures.
 
+> **Operational requirement:** Stop graph-node before running this command.
+
 The command behaves differently depending on the state of the storage:
 
 **Storage missing** (non-destructive): the command silently rebuilds the schema and resets
@@ -477,7 +479,7 @@ existing schema and rebuilding it from scratch. Use `--force` to skip the prompt
 
 In both cases, the command performs the following steps in a single transaction:
 
-1. Drops the existing storage schema if present (`DROP SCHEMA IF EXISTS ... CASCADE`).
+1. Drops the existing storage schema if present (`DROP SCHEMA ... CASCADE`).
 2. Upserts the chain's row in `ethereum_networks` on the shard: inserts if missing, or repairs
    identity metadata (`namespace`, `net_version`, `genesis_block_hash`) and resets head tracking
    columns (`head_block_hash`, `head_block_number`, `head_block_cursor`) to `NULL` if the row exists.

--- a/node/src/bin/manager.rs
+++ b/node/src/bin/manager.rs
@@ -604,6 +604,20 @@ pub enum ChainCommand {
         /// The block number to ingest
         number: BlockNumber,
     },
+
+    /// Rebuild a chain's storage schema and reset head metadata.
+    ///
+    /// If the storage schema is missing, rebuilds it silently.
+    /// If the storage already exists, prompts for confirmation before
+    /// dropping and rebuilding it (use --force to skip the prompt).
+    RebuildStorage {
+        /// Chain name (must be an existing chain, see 'chain list')
+        #[clap(value_parser = clap::builder::NonEmptyStringValueParser::new())]
+        chain_name: String,
+        /// Skip confirmation prompt when storage already exists
+        #[clap(long, short)]
+        force: bool,
+    },
 }
 
 #[derive(Clone, Debug, Subcommand)]
@@ -1585,6 +1599,10 @@ async fn main() -> anyhow::Result<()> {
                     let (chain_store, ethereum_adapter) =
                         ctx.chain_store_and_adapter(&name).await?;
                     commands::chain::ingest(&logger, chain_store, ethereum_adapter, number).await
+                }
+                RebuildStorage { chain_name, force } => {
+                    let (block_store, primary) = ctx.block_store_and_primary_pool().await;
+                    commands::chain::rebuild_storage(primary, block_store, chain_name, force).await
                 }
             }
         }

--- a/node/src/manager/commands/chain.rs
+++ b/node/src/manager/commands/chain.rs
@@ -13,6 +13,7 @@ use graph::components::store::StoreError;
 use graph::prelude::BlockNumber;
 use graph::prelude::ChainStore as _;
 use graph::prelude::LightEthereumBlock;
+use graph::prelude::anyhow::Context as _;
 use graph::prelude::{anyhow, anyhow::bail};
 use graph::slog::Logger;
 use graph::{
@@ -27,11 +28,13 @@ use graph_store_postgres::ChainStore;
 use graph_store_postgres::PoolCoordinator;
 use graph_store_postgres::ScopedFutureExt;
 use graph_store_postgres::Shard;
+use graph_store_postgres::Storage;
 use graph_store_postgres::add_chain;
 use graph_store_postgres::find_chain;
 use graph_store_postgres::update_chain_name;
 use graph_store_postgres::{ConnectionPool, command_support::catalog::block_store};
 
+use crate::manager::prompt::prompt_for_confirmation;
 use crate::network_setup::Networks;
 
 pub async fn list(primary: ConnectionPool, store: BlockStore) -> Result<(), Error> {
@@ -327,5 +330,57 @@ pub async fn ingest(
     if rows > 0 {
         println!("    (also deleted {rows} duplicate row(s) with that number)");
     }
+    Ok(())
+}
+
+pub async fn rebuild_storage(
+    primary: ConnectionPool,
+    store: BlockStore,
+    name: String,
+    force: bool,
+) -> Result<(), Error> {
+    let mut conn = primary.get().await?;
+
+    let chain = block_store::find_chain(&mut conn, &name)
+        .await?
+        .ok_or_else(|| {
+            anyhow!(
+                "Chain {} not found in public.chains.\n\
+                 This command only supports chains already present in metadata.",
+                name
+            )
+        })?;
+
+    if matches!(chain.storage, Storage::Shared) {
+        bail!(
+            "Chain {} uses shared storage public and cannot be rebuilt with this command.",
+            name
+        );
+    }
+
+    let namespace = chain.storage.to_string();
+    let shard = &chain.shard;
+    let ident = chain.network_identifier()?;
+
+    if store.has_namespace(&chain).await? {
+        let prompt = format!(
+            "Storage {namespace} for chain {name} already exists on shard {shard}.\n\
+             This will drop and rebuild chain storage. All cached blocks and call cache \
+             data in that namespace will be permanently deleted.\n\
+             Proceed?"
+        );
+        if !force && !prompt_for_confirmation(&prompt)? {
+            println!("Aborting.");
+            return Ok(());
+        }
+    }
+
+    store
+        .rebuild_chain_storage(&name, &ident)
+        .await
+        .with_context(|| format!("Failed to rebuild storage {namespace} for chain {name}"))?;
+
+    println!("Successfully rebuilt storage {namespace} for chain {name} on shard {shard}.");
+
     Ok(())
 }

--- a/node/src/manager/commands/chain.rs
+++ b/node/src/manager/commands/chain.rs
@@ -362,7 +362,8 @@ pub async fn rebuild_storage(
     let shard = &chain.shard;
     let ident = chain.network_identifier()?;
 
-    if store.has_namespace(&chain).await? {
+    let drop_schema = store.has_namespace(&chain).await?;
+    if drop_schema {
         let prompt = format!(
             "Storage {namespace} for chain {name} already exists on shard {shard}.\n\
              This will drop and rebuild chain storage. All cached blocks and call cache \
@@ -376,7 +377,7 @@ pub async fn rebuild_storage(
     }
 
     store
-        .rebuild_chain_storage(&name, &ident)
+        .rebuild_chain_storage(&name, &ident, drop_schema)
         .await
         .with_context(|| format!("Failed to rebuild storage {namespace} for chain {name}"))?;
 

--- a/store/postgres/src/block_store.rs
+++ b/store/postgres/src/block_store.rs
@@ -498,13 +498,14 @@ impl BlockStore {
         &self,
         chain: &str,
         ident: &ChainIdentifier,
+        drop_schema: bool,
     ) -> Result<(), StoreError> {
         let chain_store = self
             .store(chain)
             .await
             .ok_or_else(|| internal_error!("No chain store found for {}", chain))?;
 
-        Ok(chain_store.rebuild_storage(ident).await?)
+        Ok(chain_store.rebuild_storage(ident, drop_schema).await?)
     }
 
     // Helper to clone the list of chain stores to avoid holding the lock

--- a/store/postgres/src/block_store.rs
+++ b/store/postgres/src/block_store.rs
@@ -484,6 +484,29 @@ impl BlockStore {
         Ok(())
     }
 
+    pub async fn has_namespace(&self, chain: &primary::Chain) -> Result<bool, StoreError> {
+        let pool = self
+            .pools
+            .get(&chain.shard)
+            .ok_or_else(|| internal_error!("no pool for shard {}", chain.shard))?;
+        let nsp = crate::primary::Namespace::special(chain.storage.to_string());
+        let mut conn = pool.get_permitted().await?;
+        crate::catalog::has_namespace(&mut conn, &nsp).await
+    }
+
+    pub async fn rebuild_chain_storage(
+        &self,
+        chain: &str,
+        ident: &ChainIdentifier,
+    ) -> Result<(), StoreError> {
+        let chain_store = self
+            .store(chain)
+            .await
+            .ok_or_else(|| internal_error!("No chain store found for {}", chain))?;
+
+        Ok(chain_store.rebuild_storage(ident).await?)
+    }
+
     // Helper to clone the list of chain stores to avoid holding the lock
     // while awaiting
     fn stores(&self) -> Vec<Arc<ChainStore>> {

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use diesel::sql_types::Text;
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, insert_into, update};
 use diesel_async::AsyncConnection;
-use diesel_async::{RunQueryDsl, scoped_futures::ScopedFutureExt};
+use diesel_async::{RunQueryDsl, SimpleAsyncConnection, scoped_futures::ScopedFutureExt};
 
 use graph::components::store::ChainHeadStore;
 use graph::data::store::ethereum::call;
@@ -12,7 +12,7 @@ use graph::parking_lot::RwLock;
 use graph::prelude::MetricsRegistry;
 use graph::prelude::alloy::primitives::B256;
 use graph::prometheus::{CounterVec, GaugeVec};
-use graph::slog::{Logger, info, o};
+use graph::slog::{Logger, debug, info, o};
 use graph::stable_hash::crypto_stable_hash;
 use graph::util::herd_cache::HerdCache;
 
@@ -2472,6 +2472,55 @@ impl ChainStore {
                 delete(n::table.filter(n::name.eq(&self.chain)))
                     .execute(conn)
                     .await?;
+                Ok(())
+            }
+            .scope_boxed()
+        })
+        .await
+    }
+
+    /// Drop the chain's storage schema (if it exists), reset head
+    /// metadata in `ethereum_networks`, and rebuild the schema with
+    /// empty tables. If the `ethereum_networks` row is missing, it is
+    /// created from the provided `ident`.
+    pub(crate) async fn rebuild_storage(&self, ident: &ChainIdentifier) -> Result<(), Error> {
+        use public::ethereum_networks as n;
+
+        let nsp = self.storage.to_string();
+
+        debug!(&self.logger, "Rebuilding storage for chain"; "chain" => &self.chain, "namespace" => &nsp);
+
+        let mut conn = self.pool.get_permitted().await?;
+        conn.transaction(|conn| {
+            async {
+                debug!(&self.logger, "Dropping existing schema if present"; "namespace" => &nsp);
+                conn.batch_execute(&format!("DROP SCHEMA IF EXISTS {nsp} CASCADE"))
+                    .await?;
+
+                debug!(&self.logger, "Upserting ethereum_networks row"; "chain" => &self.chain);
+                insert_into(n::table)
+                    .values((
+                        n::name.eq(&self.chain),
+                        n::namespace.eq(&self.storage),
+                        n::net_version.eq(&ident.net_version),
+                        n::genesis_block_hash.eq(ident.genesis_block_hash.hash_hex()),
+                    ))
+                    .on_conflict(n::name)
+                    .do_update()
+                    .set((
+                        n::namespace.eq(&self.storage),
+                        n::net_version.eq(&ident.net_version),
+                        n::genesis_block_hash.eq(ident.genesis_block_hash.hash_hex()),
+                        n::head_block_hash.eq(None::<String>),
+                        n::head_block_number.eq(None::<i64>),
+                        n::head_block_cursor.eq(None::<String>),
+                    ))
+                    .execute(conn)
+                    .await?;
+
+                debug!(&self.logger, "Creating storage schema and tables"; "namespace" => &nsp);
+                self.storage.create(conn).await?;
+
                 Ok(())
             }
             .scope_boxed()

--- a/store/postgres/src/chain_store.rs
+++ b/store/postgres/src/chain_store.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use diesel::sql_types::Text;
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, insert_into, update};
 use diesel_async::AsyncConnection;
-use diesel_async::{RunQueryDsl, SimpleAsyncConnection, scoped_futures::ScopedFutureExt};
+use diesel_async::{RunQueryDsl, scoped_futures::ScopedFutureExt};
 
 use graph::components::store::ChainHeadStore;
 use graph::data::store::ethereum::call;
@@ -2483,7 +2483,11 @@ impl ChainStore {
     /// metadata in `ethereum_networks`, and rebuild the schema with
     /// empty tables. If the `ethereum_networks` row is missing, it is
     /// created from the provided `ident`.
-    pub(crate) async fn rebuild_storage(&self, ident: &ChainIdentifier) -> Result<(), Error> {
+    pub(crate) async fn rebuild_storage(
+        &self,
+        ident: &ChainIdentifier,
+        drop_schema: bool,
+    ) -> Result<(), Error> {
         use public::ethereum_networks as n;
 
         let nsp = self.storage.to_string();
@@ -2493,9 +2497,10 @@ impl ChainStore {
         let mut conn = self.pool.get_permitted().await?;
         conn.transaction(|conn| {
             async {
-                debug!(&self.logger, "Dropping existing schema if present"; "namespace" => &nsp);
-                conn.batch_execute(&format!("DROP SCHEMA IF EXISTS {nsp} CASCADE"))
-                    .await?;
+                if drop_schema {
+                    debug!(&self.logger, "Dropping existing schema"; "namespace" => &nsp);
+                    self.storage.drop_storage(conn, &self.chain).await?;
+                }
 
                 debug!(&self.logger, "Upserting ethereum_networks row"; "chain" => &self.chain);
                 insert_into(n::table)

--- a/store/test-store/tests/postgres/chain_head.rs
+++ b/store/test-store/tests/postgres/chain_head.rs
@@ -660,3 +660,228 @@ fn test_transaction_receipts_in_block_function() {
         assert!(receipts.is_empty())
     })
 }
+
+// ---- rebuild_storage tests ----
+
+/// Helper that runs a test only on NETWORK_NAME (private storage).
+/// rebuild_storage is not supported on shared storage.
+fn run_rebuild_test<R, F>(chain: FakeBlockList, test: F)
+where
+    F: Fn(Arc<DieselChainStore>, Arc<DieselStore>) -> R + Send + Sync + 'static,
+    R: Future<Output = ()> + Send + 'static,
+{
+    run_test_sequentially(|store| async move {
+        block_store::set_chain(chain.clone(), NETWORK_NAME).await;
+
+        let chain_store = store
+            .block_store()
+            .chain_store(NETWORK_NAME)
+            .await
+            .expect("chain store for NETWORK_NAME");
+
+        test(chain_store, store).await;
+    });
+}
+
+#[test]
+fn rebuild_storage_with_existing_namespace() {
+    let chain = vec![&*GENESIS_BLOCK, &*BLOCK_ONE, &*BLOCK_TWO];
+
+    run_rebuild_test(chain, |chain_store, store| async move {
+        let block_store = store.block_store();
+
+        // Look up the chain from primary metadata
+        let mut conn = PRIMARY_POOL.get().await.unwrap();
+        let chain = graph_store_postgres::find_chain(&mut conn, NETWORK_NAME)
+            .await
+            .unwrap()
+            .expect("chain exists in public.chains");
+        drop(conn);
+
+        let ident = chain.network_identifier().unwrap();
+
+        // Verify blocks are present before rebuild
+        let hashes = chain_store.block_hashes_by_block_number(1).await.unwrap();
+        assert!(!hashes.is_empty(), "block 1 should exist before rebuild");
+
+        // Verify namespace exists
+        assert!(
+            block_store.has_namespace(&chain).await.unwrap(),
+            "namespace should exist before rebuild"
+        );
+
+        // Rebuild storage (should drop and recreate)
+        block_store
+            .rebuild_chain_storage(NETWORK_NAME, &ident)
+            .await
+            .expect("rebuild_chain_storage succeeds");
+
+        // Verify namespace still exists after rebuild
+        assert!(
+            block_store.has_namespace(&chain).await.unwrap(),
+            "namespace should exist after rebuild"
+        );
+
+        // Verify blocks are gone after rebuild (tables are fresh)
+        let hashes = chain_store.block_hashes_by_block_number(1).await.unwrap();
+        assert!(hashes.is_empty(), "blocks should be gone after rebuild");
+
+        // Verify chain identity is intact
+        let ident_after = chain_store.chain_identifier().await.unwrap();
+        assert_eq!(ident.net_version, ident_after.net_version);
+        assert_eq!(ident.genesis_block_hash, ident_after.genesis_block_hash);
+
+        // Verify head is reset to null
+        let head = chain_store
+            .clone()
+            .chain_head_ptr()
+            .await
+            .expect("chain_head_ptr succeeds");
+        assert!(head.is_none(), "head should be null after rebuild");
+    });
+}
+
+#[test]
+fn rebuild_storage_with_missing_namespace() {
+    let chain = vec![&*GENESIS_BLOCK, &*BLOCK_ONE];
+
+    run_rebuild_test(chain, |chain_store, store| async move {
+        let block_store = store.block_store();
+
+        let mut conn = PRIMARY_POOL.get().await.unwrap();
+        let chain = graph_store_postgres::find_chain(&mut conn, NETWORK_NAME)
+            .await
+            .unwrap()
+            .expect("chain exists in public.chains");
+        drop(conn);
+
+        let ident = chain.network_identifier().unwrap();
+        let nsp = chain.storage.to_string();
+
+        // Drop the namespace manually to simulate missing storage
+        {
+            let mut conn = chain_store.get_conn_for_test().await.unwrap();
+            diesel::sql_query(format!("DROP SCHEMA IF EXISTS {nsp} CASCADE"))
+                .execute(&mut conn)
+                .await
+                .unwrap();
+        }
+
+        // Verify namespace is gone
+        assert!(
+            !block_store.has_namespace(&chain).await.unwrap(),
+            "namespace should be gone after manual drop"
+        );
+
+        // Rebuild should recreate the missing namespace
+        block_store
+            .rebuild_chain_storage(NETWORK_NAME, &ident)
+            .await
+            .expect("rebuild_chain_storage succeeds on missing namespace");
+
+        // Verify namespace exists again
+        assert!(
+            block_store.has_namespace(&chain).await.unwrap(),
+            "namespace should exist after rebuild"
+        );
+
+        // Verify chain identity is correct
+        let ident_after = chain_store.chain_identifier().await.unwrap();
+        assert_eq!(ident.net_version, ident_after.net_version);
+        assert_eq!(ident.genesis_block_hash, ident_after.genesis_block_hash);
+    });
+}
+
+#[test]
+fn rebuild_storage_repairs_ethereum_networks_row() {
+    let chain = vec![&*GENESIS_BLOCK];
+
+    run_rebuild_test(chain, |chain_store, store| async move {
+        let block_store = store.block_store();
+
+        let mut conn = PRIMARY_POOL.get().await.unwrap();
+        let chain = graph_store_postgres::find_chain(&mut conn, NETWORK_NAME)
+            .await
+            .unwrap()
+            .expect("chain exists in public.chains");
+        drop(conn);
+
+        let ident = chain.network_identifier().unwrap();
+        let nsp = chain.storage.to_string();
+
+        // Drop the namespace AND delete the ethereum_networks row to
+        // simulate a fully broken state
+        {
+            let mut conn = chain_store.get_conn_for_test().await.unwrap();
+            diesel::sql_query(format!("DROP SCHEMA IF EXISTS {nsp} CASCADE"))
+                .execute(&mut conn)
+                .await
+                .unwrap();
+            diesel::sql_query(format!(
+                "DELETE FROM public.ethereum_networks WHERE name = '{}'",
+                NETWORK_NAME
+            ))
+            .execute(&mut conn)
+            .await
+            .unwrap();
+        }
+
+        // Rebuild should recreate both the namespace and the
+        // ethereum_networks row via upsert
+        block_store
+            .rebuild_chain_storage(NETWORK_NAME, &ident)
+            .await
+            .expect("rebuild_chain_storage succeeds with missing ethereum_networks row");
+
+        // Verify the chain identity was restored from the ident we passed in
+        let ident_after = chain_store.chain_identifier().await.unwrap();
+        assert_eq!(ident.net_version, ident_after.net_version);
+        assert_eq!(ident.genesis_block_hash, ident_after.genesis_block_hash);
+
+        // Verify namespace exists
+        assert!(
+            block_store.has_namespace(&chain).await.unwrap(),
+            "namespace should exist after rebuild"
+        );
+    });
+}
+
+#[test]
+fn has_namespace_returns_false_for_missing_schema() {
+    let chain = vec![&*GENESIS_BLOCK];
+
+    run_rebuild_test(chain, |chain_store, store| async move {
+        let block_store = store.block_store();
+
+        let mut conn = PRIMARY_POOL.get().await.unwrap();
+        let chain = graph_store_postgres::find_chain(&mut conn, NETWORK_NAME)
+            .await
+            .unwrap()
+            .expect("chain exists");
+        drop(conn);
+
+        // Namespace should exist initially
+        assert!(block_store.has_namespace(&chain).await.unwrap());
+
+        let nsp = chain.storage.to_string();
+
+        // Drop the schema
+        {
+            let mut conn = chain_store.get_conn_for_test().await.unwrap();
+            diesel::sql_query(format!("DROP SCHEMA IF EXISTS {nsp} CASCADE"))
+                .execute(&mut conn)
+                .await
+                .unwrap();
+        }
+
+        // Should return false now
+        assert!(!block_store.has_namespace(&chain).await.unwrap());
+
+        // Rebuild to leave things clean for other tests
+        let ident = chain.network_identifier().unwrap();
+        block_store
+            .rebuild_chain_storage(NETWORK_NAME, &ident)
+            .await
+            .unwrap();
+    });
+}

--- a/store/test-store/tests/postgres/chain_head.rs
+++ b/store/test-store/tests/postgres/chain_head.rs
@@ -712,7 +712,7 @@ fn rebuild_storage_with_existing_namespace() {
 
         // Rebuild storage (should drop and recreate)
         block_store
-            .rebuild_chain_storage(NETWORK_NAME, &ident)
+            .rebuild_chain_storage(NETWORK_NAME, &ident, true)
             .await
             .expect("rebuild_chain_storage succeeds");
 
@@ -775,7 +775,7 @@ fn rebuild_storage_with_missing_namespace() {
 
         // Rebuild should recreate the missing namespace
         block_store
-            .rebuild_chain_storage(NETWORK_NAME, &ident)
+            .rebuild_chain_storage(NETWORK_NAME, &ident, false)
             .await
             .expect("rebuild_chain_storage succeeds on missing namespace");
 
@@ -829,7 +829,7 @@ fn rebuild_storage_repairs_ethereum_networks_row() {
         // Rebuild should recreate both the namespace and the
         // ethereum_networks row via upsert
         block_store
-            .rebuild_chain_storage(NETWORK_NAME, &ident)
+            .rebuild_chain_storage(NETWORK_NAME, &ident, false)
             .await
             .expect("rebuild_chain_storage succeeds with missing ethereum_networks row");
 
@@ -880,7 +880,7 @@ fn has_namespace_returns_false_for_missing_schema() {
         // Rebuild to leave things clean for other tests
         let ident = chain.network_identifier().unwrap();
         block_store
-            .rebuild_chain_storage(NETWORK_NAME, &ident)
+            .rebuild_chain_storage(NETWORK_NAME, &ident, false)
             .await
             .unwrap();
     });


### PR DESCRIPTION
### Problem

After manual DB operations or a DB failure it's possible to end up with a chain whose storage schema (e.g. `chain123`) has been dropped on the shard while its metadata row in `public.chains` still exists. `graph-node` cannot recover from this automatically and will fail with:

```bash
INFO Downloading latest blocks from Ethereum, this may take a few minutes..., provider: arbitrum-one, component:
ERRO Trying again after block polling failed: Ingestor error: store error: relation "chain123.blocks" does not exist, provider: arbitrum-one, component: EthereumPollingBlockIngestor
```
Currently the only way to fix is to manually re-create the schema, tables and `ethereum_networks` records on the shard.

### What this PR does:

Adds a new `graphman chain rebuild-storage <CHAIN_NAME>` command. It recreates the schema, tables and inserts/updates the `ethereum_networks` table

Behaviour depends on current state:

- Schema/namespace missing — silently skips drop and recreates the schema; no confirmation required.
- Schema/namespace exists — prompts for confirmation before dropping and rebuilding. Use `--force` to skip the prompt.

1. Drops the existing storage schema if present (DROP SCHEMA ... CASCADE), reusing Storage::drop_storage.
2. Upserts the chain's row in ethereum_networks: insert if missing (seeding from the provided chain identity), or reset head_block_hash, head_block_number, head_block_cursor to NULL and repair identity columns if the row exists.
3. Recreates the schema with empty blocks, call_cache, and call_meta tables.


  After this, graph-node treats the chain as a freshly added chain.