### PR TITLE
graph: Remove manual Eq::assert_receiver_is_total_eq impl

### DIFF
--- a/graph/src/util/intern.rs
+++ b/graph/src/util/intern.rs
@@ -510,9 +510,7 @@ impl<V: PartialEq> PartialEq for Object<V> {
     }
 }
 
-impl<V: Eq> Eq for Object<V> {
-    fn assert_receiver_is_total_eq(&self) {}
-}
+impl<V: Eq> Eq for Object<V> {}
 
 impl<V: Serialize> Serialize for Object<V> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
Manually implementing `Eq::assert_receiver_is_total_eq` is now a hard error in recent Rust toolchains. Remove the manual impl and use the empty impl block instead.

This is currently breaking CI on master and all open PRs.