### PR TITLE
Drop vendored bigdecimal and track diesel's version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,7 +989,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -1009,7 +1009,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "rustc_version 0.4.0",
@@ -1030,7 +1030,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "paste",
  "zeroize",
@@ -1072,7 +1072,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -1084,7 +1084,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1097,7 +1097,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1122,7 +1122,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -1134,7 +1134,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec 0.7.4",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint",
 ]
 
 [[package]]
@@ -1249,7 +1249,7 @@ checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
 dependencies = [
  "bytes",
  "half",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-traits",
 ]
 
@@ -1804,25 +1804,14 @@ checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
 
 [[package]]
 name = "bigdecimal"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1374191e2dd25f9ae02e3aa95041ed5d747fc77b3c102b49fe2dd9a8117a6244"
-dependencies = [
- "num-bigint 0.2.6",
- "num-integer",
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "bigdecimal"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -2989,14 +2978,14 @@ version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9940fb8467a0a06312218ed384185cb8536aa10d8ec017d0ce7fad2c1bd882d5"
 dependencies = [
- "bigdecimal 0.3.1",
+ "bigdecimal",
  "bitflags 2.11.1",
  "byteorder",
  "chrono",
  "diesel_derives",
  "downcast-rs",
  "itoa",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "pq-sys",
@@ -3904,7 +3893,7 @@ dependencies = [
  "async-trait",
  "atomic_refcell",
  "base64 0.21.7",
- "bigdecimal 0.1.2",
+ "bigdecimal",
  "bs58 0.5.1",
  "bytes",
  "chrono",
@@ -3934,7 +3923,7 @@ dependencies = [
  "lazy_static",
  "lru_time_cache",
  "maplit",
- "num-bigint 0.2.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "object_store",
@@ -5658,24 +5647,13 @@ checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
- "serde",
-]
-
-[[package]]
-name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -5996,7 +5974,7 @@ dependencies = [
  "half",
  "hashbrown 0.17.0",
  "lz4_flex",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "paste",
@@ -6866,7 +6844,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "itoa",
- "num-bigint 0.4.6",
+ "num-bigint",
  "percent-encoding",
  "pin-project-lite",
  "ryu",
@@ -7085,7 +7063,7 @@ dependencies = [
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
- "num-bigint 0.4.6",
+ "num-bigint",
  "num-integer",
  "num-traits",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ async-graphql = { version = "7.2.1", features = ["chrono"] }
 async-graphql-axum = "7.2.1"
 async-trait = "0.1.74"
 axum = "0.8.9"
+bigdecimal = { version = "0.3", features = ["serde"] }
 chrono = "0.4.44"
 bs58 = "0.5.1"
 clap = { version = "4.5.4", features = ["derive", "env", "wrap_help"] }
@@ -80,6 +81,7 @@ indicatif = "0.18"
 Inflector = "0.11.3"
 itertools = "0.14.0"
 lazy_static = "1.5.0"
+num-bigint = { version = "0.4", features = ["serde"] }
 prost = "0.14"
 prost-types = "0.14"
 redis = { version = "1.2.2", features = [

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -9,13 +9,8 @@ base64 = "=0.21.7"
 anyhow = "1.0"
 async-trait = { workspace = true }
 async-stream = "0.3"
-atomic_refcell = "0.1.14"
-# We require this precise version of bigdecimal. Updating to later versions
-# has caused PoI differences; if you update this version, you will need to
-# make sure that it does not cause PoI changes
-old_bigdecimal = { version = "=0.1.2", features = [
-    "serde",
-], package = "bigdecimal" }
+atomic_refcell = "0.1.13"
+bigdecimal.workspace = true
 bytes = "1.0.1"
 bs58 = { workspace = true }
 cid = "0.11.3"
@@ -38,7 +33,7 @@ futures01 = { package = "futures", version = "0.1.31" }
 lru_time_cache = "0.11"
 graphql-tools = { workspace = true }
 lazy_static = { workspace = true }
-num-bigint = { version = "=0.2.6", features = ["serde"] }
+num-bigint.workspace = true
 num-integer = { version = "=0.1.46" }
 num-traits = "=0.2.19"
 rand.workspace = true

--- a/graph/src/data/query/error.rs
+++ b/graph/src/data/query/error.rs
@@ -359,8 +359,8 @@ impl From<FromHexError> for QueryExecutionError {
     }
 }
 
-impl From<old_bigdecimal::ParseBigDecimalError> for QueryExecutionError {
-    fn from(e: old_bigdecimal::ParseBigDecimalError) -> Self {
+impl From<bigdecimal::ParseBigDecimalError> for QueryExecutionError {
+    fn from(e: bigdecimal::ParseBigDecimalError) -> Self {
         QueryExecutionError::ValueParseError("BigDecimal".to_string(), format!("{}", e))
     }
 }

--- a/graph/src/data/store/scalar/bigdecimal.rs
+++ b/graph/src/data/store/scalar/bigdecimal.rs
@@ -1,3 +1,5 @@
+use bigdecimal::BigDecimal as UpstreamBigDecimal;
+pub use bigdecimal::ToPrimitive;
 use diesel::deserialize::FromSqlRow;
 use diesel::expression::AsExpression;
 use num_bigint::{self, ToBigInt};
@@ -12,8 +14,6 @@ use std::str::FromStr;
 
 use crate::anyhow::anyhow;
 use crate::runtime::gas::{Gas, GasSizeOf};
-use old_bigdecimal::BigDecimal as OldBigDecimal;
-pub use old_bigdecimal::ToPrimitive;
 
 use super::BigInt;
 
@@ -24,12 +24,12 @@ use super::BigInt;
 #[derive(
     Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, AsExpression, FromSqlRow,
 )]
-#[serde(from = "OldBigDecimal")]
+#[serde(from = "UpstreamBigDecimal")]
 #[diesel(sql_type = diesel::sql_types::Numeric)]
-pub struct BigDecimal(OldBigDecimal);
+pub struct BigDecimal(UpstreamBigDecimal);
 
-impl From<OldBigDecimal> for BigDecimal {
-    fn from(big_decimal: OldBigDecimal) -> Self {
+impl From<UpstreamBigDecimal> for BigDecimal {
+    fn from(big_decimal: UpstreamBigDecimal) -> Self {
         BigDecimal(big_decimal).normalized()
     }
 }
@@ -43,17 +43,17 @@ impl BigDecimal {
 
     pub fn new(digits: BigInt, exp: i64) -> Self {
         // bigdecimal uses `scale` as the opposite of the power of ten, so negate `exp`.
-        Self::from(OldBigDecimal::new(digits.inner(), -exp))
+        Self::from(UpstreamBigDecimal::new(digits.inner(), -exp))
     }
 
     pub fn parse_bytes(bytes: &[u8]) -> Option<Self> {
-        OldBigDecimal::parse_bytes(bytes, 10).map(Self)
+        UpstreamBigDecimal::parse_bytes(bytes, 10).map(Self)
     }
 
     pub fn zero() -> BigDecimal {
-        use old_bigdecimal::Zero;
+        use num_traits::Zero;
 
-        BigDecimal(OldBigDecimal::zero())
+        BigDecimal(UpstreamBigDecimal::zero())
     }
 
     pub fn as_bigint_and_exponent(&self) -> (num_bigint::BigInt, i64) {
@@ -75,7 +75,9 @@ impl BigDecimal {
             ));
         }
         let bi = self.0.to_bigint().ok_or_else(|| {
-            anyhow!("The implementation of `to_bigint` for `OldBigDecimal` always returns `Some`")
+            anyhow!(
+                "The implementation of `to_bigint` for `UpstreamBigDecimal` always returns `Some`"
+            )
         })?;
         BigInt::new(bi)
     }
@@ -84,8 +86,9 @@ impl BigDecimal {
         self.0.digits()
     }
 
-    // Copy-pasted from `OldBigDecimal::normalize`. We can use the upstream version once it
-    // is included in a released version supported by Diesel.
+    // Round to `MAX_SIGNFICANT_DIGITS` and strip trailing zeros. This is our
+    // PoI-stability policy; it is enforced on every construction path via
+    // `From<UpstreamBigDecimal>`.
     #[must_use]
     pub fn normalized(&self) -> BigDecimal {
         if self == &BigDecimal::zero() {
@@ -102,7 +105,7 @@ impl BigDecimal {
         let int_val = num_bigint::BigInt::from_radix_be(sign, &digits, 10).unwrap();
         let scale = exp - trailing_count as i64;
 
-        BigDecimal(OldBigDecimal::new(int_val, scale))
+        BigDecimal(UpstreamBigDecimal::new(int_val, scale))
     }
 }
 
@@ -119,46 +122,46 @@ impl fmt::Debug for BigDecimal {
 }
 
 impl FromStr for BigDecimal {
-    type Err = <OldBigDecimal as FromStr>::Err;
+    type Err = <UpstreamBigDecimal as FromStr>::Err;
 
     fn from_str(s: &str) -> Result<BigDecimal, Self::Err> {
-        Ok(Self::from(OldBigDecimal::from_str(s)?))
+        Ok(Self::from(UpstreamBigDecimal::from_str(s)?))
     }
 }
 
 impl From<i32> for BigDecimal {
     fn from(n: i32) -> Self {
-        Self::from(OldBigDecimal::from(n))
+        Self::from(UpstreamBigDecimal::from(n))
     }
 }
 
 impl From<i64> for BigDecimal {
     fn from(n: i64) -> Self {
-        Self::from(OldBigDecimal::from(n))
+        Self::from(UpstreamBigDecimal::from(n))
     }
 }
 
 impl From<i128> for BigDecimal {
     fn from(n: i128) -> Self {
-        Self::from(OldBigDecimal::new(BigInt::from(n).inner(), 0))
+        Self::from(UpstreamBigDecimal::new(BigInt::from(n).inner(), 0))
     }
 }
 
 impl From<u64> for BigDecimal {
     fn from(n: u64) -> Self {
-        Self::from(OldBigDecimal::from(n))
+        Self::from(UpstreamBigDecimal::from(n))
     }
 }
 
 impl From<f32> for BigDecimal {
     fn from(n: f32) -> Self {
-        Self::from(OldBigDecimal::from_f32(n).unwrap_or_default())
+        Self::from(UpstreamBigDecimal::from_f32(n).unwrap_or_default())
     }
 }
 
 impl From<f64> for BigDecimal {
     fn from(n: f64) -> Self {
-        Self::from(OldBigDecimal::from_f64(n).unwrap_or_default())
+        Self::from(UpstreamBigDecimal::from_f64(n).unwrap_or_default())
     }
 }
 
@@ -198,7 +201,7 @@ impl Div for BigDecimal {
     }
 }
 
-impl old_bigdecimal::ToPrimitive for BigDecimal {
+impl bigdecimal::ToPrimitive for BigDecimal {
     fn to_i64(&self) -> Option<i64> {
         self.0.to_i64()
     }
@@ -248,355 +251,27 @@ impl GasSizeOf for BigDecimal {
     }
 }
 
-// This code was copied from diesel. Unfortunately, we need to reimplement
-// it here because any change to diesel's version of bigdecimal will cause
-// the build to break as our old_bigdecimal::BigDecimal and diesel's
-// bigdecimal::BigDecimal will then become distinct types, and we can't
-// update our old_bigdecimal because updating causes PoI divergences.
-//
-// The code was taken from diesel-2.1.4/src/pg/types/numeric.rs
+// Delegate PG numeric codec to diesel's built-in impls for
+// `bigdecimal::BigDecimal`. This works because our `UpstreamBigDecimal`
+// alias is the exact type diesel targets (both resolve the `bigdecimal`
+// crate to the same version via workspace dependency resolution).
 mod pg {
-    use std::error::Error;
-
-    use diesel::deserialize::FromSql;
+    use diesel::deserialize::{self, FromSql};
     use diesel::pg::{Pg, PgValue};
     use diesel::serialize::{self, Output, ToSql};
     use diesel::sql_types::Numeric;
-    use diesel::{data_types::PgNumeric, deserialize};
-    use num_bigint::{BigInt, BigUint, Sign};
-    use num_integer::Integer;
-    use num_traits::{Signed, ToPrimitive, Zero};
 
-    use super::super::BigIntSign;
-    use super::{BigDecimal, OldBigDecimal};
-
-    /// Iterator over the digits of a big uint in base 10k.
-    /// The digits will be returned in little endian order.
-    struct ToBase10000(Option<BigUint>);
-
-    impl Iterator for ToBase10000 {
-        type Item = i16;
-
-        fn next(&mut self) -> Option<Self::Item> {
-            self.0.take().map(|v| {
-                let (div, rem) = v.div_rem(&BigUint::from(10_000u16));
-                if !div.is_zero() {
-                    self.0 = Some(div);
-                }
-                rem.to_i16().expect("10000 always fits in an i16")
-            })
-        }
-    }
-
-    impl<'a> TryFrom<&'a PgNumeric> for BigDecimal {
-        type Error = Box<dyn Error + Send + Sync>;
-
-        fn try_from(numeric: &'a PgNumeric) -> deserialize::Result<Self> {
-            let (sign, weight, scale, digits) = match *numeric {
-                PgNumeric::Positive {
-                    weight,
-                    scale,
-                    ref digits,
-                } => (BigIntSign::Plus, weight, scale, digits),
-                PgNumeric::Negative {
-                    weight,
-                    scale,
-                    ref digits,
-                } => (Sign::Minus, weight, scale, digits),
-                PgNumeric::NaN => {
-                    return Err(Box::from("NaN is not (yet) supported in BigDecimal"));
-                }
-            };
-
-            let mut result = BigUint::default();
-            let count = digits.len() as i64;
-            for digit in digits {
-                result *= BigUint::from(10_000u64);
-                result += BigUint::from(*digit as u64);
-            }
-            // First digit got factor 10_000^(digits.len() - 1), but should get 10_000^weight
-            let correction_exp = 4 * (i64::from(weight) - count + 1);
-            let result = OldBigDecimal::new(BigInt::from_biguint(sign, result), -correction_exp)
-                .with_scale(i64::from(scale));
-            Ok(BigDecimal(result))
-        }
-    }
-
-    impl TryFrom<PgNumeric> for BigDecimal {
-        type Error = Box<dyn Error + Send + Sync>;
-
-        fn try_from(numeric: PgNumeric) -> deserialize::Result<Self> {
-            (&numeric).try_into()
-        }
-    }
-
-    impl<'a> From<&'a BigDecimal> for PgNumeric {
-        // NOTE(clippy): No `std::ops::MulAssign` impl for `BigInt`
-        // NOTE(clippy): Clippy suggests to replace the `.take_while(|i| i.is_zero())`
-        // with `.take_while(Zero::is_zero)`, but that's a false positive.
-        // The closure gets an `&&i16` due to autoderef `<i16 as Zero>::is_zero(&self) -> bool`
-        // is called. There is no impl for `&i16` that would work with this closure.
-        #[allow(clippy::assign_op_pattern, clippy::redundant_closure)]
-        fn from(decimal: &'a BigDecimal) -> Self {
-            let (mut integer, scale) = decimal.as_bigint_and_exponent();
-
-            // Handling of negative scale
-            let scale = if scale < 0 {
-                for _ in 0..(-scale) {
-                    integer = integer * 10;
-                }
-                0
-            } else {
-                scale as u16
-            };
-
-            integer = integer.abs();
-
-            // Ensure that the decimal will always lie on a digit boundary
-            for _ in 0..(4 - scale % 4) {
-                integer = integer * 10;
-            }
-            let integer = integer.to_biguint().expect("integer is always positive");
-
-            let mut digits = ToBase10000(Some(integer)).collect::<Vec<_>>();
-            digits.reverse();
-            let digits_after_decimal = scale / 4 + 1;
-            let weight = digits.len() as i16 - digits_after_decimal as i16 - 1;
-
-            let unnecessary_zeroes = digits.iter().rev().take_while(|i| i.is_zero()).count();
-
-            let relevant_digits = digits.len() - unnecessary_zeroes;
-            digits.truncate(relevant_digits);
-
-            match decimal.0.sign() {
-                Sign::Plus => PgNumeric::Positive {
-                    digits,
-                    scale,
-                    weight,
-                },
-                Sign::Minus => PgNumeric::Negative {
-                    digits,
-                    scale,
-                    weight,
-                },
-                Sign::NoSign => PgNumeric::Positive {
-                    digits: vec![0],
-                    scale: 0,
-                    weight: 0,
-                },
-            }
-        }
-    }
-
-    impl From<BigDecimal> for PgNumeric {
-        fn from(bigdecimal: BigDecimal) -> Self {
-            (&bigdecimal).into()
-        }
-    }
+    use super::{BigDecimal, UpstreamBigDecimal};
 
     impl ToSql<Numeric, Pg> for BigDecimal {
         fn to_sql<'b>(&'b self, out: &mut Output<'b, '_, Pg>) -> serialize::Result {
-            let numeric = PgNumeric::from(self);
-            ToSql::<Numeric, Pg>::to_sql(&numeric, &mut out.reborrow())
+            <UpstreamBigDecimal as ToSql<Numeric, Pg>>::to_sql(&self.0, out)
         }
     }
 
     impl FromSql<Numeric, Pg> for BigDecimal {
-        fn from_sql(numeric: PgValue<'_>) -> deserialize::Result<Self> {
-            PgNumeric::from_sql(numeric)?.try_into()
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        // The tests are exactly the same as Diesel's tests, but we use our
-        // BigDecimal instead of bigdecimal::BigDecimal. In a few places, we
-        // have to construct the BigDecimal directly as
-        // `BigDecimal(OldBigDecimal...)` because BigDecimal::new inverts
-        // the sign of the exponent
-        use diesel::data_types::PgNumeric;
-
-        use super::super::{BigDecimal, OldBigDecimal};
-        use std::str::FromStr;
-
-        #[test]
-        fn bigdecimal_to_pgnumeric_converts_digits_to_base_10000() {
-            let decimal = BigDecimal::from_str("1").unwrap();
-            let expected = PgNumeric::Positive {
-                weight: 0,
-                scale: 0,
-                digits: vec![1],
-            };
-            assert_eq!(expected, decimal.into());
-
-            let decimal = BigDecimal::from_str("10").unwrap();
-            let expected = PgNumeric::Positive {
-                weight: 0,
-                scale: 0,
-                digits: vec![10],
-            };
-            assert_eq!(expected, decimal.into());
-
-            let decimal = BigDecimal::from_str("10000").unwrap();
-            let expected = PgNumeric::Positive {
-                weight: 1,
-                scale: 0,
-                digits: vec![1],
-            };
-            assert_eq!(expected, decimal.into());
-
-            let decimal = BigDecimal::from_str("10001").unwrap();
-            let expected = PgNumeric::Positive {
-                weight: 1,
-                scale: 0,
-                digits: vec![1, 1],
-            };
-            assert_eq!(expected, decimal.into());
-
-            let decimal = BigDecimal::from_str("100000000").unwrap();
-            let expected = PgNumeric::Positive {
-                weight: 2,
-                scale: 0,
-                digits: vec![1],
-            };
-            assert_eq!(expected, decimal.into());
-        }
-
-        #[test]
-        fn bigdecimal_to_pg_numeric_properly_adjusts_scale() {
-            let decimal = BigDecimal::from_str("1").unwrap();
-            let expected = PgNumeric::Positive {
-                weight: 0,
-                scale: 0,
-                digits: vec![1],
-            };
-            assert_eq!(expected, decimal.into());
-
-            let decimal = BigDecimal(OldBigDecimal::from_str("1.0").unwrap());
-            let expected = PgNumeric::Positive {
-                weight: 0,
-                scale: 1,
-                digits: vec![1],
-            };
-            assert_eq!(expected, decimal.into());
-
-            let decimal = BigDecimal::from_str("1.1").unwrap();
-            let expected = PgNumeric::Positive {
-                weight: 0,
-                scale: 1,
-                digits: vec![1, 1000],
-            };
-            assert_eq!(expected, decimal.into());
-
-            let decimal = BigDecimal(OldBigDecimal::from_str("1.10").unwrap());
-            let expected = PgNumeric::Positive {
-                weight: 0,
-                scale: 2,
-                digits: vec![1, 1000],
-            };
-            assert_eq!(expected, decimal.into());
-
-            let decimal = BigDecimal::from_str("100000000.0001").unwrap();
-            let expected = PgNumeric::Positive {
-                weight: 2,
-                scale: 4,
-                digits: vec![1, 0, 0, 1],
-            };
-            assert_eq!(expected, decimal.into());
-
-            let decimal = BigDecimal::from_str("0.1").unwrap();
-            let expected = PgNumeric::Positive {
-                weight: -1,
-                scale: 1,
-                digits: vec![1000],
-            };
-            assert_eq!(expected, decimal.into());
-        }
-
-        #[test]
-        fn bigdecimal_to_pg_numeric_retains_sign() {
-            let decimal = BigDecimal::from_str("123.456").unwrap();
-            let expected = PgNumeric::Positive {
-                weight: 0,
-                scale: 3,
-                digits: vec![123, 4560],
-            };
-            assert_eq!(expected, decimal.into());
-
-            let decimal = BigDecimal::from_str("-123.456").unwrap();
-            let expected = PgNumeric::Negative {
-                weight: 0,
-                scale: 3,
-                digits: vec![123, 4560],
-            };
-            assert_eq!(expected, decimal.into());
-        }
-
-        #[test]
-        fn bigdecimal_with_negative_scale_to_pg_numeric_works() {
-            let decimal = BigDecimal(OldBigDecimal::new(50.into(), -2));
-            let expected = PgNumeric::Positive {
-                weight: 0,
-                scale: 0,
-                digits: vec![5000],
-            };
-            assert_eq!(expected, decimal.into());
-
-            let decimal = BigDecimal(OldBigDecimal::new(1.into(), -4));
-            let expected = PgNumeric::Positive {
-                weight: 1,
-                scale: 0,
-                digits: vec![1],
-            };
-            assert_eq!(expected, decimal.into());
-        }
-
-        #[test]
-        fn bigdecimal_with_negative_weight_to_pg_numeric_works() {
-            let decimal = BigDecimal(OldBigDecimal::from_str("0.1000000000000000").unwrap());
-            let expected = PgNumeric::Positive {
-                weight: -1,
-                scale: 16,
-                digits: vec![1000],
-            };
-            assert_eq!(expected, decimal.into());
-
-            let decimal = BigDecimal::from_str("0.00315937").unwrap();
-            let expected = PgNumeric::Positive {
-                weight: -1,
-                scale: 8,
-                digits: vec![31, 5937],
-            };
-            assert_eq!(expected, decimal.into());
-
-            let decimal = BigDecimal(OldBigDecimal::from_str("0.003159370000000000").unwrap());
-            let expected = PgNumeric::Positive {
-                weight: -1,
-                scale: 18,
-                digits: vec![31, 5937],
-            };
-            assert_eq!(expected, decimal.into());
-        }
-
-        #[test]
-        fn pg_numeric_to_bigdecimal_works() {
-            let expected = BigDecimal::from_str("123.456").unwrap();
-            let pg_numeric = PgNumeric::Positive {
-                weight: 0,
-                scale: 3,
-                digits: vec![123, 4560],
-            };
-            let res: BigDecimal = pg_numeric.try_into().unwrap();
-            assert_eq!(res, expected);
-
-            let expected = BigDecimal::from_str("-56.78").unwrap();
-            let pg_numeric = PgNumeric::Negative {
-                weight: 0,
-                scale: 2,
-                digits: vec![56, 7800],
-            };
-            let res: BigDecimal = pg_numeric.try_into().unwrap();
-            assert_eq!(res, expected);
+        fn from_sql(value: PgValue<'_>) -> deserialize::Result<Self> {
+            <UpstreamBigDecimal as FromSql<Numeric, Pg>>::from_sql(value).map(BigDecimal)
         }
     }
 }
@@ -606,7 +281,7 @@ mod test {
     use super::{
         super::Bytes,
         super::test::{crypto_stable_hash, same_stable_hash},
-        BigDecimal, BigInt, OldBigDecimal,
+        BigDecimal, BigInt, UpstreamBigDecimal,
     };
     use std::str::FromStr;
 
@@ -664,17 +339,17 @@ mod test {
         let vals = vec![
             (
                 BigDecimal::new(BigInt::from(10), -2),
-                BigDecimal(OldBigDecimal::new(1.into(), 1)),
+                BigDecimal(UpstreamBigDecimal::new(1.into(), 1)),
                 "0.1",
             ),
             (
                 BigDecimal::new(BigInt::from(132400), 4),
-                BigDecimal(OldBigDecimal::new(1324.into(), -6)),
+                BigDecimal(UpstreamBigDecimal::new(1324.into(), -6)),
                 "1324000000",
             ),
             (
                 BigDecimal::new(BigInt::from(1_900_000), -3),
-                BigDecimal(OldBigDecimal::new(19.into(), -2)),
+                BigDecimal(UpstreamBigDecimal::new(19.into(), -2)),
                 "1900",
             ),
             (BigDecimal::new(0.into(), 3), BigDecimal::zero(), "0"),

--- a/graph/src/data/store/scalar/bigint.rs
+++ b/graph/src/data/store/scalar/bigint.rs
@@ -42,7 +42,7 @@ mod big_int {
         pub fn new(inner: num_bigint::BigInt) -> Result<Self, anyhow::Error> {
             // `inner.bits()` won't include the sign bit, so we add 1 to account for it.
             let bits = inner.bits() + 1;
-            if bits > Self::MAX_BITS as usize {
+            if bits > Self::MAX_BITS as u64 {
                 anyhow::bail!(
                     "BigInt is too big, total bits {} (max {})",
                     bits,
@@ -74,7 +74,7 @@ mod big_int {
         }
 
         pub fn bits(&self) -> usize {
-            self.0.bits()
+            self.0.bits() as usize
         }
 
         pub(in super::super) fn inner(self) -> num_bigint::BigInt {
@@ -392,7 +392,7 @@ impl Shl<u8> for BigInt {
     type Output = Self;
 
     fn shl(self, bits: u8) -> Self {
-        BigInt::unchecked_new(self.inner().shl(bits.into()))
+        BigInt::unchecked_new(self.inner().shl(usize::from(bits)))
     }
 }
 
@@ -400,7 +400,7 @@ impl Shr<u8> for BigInt {
     type Output = Self;
 
     fn shr(self, bits: u8) -> Self {
-        BigInt::unchecked_new(self.inner().shr(bits.into()))
+        BigInt::unchecked_new(self.inner().shr(usize::from(bits)))
     }
 }
 

--- a/graph/src/data/store/scalar/mod.rs
+++ b/graph/src/data/store/scalar/mod.rs
@@ -4,9 +4,9 @@ mod bytes;
 mod timestamp;
 
 pub use bigdecimal::BigDecimal;
+pub use bigdecimal::ToPrimitive;
 pub use bigint::{BigInt, BigIntSign};
 pub use bytes::Bytes;
-pub use old_bigdecimal::ToPrimitive;
 pub use timestamp::Timestamp;
 
 // Test helpers for BigInt and BigDecimal tests


### PR DESCRIPTION
### Summary                                                                                                                                                                   
                                                                                                                                                                                
  `graph::data::store::scalar::BigDecimal` wrapped `bigdecimal = 0.1.2` (aliased as `old_bigdecimal`) to work around two long-standing constraints: diesel's built-in  `ToSql<Numeric, Pg>` / `FromSql<Numeric, Pg>` impls targeted a *different* `bigdecimal::BigDecimal` type than ours, and an earlier upgrade attempt was blamed on a Proof-of-Indexing (PoI) divergence. As a result we carried ~150 lines of vendored `PgNumeric` ↔ `BigDecimal` codec, and `num-bigint` was transitively pinned to `=0.2.6`.     
                                                         
  This PR takes a different tack: instead of picking a specific new version, **track the version diesel already resolves**. Our newtype now wraps the same type diesel's codec targets, so the vendored `mod pg` collapses to two trivial delegations to diesel's built-in impls. A future diesel release that ships `bigdecimal 0.4.x` will carry us along automatically.                                                                                                                                                                
                                                         
  ### Changes

  - `bigdecimal` and `num-bigint` are promoted to `[workspace.dependencies]` (`0.3` and `0.4`, unpinned) — this is the pattern already used for `diesel`, `serde`, etc.         
  - `graph/Cargo.toml` replaces the `old_bigdecimal = "=0.1.2"` renamed dep with `bigdecimal.workspace = true`, and drops the `=0.2.6` pin on `num-bigint`.
  - `graph/src/data/store/scalar/bigdecimal.rs`: rename internal alias `OldBigDecimal` → `UpstreamBigDecimal`; replace the 150-line `mod pg` vendored codec with two-impl   delegations to diesel's built-in `ToSql`/`FromSql` for `bigdecimal::BigDecimal`. The `BigDecimal` newtype itself stays — it enforces normalization on every construction  (PoI-stability policy), carries our custom `StableHash` impls (orphan rule), and flips the exp-sign convention in `new()`.                                                    
  - `graph/src/data/store/scalar/bigint.rs`: adapt to `num-bigint 0.4` — `BigInt::bits()` now returns `u64`, and `Shl`/`Shr` need a typed shift operand.                        
  - Small import fix-ups in `graph/src/data/query/error.rs` and `graph/src/data/store/scalar/mod.rs`.                                                                           
                                                                                                                                                                                
  Net: **-350 lines**.                                                                                                                                                          
                                                                                                                                                                                
  ### PoI stability                                                                                                                                                             
   
  The load-bearing check is the `big_decimal_stable` test, which pins exact SHA hashes for five canonical values (`"0.1"`, `"-0.1"`, `"198.98765544"`, `"0.00000093937698"`,  `"98765587998098786876.0"`). **All hashes are unchanged** under `bigdecimal 0.3.1`. The rest of the `scalar::bigdecimal` and `scalar::bigint` tests pass as well.
                                                                                                                                                                            