### PR TITLE
all: Replace tiny-keccak with alloy::primitives::keccak256

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "sha3",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -712,7 +712,7 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "syn-solidity",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -2291,7 +2291,7 @@ checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
  "getrandom 0.2.15",
  "once_cell",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -3955,7 +3955,6 @@ dependencies = [
  "strum_macros 0.28.0",
  "tempfile",
  "thiserror 2.0.18",
- "tiny-keccak 1.5.0",
  "tokio",
  "tokio-retry",
  "tokio-stream",
@@ -3999,7 +3998,6 @@ dependencies = [
  "semver 1.0.28",
  "serde",
  "thiserror 2.0.18",
- "tiny-keccak 1.5.0",
  "tokio",
  "tokio-stream",
  "tonic-prost-build",
@@ -8284,15 +8282,6 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]

--- a/chain/ethereum/Cargo.toml
+++ b/chain/ethereum/Cargo.toml
@@ -12,7 +12,6 @@ serde = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 anyhow = "1.0"
-tiny-keccak = "1.5.0"
 hex = "0.4.3"
 semver = { workspace = true }
 thiserror = { workspace = true }

--- a/chain/ethereum/src/adapter.rs
+++ b/chain/ethereum/src/adapter.rs
@@ -9,6 +9,7 @@ use graph::data_source::common::ContractCall;
 use graph::firehose::CallToFilter;
 use graph::firehose::CombinedFilter;
 use graph::firehose::LogFilter;
+use graph::prelude::alloy::primitives::keccak256;
 use graph::prelude::alloy::primitives::{Address, B256};
 use graph::prelude::alloy::rpc::types::Log;
 use graph::prelude::alloy::transports::{RpcError, TransportErrorKind};
@@ -19,7 +20,6 @@ use std::cmp;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use thiserror::Error;
-use tiny_keccak::keccak256;
 
 use graph::prelude::*;
 use graph::{

--- a/chain/ethereum/src/call_helper.rs
+++ b/chain/ethereum/src/call_helper.rs
@@ -72,7 +72,7 @@ fn is_rpc_revert_message(message: &str) -> bool {
 
 /// Decode a Solidity revert(reason) payload, returning the reason string when possible.
 fn as_solidity_revert_reason(bytes: &[u8]) -> Option<String> {
-    let selector = &tiny_keccak::keccak256(b"Error(string)")[..4];
+    let selector = &graph::prelude::alloy::primitives::keccak256(b"Error(string)")[..4];
     if bytes.len() >= 4 && &bytes[..4] == selector {
         abi::DynSolType::String
             .abi_decode(&bytes[4..])

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -21,6 +21,7 @@ use graph::env::ENV_VARS;
 use graph::futures03::TryStreamExt;
 use graph::futures03::future::try_join;
 use graph::futures03::stream::FuturesOrdered;
+use graph::prelude::alloy::primitives::keccak256;
 use graph::prelude::alloy::{
     consensus::{TxEnvelope, TxLegacy},
     network::TransactionResponse,
@@ -37,7 +38,6 @@ use std::num::NonZeroU32;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tiny_keccak::{Keccak, keccak256};
 
 use graph::{
     blockchain::{self, Blockchain},
@@ -1590,13 +1590,7 @@ impl MappingEventHandler {
 
 /// Hashes a string to a B256 hash.
 fn string_to_b256(s: &str) -> B256 {
-    let mut result = [0u8; 32];
-    let data = s.replace(' ', "").into_bytes();
-    let mut sponge = Keccak::new_keccak256();
-    sponge.update(&data);
-    sponge.finalize(&mut result);
-
-    B256::from_slice(&result)
+    keccak256(s.replace(' ', "").as_bytes())
 }
 
 #[derive(Clone, Debug, Default, Hash, Eq, PartialEq, Deserialize)]

--- a/core/src/subgraph/context/instance/mod.rs
+++ b/core/src/subgraph/context/instance/mod.rs
@@ -104,7 +104,7 @@ where
         };
 
         let mapping_request_sender = {
-            let module_hash = tiny_keccak::keccak256(module_bytes.as_ref());
+            let module_hash = alloy::primitives::keccak256(module_bytes.as_ref()).0;
             if let Some(sender) = self.module_cache.get(&module_hash) {
                 sender.clone()
             } else {

--- a/graph/Cargo.toml
+++ b/graph/Cargo.toml
@@ -63,7 +63,6 @@ slog-async = "2.5.0"
 slog-envlogger = "2.1.0"
 slog-term = "2.7.0"
 petgraph = "0.8.3"
-tiny-keccak = "1.5.0"
 tokio = { workspace = true}
 tokio-stream = { workspace = true }
 tokio-retry = { workspace = true }

--- a/graph/src/components/subgraph/proof_of_indexing/mod.rs
+++ b/graph/src/components/subgraph/proof_of_indexing/mod.rs
@@ -134,7 +134,8 @@ mod tests {
         // return the same result.
         check_for_child_errors(&case.data).expect("Found child errors");
 
-        let offline_fast = tiny_keccak::keccak256(&fast_stable_hash(&case.data).to_le_bytes());
+        let offline_fast =
+            alloy::primitives::keccak256(fast_stable_hash(&case.data).to_le_bytes()).0;
         let offline_legacy = stable_hash_legacy::<SetHasher, _>(&case.data);
 
         for (version, offline, hardcoded) in [

--- a/graph/src/components/subgraph/proof_of_indexing/online.rs
+++ b/graph/src/components/subgraph/proof_of_indexing/online.rs
@@ -324,7 +324,7 @@ impl ProofOfIndexingFinisher {
 
         match self.state {
             Hashers::Legacy(legacy) => legacy.finish(),
-            Hashers::Fast(fast) => tiny_keccak::keccak256(&fast.finish().to_le_bytes()),
+            Hashers::Fast(fast) => alloy::primitives::keccak256(fast.finish().to_le_bytes()).0,
         }
     }
 }

--- a/graph/src/lib.rs
+++ b/graph/src/lib.rs
@@ -102,7 +102,6 @@ pub mod prelude {
     pub use std::sync::Arc;
     pub use std::time::Duration;
     pub use thiserror;
-    pub use tiny_keccak;
     pub use tokio;
     pub use toml;
     pub use tonic;

--- a/runtime/wasm/src/host_exports.rs
+++ b/runtime/wasm/src/host_exports.rs
@@ -670,7 +670,7 @@ impl HostExports {
             gas::DEFAULT_GAS_OP.with_args(complexity::Size, data),
             "crypto_keccak_256",
         )?;
-        Ok(tiny_keccak::keccak256(data))
+        Ok(alloy::primitives::keccak256(data).0)
     }
 
     pub(crate) fn big_int_plus(

--- a/tests/src/fixture/ethereum.rs
+++ b/tests/src/fixture/ethereum.rs
@@ -13,11 +13,11 @@ use graph::blockchain::client::ChainClient;
 use graph::blockchain::{BlockPtr, Trigger, TriggersAdapterSelector};
 use graph::cheap_clone::CheapClone;
 use graph::data_source::subgraph;
-use graph::prelude::alloy::primitives::{Address, B256, U256};
+use graph::prelude::alloy::primitives::{Address, B256, U256, keccak256};
 use graph::prelude::alloy::rpc::types::BlockTransactions;
 use graph::prelude::{
     DeploymentHash, ENV_VARS, Entity, LightEthereumBlock, create_dummy_transaction,
-    create_minimal_block_for_test, tiny_keccak,
+    create_minimal_block_for_test,
 };
 use graph::schema::EntityType;
 use graph_chain_ethereum::network::EthereumNetworkAdapters;
@@ -143,7 +143,7 @@ pub fn push_test_log(block: &mut BlockWithTriggers<Chain>, payload: impl Into<St
         inner: alloy::primitives::Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![tiny_keccak::keccak256(b"TestEvent(string)").into()],
+                vec![keccak256(b"TestEvent(string)")],
                 abi::DynSolValue::String(payload.into()).abi_encode().into(),
             ),
         },
@@ -199,7 +199,7 @@ pub fn push_test_command(
         inner: alloy::primitives::Log {
             address: Address::ZERO,
             data: LogData::new_unchecked(
-                vec![tiny_keccak::keccak256(b"TestEvent(string,string)").into()],
+                vec![keccak256(b"TestEvent(string,string)")],
                 abi::DynSolValue::Tuple(vec![
                     abi::DynSolValue::String(test_command.into()),
                     abi::DynSolValue::String(data.into()),


### PR DESCRIPTION
tiny-keccak 2.0 dropped the top-level keccak256 function and changed Keccak's streaming API, breaking every call site. Route all keccak hashing through alloy::primitives::keccak256, which is already used elsewhere in the codebase, and drop the tiny-keccak dependency.

