### PR TITLE
v0.44.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "gnd"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "graph"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "Inflector",
  "ahash",
@@ -3970,7 +3970,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-common"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -3980,11 +3980,11 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-ethereum"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.22.1",
+ "base64 0.21.7",
  "envconfig",
  "futures 0.3.31",
  "graph",
@@ -4006,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-near"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4023,7 +4023,7 @@ dependencies = [
 
 [[package]]
 name = "graph-core"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "graph-graphql"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4070,7 +4070,7 @@ dependencies = [
 
 [[package]]
 name = "graph-node"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4106,7 +4106,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-derive"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-test"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "graph",
@@ -4128,7 +4128,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-wasm"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4146,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-http"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "graph",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-index-node"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "blake3 1.8.5",
@@ -4170,7 +4170,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-json-rpc"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "axum",
  "graph",
@@ -4183,14 +4183,14 @@ dependencies = [
 
 [[package]]
 name = "graph-server-metrics"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "graph",
 ]
 
 [[package]]
 name = "graph-store-postgres"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -4233,7 +4233,7 @@ dependencies = [
 
 [[package]]
 name = "graph-tests"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "graph_derive"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "proc-macro-utils",
  "proc-macro2",
@@ -4269,7 +4269,7 @@ dependencies = [
 
 [[package]]
 name = "graphman"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "diesel",
@@ -4284,7 +4284,7 @@ dependencies = [
 
 [[package]]
 name = "graphman-server"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -4310,7 +4310,7 @@ dependencies = [
 
 [[package]]
 name = "graphman-store"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8167,7 +8167,7 @@ dependencies = [
 
 [[package]]
 name = "test-store"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.43.0"
+version = "0.44.0"
 edition = "2024"
 authors = ["The Graph core developers & contributors"]
 readme = "README.md"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,53 @@
 # NEWS
 
+## v0.44.0
+
+```
+$ docker pull graphprotocol/graph-node:v0.44.0
+```
+
+### Critical Fix
+
+- **`EntityCache::load_related` returned wrong derived-collection membership on same-block parent reassignment.** Membership was decided against intermediate cache layers rather than the entity's final state, so entities reassigned to a new parent within the same block could be left in the old collection, omitted from the new one, or wrongly retained after a cross-handler revert. See Upgrade Notes. ([#6548](https://github.com/graphprotocol/graph-node/pull/6548))
+
+### Breaking Changes
+
+- **Elasticsearch CLI flags removed.** `--elasticsearch-url`, `--elasticsearch-user`, `--elasticsearch-password` (and the matching `ELASTICSEARCH_*` env vars) are gone. Configure Elasticsearch under the new `[log_store]` section in `graph-node.toml`. See Upgrade Notes. ([#6278](https://github.com/graphprotocol/graph-node/pull/6278))
+
+### What's New
+
+- **Query subgraph logs over GraphQL.** A new `_logs` field exposes subgraph-emitted logs (mapping `log.*` calls, runtime, system) with filters for level, timestamp range, and text search, plus pagination and `orderDirection`. The old Elasticsearch sink for subgraph logs is replaced by a unified `LogStore` abstraction with three backends configured under a new `[log_store]` section in `graph-node.toml`: File (JSON Lines), Loki, or Elasticsearch. Omit `[log_store]` to disable; logs still go to stdout/stderr. ([#6278](https://github.com/graphprotocol/graph-node/pull/6278))
+
+<!--
+TODO(next release): re-add the postponed-index-creation entry once #6608 is verified in the hosted service.
+The implementation (#6434, #6583) is in this release but disabled via `graph: Disable postponed index creation`
+(`postpone_attribute_index_creation` hardcoded to false). Suggested bullet:
+
+- **Postponed index creation extended to syncing subgraphs.** `GRAPH_POSTPONE_ATTRIBUTE_INDEX_CREATION` previously only deferred indexes during copies. It now also postpones indexes during the initial sync of any subgraph, with a new `GRAPH_POSTPONE_INDEXES_CREATION_THRESHOLD` (default 10000) controlling how close to chain head the deployment must get before they're created. Tracked per-deployment so creation runs at most once, even if indexes are manually dropped later. ([#6434](https://github.com/graphprotocol/graph-node/pull/6434) [#6583](https://github.com/graphprotocol/graph-node/pull/6583))
+-->
+
+
+### Improvements
+
+- Revert entity versions during copy instead of in a separate post-copy pass, speeding up subgraph copy and graft. ([#6472](https://github.com/graphprotocol/graph-node/pull/6472))
+
+### Bug Fixes
+
+- Fixed `trace_filter` deserialization failing on providers that omit `result.output` (notably Sonic), which caused repeated trace ingestion retries. Fixed upstream in alloy 2.0.5 ([alloy#3931](https://github.com/alloy-rs/alloy/pull/3931)) and picked up via the bump in this release. ([#6576](https://github.com/graphprotocol/graph-node/pull/6576))
+- Fixed runner panics on out-of-range `BigInt` values: `to_signed_u256` replaced by fallible `to_i256`, and `to_unsigned_u256` now errors on values `>= 2^256` instead of panicking. ([#6560](https://github.com/graphprotocol/graph-node/pull/6560))
+- Fixed `graphman chain change-shard` failing with a duplicate-key error on revert to the original shard. Backups now use unique names and revert reuses the existing `<chain>-old`. ([#6199](https://github.com/graphprotocol/graph-node/pull/6199))
+
+### Upgrade Notes
+
+- v0.44.0 changes `EntityCache::load_related` results for same-block parent-reassignment edge cases ([#6548](https://github.com/graphprotocol/graph-node/pull/6548)). Subgraphs that read derived fields within handlers may diverge in POI from v0.43.0 on blocks exhibiting this pattern; resync from before the affected blocks if affected. The v0.44.0 result is canonical.
+- If you set `--elasticsearch-*` flags or `ELASTICSEARCH_*` env vars, migrate to a `[log_store]` section in `graph-node.toml` before upgrading. See `docs/log-store.md`. ([#6278](https://github.com/graphprotocol/graph-node/pull/6278))
+
+### Contributors
+
+Thanks to all contributors for this release: @erayack, @fordN, @incrypto32, @lutter
+
+**Full Changelog**: https://github.com/graphprotocol/graph-node/compare/v0.43.0...v0.44.0
+
 ## v0.43.0
 
 ### What's New

--- a/graph/src/env/mod.rs
+++ b/graph/src/env/mod.rs
@@ -351,8 +351,7 @@ impl EnvVars {
             subgraph_error_retry_ceil: Duration::from_secs(inner.subgraph_error_retry_ceil_in_secs),
             subgraph_error_retry_jitter: inner.subgraph_error_retry_jitter,
             enable_select_by_specific_attributes: inner.enable_select_by_specific_attributes.0,
-            postpone_attribute_index_creation: inner.postpone_attribute_index_creation.0
-                || cfg!(debug_assertions),
+            postpone_attribute_index_creation: false,
             postpone_indexes_creation_threshold: inner.postpone_indexes_creation_threshold,
             log_trigger_data: inner.log_trigger_data.0,
             explorer_ttl: Duration::from_secs(inner.explorer_ttl_in_secs),
@@ -557,6 +556,7 @@ struct Inner {
     #[envconfig(from = "GRAPH_ENABLE_SELECT_BY_SPECIFIC_ATTRIBUTES", default = "true")]
     enable_select_by_specific_attributes: EnvVarBoolean,
     #[envconfig(from = "GRAPH_POSTPONE_ATTRIBUTE_INDEX_CREATION", default = "false")]
+    #[allow(unused)]
     postpone_attribute_index_creation: EnvVarBoolean,
     #[envconfig(from = "GRAPH_POSTPONE_INDEXES_CREATION_THRESHOLD", default = "10000")]
     postpone_indexes_creation_threshold: i32,


### PR DESCRIPTION
Version bump and release notes for v0.44.0.

- Bumps workspace version to 0.44.0
- Adds NEWS.md entry for v0.44.0