### PR TITLE
ci: trigger gnd binary build on release published

### DIFF
--- a/.github/workflows/gnd-binary-build.yml
+++ b/.github/workflows/gnd-binary-build.yml
@@ -1,6 +1,8 @@
 name: Build gnd Binaries
 
 on:
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
Adds `release: [published]` trigger to the gnd binary build workflow so it runs
automatically whenever a new GitHub release is published, in addition to the existing
manual `workflow_dispatch`.

- `github.ref` on release events is `refs/tags/<tag>`, so all existing tag guards pass as expected
- `inputs.dry_run` is empty/falsy on release events — correct default for a real publish run