### PR TITLE
ci: Fix Windows build and support publishing to an existing release

### DIFF
--- a/.github/workflows/gnd-binary-build.yml
+++ b/.github/workflows/gnd-binary-build.yml
@@ -3,6 +3,10 @@ name: Build gnd Binaries
 on:
   workflow_dispatch:
     inputs:
+      release_tag:
+        description: 'Existing release tag to upload binaries to and publish as on npm (e.g. v0.44.0). Leave empty to only build artifacts.'
+        type: string
+        default: ''
       dry_run:
         description: 'Dry-run npm publish (no actual publish)'
         type: boolean
@@ -130,7 +134,7 @@ jobs:
   release:
     name: Create Release
     needs: build
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || inputs.release_tag != ''
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -153,10 +157,8 @@ jobs:
 
       - name: Upload Assets to Release
         run: |
-          # Extract version from ref (remove refs/tags/ prefix)
-          VERSION=${GITHUB_REF#refs/tags/}
-          
-          # Upload Linux x86_64 asset
+          VERSION="${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}"
+
           gh release upload $VERSION --clobber --repo $GITHUB_REPOSITORY \
             artifacts/gnd-linux-x86_64/gnd-linux-x86_64.gz \
             artifacts/gnd-linux-aarch64/gnd-linux-aarch64.gz \
@@ -169,7 +171,7 @@ jobs:
   publish-npm:
     name: Publish npm package for ${{ matrix.platform }}
     needs: release
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || inputs.release_tag != ''
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -212,7 +214,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download "${{ github.ref_name }}" \
+          gh release download "${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}" \
             --repo "${{ github.repository }}" \
             --pattern "${{ matrix.asset }}" \
             --output ./binary-archive
@@ -232,7 +234,7 @@ jobs:
         id: version
         shell: bash
         run: |
-          VERSION="${{ github.ref_name }}"
+          VERSION="${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}"
           VERSION="${VERSION#v}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           # Prerelease versions (e.g. 0.42.2-dev.1) need an explicit --tag
@@ -283,7 +285,7 @@ jobs:
   publish-npm-wrapper:
     name: Publish @graphprotocol/gnd wrapper
     needs: publish-npm
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') || inputs.release_tag != ''
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -299,7 +301,7 @@ jobs:
         id: version
         shell: bash
         run: |
-          VERSION="${{ github.ref_name }}"
+          VERSION="${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}"
           VERSION="${VERSION#v}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           if [[ "$VERSION" == *-* ]]; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse 0.2.4",
@@ -945,7 +945,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2148,7 +2148,7 @@ version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
 dependencies = [
- "anstream 0.6.14",
+ "anstream 0.6.21",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -6672,7 +6672,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7165,7 +7165,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7246,7 +7246,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8148,7 +8148,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Two changes:

- Bump anstream to 0.6.21. The 0.6.14 version that clap_builder pins fails to compile on Windows because of a trait conflict with the blanket impl added in anstyle-wincon 3.0.11 (E0119).
- Add a `release_tag` workflow_dispatch input. When set, the release, publish-npm and publish-npm-wrapper jobs target that tag instead of `github.ref_name`, so binaries can be attached to an existing release and published as that version. Tag-ref dispatch behaves as before when the input is empty.