### PR TITLE
fix(gnd): surface anyhow error chains in error output

### DIFF
--- a/gnd/src/commands/build.rs
+++ b/gnd/src/commands/build.rs
@@ -486,7 +486,8 @@ fn create_ipfs_manifest(
     let manifest_str = fs::read_to_string(&manifest_path)
         .with_context(|| format!("Failed to read manifest: {}", manifest_path.display()))?;
 
-    let mut value: serde_yaml::Value = serde_yaml::from_str(&manifest_str)?;
+    let mut value: serde_yaml::Value = serde_yaml::from_str(&manifest_str)
+        .with_context(|| format!("Failed to parse manifest: {}", manifest_path.display()))?;
 
     // Update schema path to IPFS reference
     if let Some(schema_path) = &manifest.schema {
@@ -747,7 +748,8 @@ fn write_output_manifest(
     let manifest_str = fs::read_to_string(manifest_path)
         .with_context(|| format!("Failed to read manifest: {:?}", manifest_path))?;
 
-    let mut value: serde_yaml::Value = serde_yaml::from_str(&manifest_str)?;
+    let mut value: serde_yaml::Value = serde_yaml::from_str(&manifest_str)
+        .with_context(|| format!("Failed to parse manifest: {:?}", manifest_path))?;
 
     // Update schema path
     if let Some(schema) = value.get_mut("schema")

--- a/gnd/src/main.rs
+++ b/gnd/src/main.rs
@@ -263,7 +263,7 @@ async fn main() -> Result<()> {
     };
 
     if let Err(e) = res {
-        eprintln!("Error: {}", e);
+        eprintln!("Error: {:#}", e);
         std::process::exit(1);
     }
 

--- a/gnd/src/manifest.rs
+++ b/gnd/src/manifest.rs
@@ -698,6 +698,47 @@ dataSources:
     }
 
     #[test]
+    fn test_load_manifest_error_chain_includes_parse_context_and_cause() {
+        let temp_dir = TempDir::new().unwrap();
+        let manifest_path = temp_dir.path().join("subgraph.yaml");
+
+        let manifest_content = r#"
+specVersion: 0.0.4
+schema: {}
+dataSources:
+  - kind: ethereum/contract
+    name: Token
+    network: mainnet
+    source:
+      abi: ERC20
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      file: ./src/mapping.ts
+      entities:
+        - MyEntity
+      abis:
+        - name: ERC20
+          file: ./abis/ERC20.json
+"#;
+
+        fs::write(&manifest_path, manifest_content).unwrap();
+
+        let err_chain = format!("{:#}", load_manifest(&manifest_path).unwrap_err());
+        assert!(
+            err_chain.contains("Failed to parse manifest"),
+            "Error chain should include manifest parse context, got: {}",
+            err_chain
+        );
+        assert!(
+            err_chain.contains("missing field") && err_chain.contains("file"),
+            "Error chain should include the underlying serde_yaml cause, got: {}",
+            err_chain
+        );
+    }
+
+    #[test]
     fn test_load_manifest_missing_mapping_abis_fails() {
         let temp_dir = TempDir::new().unwrap();
         let manifest_path = temp_dir.path().join("subgraph.yaml");

--- a/gnd/src/watch.rs
+++ b/gnd/src/watch.rs
@@ -46,7 +46,7 @@ where
 {
     // Do initial run
     if let Err(e) = on_change().await {
-        eprintln!("Error during initial run: {}", e);
+        eprintln!("Error during initial run: {:#}", e);
     }
 
     println!("\n{}", initial_msg);
@@ -101,7 +101,7 @@ where
                     println!("\nFile change detected: {}\n", changed);
 
                     if let Err(e) = on_change().await {
-                        eprintln!("Error during rebuild: {}", e);
+                        eprintln!("Error during rebuild: {:#}", e);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
`gnd` error output now surfaces the full anyhow error chain instead of only the top-level message. The bare `{}` Display formattings in `main.rs` and `watch.rs` printed just the outermost context (for example `failed to load manifest`), hiding the underlying cause a developer needs to act on; they now use the alternate `{:#}` chain rendering. The two bare `serde_yaml::from_str()?` sites in `commands/build.rs` and `manifest.rs` gain context so YAML parse failures name the file being parsed.

## Why this matters
Issue #6360 reports that gnd swallows error causes, leaving developers with messages like `Error: failed to start watch mode` and no underlying reason. The silenced chains were verified at `main.rs:266` and `watch.rs:49`/`104` before the change. This covers the error-display half of the issue; the issue also discusses restructuring some error sites to attach more context at creation time, which is a larger refactor left for a follow-up.

## Testing
A new unit test asserts a manifest parse failure renders with its cause chain (file name + YAML error) rather than the bare context string. `cargo fmt --check` and `cargo check -p gnd` pass; the new manifest error-chain test passes.

Refs #6360
