### PR TITLE
chain(ethereum): treat Reth StackUnderflow/StackOverflow/OpcodeNotFound halts as deterministic

### DIFF
--- a/chain/ethereum/src/call_helper.rs
+++ b/chain/ethereum/src/call_helper.rs
@@ -58,6 +58,17 @@ const RPC_EXECUTION_ERRORS: &[&str] = &[
     "invalidjump",
     "notactivated",
     "invalidfeopcode",
+    // Reth surfaces EVM halts via `EvmHalt(HaltReason)`, formatted with the
+    // reason's `Debug` repr (`"EVM error: {0:?}"`). revm's `HaltReason`
+    // variants are CamelCase with no spaces, so e.g. a stack underflow arrives
+    // as "EVM error: StackUnderflow", which the space-separated "stack
+    // underflow" above does not match. "invalidjump"/"invalidfeopcode" already
+    // cover the matching variants; these add the rest. Reth's OutOfGas is
+    // handled before EvmHalt and rendered as "out of gas: ...", so it is
+    // already covered above. See https://github.com/streamingfast/eth-go/pull/10.
+    "stackunderflow",
+    "stackoverflow",
+    "opcodenotfound",
 ];
 
 /// Helper that checks if a geth style RPC error message corresponds to a revert.


### PR DESCRIPTION
Fixes #6582.

### Problem

Reth surfaces EVM halts through reth's `EthApiError::EvmHalt(HaltReason)`, which is formatted with the reason's **`Debug`** representation:

```rust
// reth: crates/rpc/rpc-eth-types/src/error/mod.rs
#[error("EVM error: {0:?}")]
EvmHalt(HaltReason),
```

revm's `HaltReason` / `InstructionResult` variants are derived `Debug`, so they render in CamelCase **with no spaces**. A stack underflow therefore reaches `eth_call` error handling as:

```
EVM error: StackUnderflow
```

`is_rpc_revert_message` lower-cases the message and checks `contains`, so it compares against `"evm error: stackunderflow"`. The existing space-separated entry `"stack underflow"` never matches this, so the error is treated as **non-deterministic** — the subgraph stalls/retries instead of recording a deterministic revert.

This is the same gap streamingfast/eth-go#10 closed on the Firehose side.

### Fix

Add the missing reth halt variants (no spaces, matching the `Debug` output) to `RPC_EXECUTION_ERRORS`:

- `stackunderflow`  ← the reported bug
- `stackoverflow`
- `opcodenotfound`

The list already contains `invalidjump` and `invalidfeopcode`, which catch `"EVM error: InvalidJump"` / `"InvalidFEOpcode"` via this exact path — so the pattern is already established and proven; these three siblings were simply missed.

Note: reth's `OutOfGas` is intercepted **before** `EvmHalt` and rendered as `"out of gas: ..."` (with spaces), which the existing `"out of gas"` entry already matches — so unlike the Firehose list, a no-space `outofgas` is not required here.

### Verification

- reth: `EvmHalt` uses `{0:?}` (`crates/rpc/rpc-eth-types/src/error/mod.rs`).
- revm: `InstructionResult` / `HaltReason` are `#[derive(Debug)]` with variants `StackUnderflow`, `StackOverflow`, `OpcodeNotFound`, `InvalidJump`, `InvalidFEOpcode` (`crates/interpreter/src/instruction_result.rs`).
- Precedent: streamingfast/eth-go#10.
