### PR TITLE
store: skip chains in pool_size = 0 shards instead of panicking at startup (#6195)

### DIFF
--- a/store/postgres/src/block_store.rs
+++ b/store/postgres/src/block_store.rs
@@ -253,7 +253,27 @@ impl BlockStore {
         const CHAIN_HEAD_CACHE_TTL: Duration = Duration::from_secs(2);
 
         let mirror = PrimaryMirror::new(&pools);
-        let existing_chains = mirror.read_async(primary::load_chains).await?;
+        // Treat a chain whose shard has no connection pool (i.e. a shard
+        // configured with `pool_size = 0`, which `store_builder` drops) as if it
+        // doesn't exist: skip it here so we neither create a chain store for it
+        // nor fail startup. See issue #6195.
+        let existing_chains: Vec<_> = mirror
+            .read_async(primary::load_chains)
+            .await?
+            .into_iter()
+            .filter(|chain| {
+                let has_pool = pools.contains_key(&chain.shard);
+                if !has_pool {
+                    warn!(
+                        &logger,
+                        "Ignoring chain `{}`: its shard `{}` has no connection pool (pool_size = 0)",
+                        chain.name,
+                        chain.shard,
+                    );
+                }
+                has_pool
+            })
+            .collect();
         let chain_head_cache = TimedCache::new(CHAIN_HEAD_CACHE_TTL);
         let chains = shards.clone();
 
@@ -275,18 +295,6 @@ impl BlockStore {
                 .iter()
                 .find(|chain| chain.name == chain_name)
             {
-                // A shard configured with `pool_size = 0` is intentionally
-                // ignored and has no connection pool. Skip chains that live in
-                // such a shard rather than failing startup. See issue #6195.
-                if !block_store.pools.contains_key(&chain.shard) {
-                    warn!(
-                        &block_store.logger,
-                        "Skipping chain `{}`: its shard `{}` has no connection pool (pool_size = 0)",
-                        chain.name,
-                        chain.shard,
-                    );
-                    continue;
-                }
                 if chain.shard != shard {
                     warn!(
                         &block_store.logger,
@@ -312,17 +320,6 @@ impl BlockStore {
             .iter()
             .filter(|chain| !configured_chains.contains(&chain.name))
         {
-            // Skip chains whose shard has no connection pool (pool_size = 0)
-            // instead of failing startup. See issue #6195.
-            if !block_store.pools.contains_key(&chain.shard) {
-                warn!(
-                    &block_store.logger,
-                    "Skipping chain `{}`: its shard `{}` has no connection pool (pool_size = 0)",
-                    chain.name,
-                    chain.shard,
-                );
-                continue;
-            }
             block_store.add_chain_store(chain, false).await?;
         }
         Ok(block_store)

--- a/store/postgres/src/block_store.rs
+++ b/store/postgres/src/block_store.rs
@@ -275,6 +275,18 @@ impl BlockStore {
                 .iter()
                 .find(|chain| chain.name == chain_name)
             {
+                // A shard configured with `pool_size = 0` is intentionally
+                // ignored and has no connection pool. Skip chains that live in
+                // such a shard rather than failing startup. See issue #6195.
+                if !block_store.pools.contains_key(&chain.shard) {
+                    warn!(
+                        &block_store.logger,
+                        "Skipping chain `{}`: its shard `{}` has no connection pool (pool_size = 0)",
+                        chain.name,
+                        chain.shard,
+                    );
+                    continue;
+                }
                 if chain.shard != shard {
                     warn!(
                         &block_store.logger,
@@ -300,6 +312,17 @@ impl BlockStore {
             .iter()
             .filter(|chain| !configured_chains.contains(&chain.name))
         {
+            // Skip chains whose shard has no connection pool (pool_size = 0)
+            // instead of failing startup. See issue #6195.
+            if !block_store.pools.contains_key(&chain.shard) {
+                warn!(
+                    &block_store.logger,
+                    "Skipping chain `{}`: its shard `{}` has no connection pool (pool_size = 0)",
+                    chain.name,
+                    chain.shard,
+                );
+                continue;
+            }
             block_store.add_chain_store(chain, false).await?;
         }
         Ok(block_store)


### PR DESCRIPTION
## Summary

Fixes #6195. A node configured with `pool_size = 0` for an unused shard (a
documented option from #3513) panics on startup:

```
WARN pool size for shard eth_chain is 0, ignoring this shard
thread 'main' panicked at node/src/store_builder.rs:203:
Creating the BlockStore works: InternalError("there is no pool for shard eth_chain")
```

`store_builder` correctly drops `pool_size = 0` shards from the pool map, but
`DieselBlockStore::new` then iterates **every** chain — both configured chains
and all chains present in the database — and calls `add_chain_store` for each.
`add_chain_store` errors when a chain's shard has no pool, and that error is
`.expect()`ed in `store_builder`, killing startup. So `pool_size = 0` is only
half-implemented: the pool is skipped, but the chains living in that shard are
not.

## Fix

In both chain-enumeration loops in `DieselBlockStore::new`, skip chains whose
shard has no connection pool (logging a `WARN`) instead of calling
`add_chain_store`. This lets a node list all shards in `config.toml` but only
consume Postgres connections for the shards it actually uses, which is the
intent of `pool_size = 0`.

`add_chain_store`'s contract is unchanged — it still errors when *creating* a
new chain in a shard with no pool, which remains a genuine misconfiguration.

## Testing

- `cargo fmt`, `cargo clippy --all-targets`, and `cargo check --release` clean
  for `graph-store-postgres`.

I was not able to add an automated test: `DieselBlockStore::new` and
`ConnectionPool` require a live multi-shard Postgres, so exercising the
multi-shard startup path isn't possible in a unit test. The change is small and
verified by inspection, but I'd appreciate a maintainer (or @0x19dG87) confirming
startup against a real multi-shard config with `pool_size = 0` set on an unused
shard.
