### PR TITLE
gnd: Fix `add` and unify subgraph scaffolding generators

### DIFF
--- a/gnd/src/commands/add.rs
+++ b/gnd/src/commands/add.rs
@@ -8,14 +8,15 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
 use clap::Parser;
-use inflector::Inflector;
 use serde_json::Value as JsonValue;
 
 use crate::config::networks::update_networks_file;
 use crate::formatter::format_typescript;
 use crate::output::{Step, step};
-use crate::scaffold::ScaffoldOptions;
 use crate::scaffold::manifest::{EventInfo, extract_events_from_abi};
+use crate::scaffold::{
+    MAPPING_API_VERSION, ResolvedEvent, ScaffoldOptions, generate_event_handlers, to_kebab_case,
+};
 use crate::services::ContractService;
 
 #[derive(Clone, Debug, Parser)]
@@ -232,41 +233,12 @@ fn add_abi_file(project_dir: &Path, contract_name: &str, abi: &JsonValue) -> Res
     Ok(())
 }
 
-/// Sanitize a field name for GraphQL.
-fn sanitize_field_name(name: &str) -> String {
-    if name.is_empty() {
-        return "value".to_string();
-    }
-
-    let mut result = name.to_string();
-
-    // Convert to camelCase if starts with uppercase
-    if result
-        .chars()
-        .next()
-        .map(|c| c.is_uppercase())
-        .unwrap_or(false)
-    {
-        let mut chars = result.chars();
-        if let Some(first) = chars.next() {
-            result = first.to_lowercase().collect::<String>() + chars.as_str();
-        }
-    }
-
-    // Avoid reserved words
-    match result.as_str() {
-        "id" => "eventId".to_string(),
-        "type" => "eventType".to_string(),
-        _ => result,
-    }
-}
-
 /// Add mapping file for the new data source.
 fn add_mapping_file(project_dir: &Path, contract_name: &str, events: &[EventInfo]) -> Result<()> {
     let src_dir = project_dir.join("src");
     fs::create_dir_all(&src_dir).context("Failed to create src directory")?;
 
-    let mapping_file = src_dir.join(format!("{}.ts", contract_name.to_kebab_case()));
+    let mapping_file = src_dir.join(format!("{}.ts", to_kebab_case(contract_name)));
 
     if mapping_file.exists() {
         step(
@@ -276,7 +248,12 @@ fn add_mapping_file(project_dir: &Path, contract_name: &str, events: &[EventInfo
         return Ok(());
     }
 
-    let mapping_content = generate_mapping(contract_name, events);
+    let resolved: Vec<ResolvedEvent> = events
+        .iter()
+        .cloned()
+        .map(ResolvedEvent::passthrough)
+        .collect();
+    let mapping_content = generate_event_handlers(contract_name, &resolved);
     let formatted = format_typescript(&mapping_content).unwrap_or(mapping_content);
 
     step(
@@ -286,76 +263,6 @@ fn add_mapping_file(project_dir: &Path, contract_name: &str, events: &[EventInfo
     fs::write(&mapping_file, formatted).context("Failed to write mapping file")?;
 
     Ok(())
-}
-
-/// Generate mapping handlers for events.
-fn generate_mapping(contract_name: &str, events: &[EventInfo]) -> String {
-    let mut imports = String::new();
-    let mut handlers = String::new();
-
-    imports.push_str("import { BigInt, Bytes } from \"@graphprotocol/graph-ts\"\n");
-
-    if events.is_empty() {
-        return imports;
-    }
-
-    // Import event types
-    let event_imports: Vec<String> = events
-        .iter()
-        .map(|e| format!("{} as {}Event", e.name, e.name))
-        .collect();
-
-    imports.push_str(&format!(
-        "import {{ {} }} from \"../generated/{}/{}\"\n",
-        event_imports.join(", "),
-        contract_name,
-        contract_name
-    ));
-
-    // Import entity types
-    let entity_imports: Vec<String> = events.iter().map(|e| e.name.clone()).collect();
-
-    imports.push_str(&format!(
-        "import {{ {} }} from \"../generated/schema\"\n",
-        entity_imports.join(", ")
-    ));
-
-    // Generate handler for each event
-    for event in events {
-        handlers.push('\n');
-        handlers.push_str(&generate_event_handler(event));
-    }
-
-    format!("{}\n{}", imports, handlers)
-}
-
-/// Generate a handler function for an event.
-fn generate_event_handler(event: &EventInfo) -> String {
-    let event_name = &event.name;
-
-    let mut field_assignments = String::new();
-    for input in &event.inputs {
-        let field_name = sanitize_field_name(&input.name);
-        field_assignments.push_str(&format!(
-            "  entity.{} = event.params.{}\n",
-            field_name, input.name
-        ));
-    }
-
-    format!(
-        r#"export function handle{event_name}(event: {event_name}Event): void {{
-  let entity = new {event_name}(
-    event.transaction.hash.concatI32(event.logIndex.toI32())
-  )
-
-{field_assignments}  entity.blockNumber = event.block.number
-  entity.blockTimestamp = event.block.timestamp
-  entity.transactionHash = event.transaction.hash
-
-  entity.save()
-}}
-"#
-    )
 }
 
 /// Update the manifest with the new data source.
@@ -429,7 +336,7 @@ fn update_manifest(
     );
     mapping.insert(
         serde_yaml::Value::String("apiVersion".to_string()),
-        serde_yaml::Value::String("0.0.9".to_string()),
+        serde_yaml::Value::String(MAPPING_API_VERSION.to_string()),
     );
     mapping.insert(
         serde_yaml::Value::String("language".to_string()),
@@ -449,7 +356,7 @@ fn update_manifest(
     );
     mapping.insert(
         serde_yaml::Value::String("file".to_string()),
-        serde_yaml::Value::String(format!("./src/{}.ts", contract_name.to_kebab_case())),
+        serde_yaml::Value::String(format!("./src/{}.ts", to_kebab_case(contract_name))),
     );
 
     // Build the data source
@@ -494,7 +401,6 @@ fn update_manifest(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::scaffold::manifest::{EventInfo, EventInput};
 
     #[tokio::test]
     async fn test_invalid_address() {
@@ -517,87 +423,6 @@ mod tests {
                 .to_string()
                 .contains("Invalid contract address")
         );
-    }
-
-    #[test]
-    fn test_sanitize_field_name() {
-        assert_eq!(sanitize_field_name("owner"), "owner");
-        assert_eq!(sanitize_field_name("Owner"), "owner");
-        assert_eq!(sanitize_field_name(""), "value");
-        // Reserved words
-        assert_eq!(sanitize_field_name("id"), "eventId");
-        assert_eq!(sanitize_field_name("type"), "eventType");
-    }
-
-    #[test]
-    fn test_to_kebab_case() {
-        assert_eq!("MyContract".to_kebab_case(), "my-contract");
-        assert_eq!("SimpleToken".to_kebab_case(), "simple-token");
-        assert_eq!("Contract".to_kebab_case(), "contract");
-        assert_eq!("contract".to_kebab_case(), "contract");
-        assert_eq!("ERC20Token".to_kebab_case(), "erc20-token");
-    }
-
-    #[test]
-    fn test_generate_event_handler() {
-        let event = EventInfo {
-            name: "Approval".to_string(),
-            signature: "Approval(address,address,uint256)".to_string(),
-            inputs: vec![
-                EventInput {
-                    name: "owner".to_string(),
-                    solidity_type: "address".to_string(),
-                    indexed: true,
-                },
-                EventInput {
-                    name: "spender".to_string(),
-                    solidity_type: "address".to_string(),
-                    indexed: true,
-                },
-                EventInput {
-                    name: "value".to_string(),
-                    solidity_type: "uint256".to_string(),
-                    indexed: false,
-                },
-            ],
-        };
-
-        let handler = generate_event_handler(&event);
-        assert!(handler.contains("export function handleApproval"));
-        assert!(handler.contains("event: ApprovalEvent"));
-        assert!(handler.contains("new Approval("));
-        assert!(handler.contains("entity.owner = event.params.owner"));
-        assert!(handler.contains("entity.spender = event.params.spender"));
-        assert!(handler.contains("entity.value = event.params.value"));
-        assert!(handler.contains("entity.save()"));
-    }
-
-    #[test]
-    fn test_generate_mapping() {
-        let events = vec![EventInfo {
-            name: "Transfer".to_string(),
-            signature: "Transfer(address,address,uint256)".to_string(),
-            inputs: vec![EventInput {
-                name: "from".to_string(),
-                solidity_type: "address".to_string(),
-                indexed: true,
-            }],
-        }];
-
-        let mapping = generate_mapping("Token", &events);
-        assert!(mapping.contains("import { BigInt, Bytes }"));
-        assert!(mapping.contains("Transfer as TransferEvent"));
-        assert!(mapping.contains("../generated/Token/Token"));
-        assert!(mapping.contains("import { Transfer }"));
-        assert!(mapping.contains("../generated/schema"));
-    }
-
-    #[test]
-    fn test_generate_mapping_empty_events() {
-        let events: Vec<EventInfo> = vec![];
-        let mapping = generate_mapping("Empty", &events);
-        assert!(mapping.contains("import { BigInt, Bytes }"));
-        assert!(!mapping.contains("export function handle"));
     }
 
     #[tokio::test]

--- a/gnd/src/commands/add.rs
+++ b/gnd/src/commands/add.rs
@@ -3,7 +3,7 @@
 //! This command adds a new data source to an existing subgraph, generating
 //! the necessary manifest entries, schema types, and mapping stubs.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -16,8 +16,8 @@ use crate::formatter::format_typescript;
 use crate::output::{Step, step};
 use crate::scaffold::manifest::{EventInfo, extract_events_from_abi};
 use crate::scaffold::{
-    MAPPING_API_VERSION, ResolvedEvent, ScaffoldOptions, generate_event_entity,
-    generate_event_handlers, to_kebab_case,
+    MAPPING_API_VERSION, ResolvedEvent, ScaffoldOptions, disambiguate_events,
+    generate_event_entity, generate_event_handlers, to_kebab_case,
 };
 use crate::services::ContractService;
 
@@ -335,45 +335,28 @@ fn resolve_events(
     contract_name: &str,
     merge_entities: bool,
 ) -> Result<Vec<ResolvedEvent>> {
-    let mut seen: HashMap<String, usize> = HashMap::new();
-    let mut resolved = Vec::with_capacity(events.len());
+    let mut resolved = disambiguate_events(events);
 
-    for event in events {
-        // Disambiguate events overloaded within this ABI.
-        let count = seen.entry(event.name.clone()).or_insert(0);
-        let alias = if *count == 0 {
-            event.name.clone()
+    for r in &mut resolved {
+        if !existing.contains(&r.event.name) {
+            continue;
+        }
+        if merge_entities {
+            // Reuse the existing entity. Merge is by name only, so a
+            // signature mismatch surfaces at codegen/build, not here.
+            r.entity_name = r.event.name.clone();
+            r.declare_in_schema = false;
         } else {
-            format!("{}{}", event.name, count)
-        };
-        *count += 1;
-
-        let (entity_name, declare_in_schema) = if existing.contains(&event.name) {
-            if merge_entities {
-                // Reuse the existing entity. Merge is by name only, so a
-                // signature mismatch surfaces at codegen/build, not here.
-                (event.name.clone(), false)
-            } else {
-                let prefixed = format!("{}{}", contract_name, alias);
-                if existing.contains(&prefixed) {
-                    return Err(anyhow!(
-                        "Entity '{}' already exists; cannot rename '{}' to avoid a collision. Choose a different contract name.",
-                        prefixed,
-                        event.name
-                    ));
-                }
-                (prefixed, true)
+            let prefixed = format!("{}{}", contract_name, r.alias);
+            if existing.contains(&prefixed) {
+                return Err(anyhow!(
+                    "Entity '{}' already exists; cannot rename '{}' to avoid a collision. Choose a different contract name.",
+                    prefixed,
+                    r.event.name
+                ));
             }
-        } else {
-            (alias.clone(), true)
-        };
-
-        resolved.push(ResolvedEvent {
-            event,
-            alias,
-            entity_name,
-            declare_in_schema,
-        });
+            r.entity_name = prefixed;
+        }
     }
 
     Ok(resolved)

--- a/gnd/src/commands/add.rs
+++ b/gnd/src/commands/add.rs
@@ -3,7 +3,7 @@
 //! This command adds a new data source to an existing subgraph, generating
 //! the necessary manifest entries, schema types, and mapping stubs.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -122,14 +122,21 @@ pub async fn run_add(opt: AddOpt) -> Result<()> {
         index_events: true, // Always index events for add command
     };
 
-    // Extract events from ABI
+    // Extract events from the ABI and resolve their names against the entities
+    // already present in the subgraph (handles overloads and collisions).
     let events = extract_events_from_abi(&scaffold_options);
+    let resolved = resolve_events(
+        events,
+        &existing_entities(&manifest),
+        &contract_name,
+        opt.merge_entities,
+    )?;
 
     // Add ABI file
     add_abi_file(project_dir, &contract_name, &abi)?;
 
     // Add mapping file
-    add_mapping_file(project_dir, &contract_name, &events)?;
+    add_mapping_file(project_dir, &contract_name, &resolved)?;
 
     // Update manifest
     update_manifest(
@@ -138,11 +145,11 @@ pub async fn run_add(opt: AddOpt) -> Result<()> {
         &contract_name,
         &network,
         start_block,
-        &events,
+        &resolved,
     )?;
 
     // Declare the new event entities in the schema so codegen/build succeed.
-    add_schema_entities(project_dir, &manifest, &events)?;
+    add_schema_entities(project_dir, &manifest, &resolved)?;
 
     // Update networks.json if the subgraph uses one.
     let networks_path = project_dir.join(&opt.network_file);
@@ -249,7 +256,11 @@ fn add_abi_file(project_dir: &Path, contract_name: &str, abi: &JsonValue) -> Res
 }
 
 /// Add mapping file for the new data source.
-fn add_mapping_file(project_dir: &Path, contract_name: &str, events: &[EventInfo]) -> Result<()> {
+fn add_mapping_file(
+    project_dir: &Path,
+    contract_name: &str,
+    events: &[ResolvedEvent],
+) -> Result<()> {
     let src_dir = project_dir.join("src");
     fs::create_dir_all(&src_dir).context("Failed to create src directory")?;
 
@@ -263,12 +274,7 @@ fn add_mapping_file(project_dir: &Path, contract_name: &str, events: &[EventInfo
         return Ok(());
     }
 
-    let resolved: Vec<ResolvedEvent> = events
-        .iter()
-        .cloned()
-        .map(ResolvedEvent::passthrough)
-        .collect();
-    let mapping_content = generate_event_handlers(contract_name, &resolved);
+    let mapping_content = generate_event_handlers(contract_name, events);
     let formatted = format_typescript(&mapping_content).unwrap_or(mapping_content);
 
     step(
@@ -295,6 +301,85 @@ fn existing_source_names(manifest: &serde_yaml::Value) -> HashSet<String> {
     names
 }
 
+/// Collect the entity names already declared by existing data sources / templates.
+fn existing_entities(manifest: &serde_yaml::Value) -> HashSet<String> {
+    let mut entities = HashSet::new();
+    for key in ["dataSources", "templates"] {
+        if let Some(seq) = manifest.get(key).and_then(|v| v.as_sequence()) {
+            for item in seq {
+                if let Some(list) = item
+                    .get("mapping")
+                    .and_then(|m| m.get("entities"))
+                    .and_then(|e| e.as_sequence())
+                {
+                    for entity in list.iter().filter_map(|e| e.as_str()) {
+                        entities.insert(entity.to_string());
+                    }
+                }
+            }
+        }
+    }
+    entities
+}
+
+/// Resolve event names against the entities already present in the subgraph.
+///
+/// - Events overloaded within this ABI are disambiguated (`Transfer`, `Transfer1`).
+/// - An event whose name collides with an existing entity is either merged into
+///   that entity (`merge_entities`: reuse it, keeping the handler so this
+///   contract's events are still indexed, but don't redeclare the type) or
+///   renamed with the contract prefix so both entities can coexist.
+fn resolve_events(
+    events: Vec<EventInfo>,
+    existing: &HashSet<String>,
+    contract_name: &str,
+    merge_entities: bool,
+) -> Result<Vec<ResolvedEvent>> {
+    let mut seen: HashMap<String, usize> = HashMap::new();
+    let mut resolved = Vec::with_capacity(events.len());
+
+    for event in events {
+        // Disambiguate events overloaded within this ABI.
+        let count = seen.entry(event.name.clone()).or_insert(0);
+        let alias = if *count == 0 {
+            event.name.clone()
+        } else {
+            format!("{}{}", event.name, count)
+        };
+        *count += 1;
+
+        let (entity_name, declare_in_schema) = if existing.contains(&event.name) {
+            if merge_entities {
+                // Reuse the existing entity. NOTE: this does not verify that the
+                // two events share a signature; an incompatible merge surfaces at
+                // codegen/build.
+                (event.name.clone(), false)
+            } else {
+                let prefixed = format!("{}{}", contract_name, alias);
+                if existing.contains(&prefixed) {
+                    return Err(anyhow!(
+                        "Entity '{}' already exists; cannot rename '{}' to avoid a collision. Choose a different contract name.",
+                        prefixed,
+                        event.name
+                    ));
+                }
+                (prefixed, true)
+            }
+        } else {
+            (alias.clone(), true)
+        };
+
+        resolved.push(ResolvedEvent {
+            event,
+            alias,
+            entity_name,
+            declare_in_schema,
+        });
+    }
+
+    Ok(resolved)
+}
+
 /// Append entity type definitions for the new events to the subgraph schema.
 ///
 /// The mapping and manifest reference one entity per event; without this the
@@ -302,9 +387,23 @@ fn existing_source_names(manifest: &serde_yaml::Value) -> HashSet<String> {
 fn add_schema_entities(
     project_dir: &Path,
     manifest: &serde_yaml::Value,
-    events: &[EventInfo],
+    events: &[ResolvedEvent],
 ) -> Result<()> {
-    if events.is_empty() {
+    let mut additions = String::new();
+    for resolved in events {
+        // Reused entities already exist in the schema; don't redeclare them.
+        if !resolved.declare_in_schema {
+            continue;
+        }
+        additions.push('\n');
+        additions.push_str(&generate_event_entity(
+            &resolved.entity_name,
+            &resolved.event.inputs,
+        ));
+        additions.push('\n');
+    }
+
+    if additions.is_empty() {
         return Ok(());
     }
 
@@ -314,13 +413,6 @@ fn add_schema_entities(
         .and_then(|f| f.as_str())
         .unwrap_or("schema.graphql");
     let schema_path = project_dir.join(schema_file);
-
-    let mut additions = String::new();
-    for event in events {
-        additions.push('\n');
-        additions.push_str(&generate_event_entity(&event.name, &event.inputs));
-        additions.push('\n');
-    }
 
     step(Step::Write, &format!("Updating {}", schema_path.display()));
 
@@ -343,7 +435,7 @@ fn update_manifest(
     contract_name: &str,
     network: &str,
     start_block: Option<u64>,
-    events: &[EventInfo],
+    events: &[ResolvedEvent],
 ) -> Result<()> {
     let content = fs::read_to_string(manifest_path).context("Failed to read manifest")?;
 
@@ -369,15 +461,15 @@ fn update_manifest(
 
     // Build event handlers
     let mut event_handlers = Vec::new();
-    for event in events {
+    for resolved in events {
         let mut handler = serde_yaml::Mapping::new();
         handler.insert(
             serde_yaml::Value::String("event".to_string()),
-            serde_yaml::Value::String(event.signature.clone()),
+            serde_yaml::Value::String(resolved.event.signature.clone()),
         );
         handler.insert(
             serde_yaml::Value::String("handler".to_string()),
-            serde_yaml::Value::String(format!("handle{}", event.name)),
+            serde_yaml::Value::String(format!("handle{}", resolved.alias)),
         );
         event_handlers.push(serde_yaml::Value::Mapping(handler));
     }
@@ -385,7 +477,7 @@ fn update_manifest(
     // Build entities list
     let entities: Vec<serde_yaml::Value> = events
         .iter()
-        .map(|e| serde_yaml::Value::String(e.name.clone()))
+        .map(|e| serde_yaml::Value::String(e.entity_name.clone()))
         .collect();
 
     // Build ABI entry
@@ -512,5 +604,80 @@ mod tests {
         let result = run_add(opt).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Manifest file"));
+    }
+
+    fn ev(name: &str) -> EventInfo {
+        EventInfo {
+            name: name.to_string(),
+            signature: format!("{}()", name),
+            inputs: vec![],
+        }
+    }
+
+    fn entities(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_resolve_events_no_collision() {
+        let resolved =
+            resolve_events(vec![ev("Transfer")], &entities(&[]), "Token", false).unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].alias, "Transfer");
+        assert_eq!(resolved[0].entity_name, "Transfer");
+        assert!(resolved[0].declare_in_schema);
+    }
+
+    #[test]
+    fn test_resolve_events_overload_disambiguates() {
+        // Two events named Transfer in one ABI get distinct aliases.
+        let resolved = resolve_events(
+            vec![ev("Transfer"), ev("Transfer")],
+            &entities(&[]),
+            "Token",
+            false,
+        )
+        .unwrap();
+        assert_eq!(resolved[0].alias, "Transfer");
+        assert_eq!(resolved[1].alias, "Transfer1");
+        assert_eq!(resolved[1].entity_name, "Transfer1");
+    }
+
+    #[test]
+    fn test_resolve_events_collision_merge_reuses() {
+        let resolved = resolve_events(
+            vec![ev("Transfer")],
+            &entities(&["Transfer"]),
+            "Token",
+            true,
+        )
+        .unwrap();
+        // Reuse the existing entity, don't redeclare it, but keep the handler.
+        assert_eq!(resolved[0].entity_name, "Transfer");
+        assert!(!resolved[0].declare_in_schema);
+    }
+
+    #[test]
+    fn test_resolve_events_collision_no_merge_renames() {
+        let resolved = resolve_events(
+            vec![ev("Transfer")],
+            &entities(&["Transfer"]),
+            "Token",
+            false,
+        )
+        .unwrap();
+        assert_eq!(resolved[0].entity_name, "TokenTransfer");
+        assert!(resolved[0].declare_in_schema);
+    }
+
+    #[test]
+    fn test_resolve_events_collision_renamed_also_exists_errors() {
+        let result = resolve_events(
+            vec![ev("Transfer")],
+            &entities(&["Transfer", "TokenTransfer"]),
+            "Token",
+            false,
+        );
+        assert!(result.is_err());
     }
 }

--- a/gnd/src/commands/add.rs
+++ b/gnd/src/commands/add.rs
@@ -3,6 +3,7 @@
 //! This command adds a new data source to an existing subgraph, generating
 //! the necessary manifest entries, schema types, and mapping stubs.
 
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -15,7 +16,8 @@ use crate::formatter::format_typescript;
 use crate::output::{Step, step};
 use crate::scaffold::manifest::{EventInfo, extract_events_from_abi};
 use crate::scaffold::{
-    MAPPING_API_VERSION, ResolvedEvent, ScaffoldOptions, generate_event_handlers, to_kebab_case,
+    MAPPING_API_VERSION, ResolvedEvent, ScaffoldOptions, generate_event_entity,
+    generate_event_handlers, to_kebab_case,
 };
 use crate::services::ContractService;
 
@@ -98,6 +100,14 @@ pub async fn run_add(opt: AddOpt) -> Result<()> {
     // Fetch or load ABI
     let (abi, contract_name, start_block) = get_contract_info(&opt, &network).await?;
 
+    // A data source / template name must be unique within the subgraph.
+    if existing_source_names(&manifest).contains(&contract_name) {
+        return Err(anyhow!(
+            "Data source or template named '{}' already exists. Choose a different name with --contract-name.",
+            contract_name
+        ));
+    }
+
     // Get project directory
     let project_dir = crate::manifest::manifest_dir(&opt.manifest);
 
@@ -131,19 +141,24 @@ pub async fn run_add(opt: AddOpt) -> Result<()> {
         &events,
     )?;
 
-    // Update networks.json
+    // Declare the new event entities in the schema so codegen/build succeed.
+    add_schema_entities(project_dir, &manifest, &events)?;
+
+    // Update networks.json if the subgraph uses one.
     let networks_path = project_dir.join(&opt.network_file);
-    update_networks_file(
-        &networks_path,
-        &network,
-        &contract_name,
-        &opt.address,
-        start_block,
-    )?;
-    step(
-        Step::Write,
-        &format!("Updated {}", opt.network_file.display()),
-    );
+    if networks_path.exists() {
+        update_networks_file(
+            &networks_path,
+            &network,
+            &contract_name,
+            &opt.address,
+            start_block,
+        )?;
+        step(
+            Step::Write,
+            &format!("Updated {}", opt.network_file.display()),
+        );
+    }
 
     step(Step::Done, &format!("Added data source: {}", contract_name));
 
@@ -261,6 +276,62 @@ fn add_mapping_file(project_dir: &Path, contract_name: &str, events: &[EventInfo
         &format!("Writing mapping to {}", mapping_file.display()),
     );
     fs::write(&mapping_file, formatted).context("Failed to write mapping file")?;
+
+    Ok(())
+}
+
+/// Collect the names of all existing data sources and templates in the manifest.
+fn existing_source_names(manifest: &serde_yaml::Value) -> HashSet<String> {
+    let mut names = HashSet::new();
+    for key in ["dataSources", "templates"] {
+        if let Some(seq) = manifest.get(key).and_then(|v| v.as_sequence()) {
+            for item in seq {
+                if let Some(name) = item.get("name").and_then(|n| n.as_str()) {
+                    names.insert(name.to_string());
+                }
+            }
+        }
+    }
+    names
+}
+
+/// Append entity type definitions for the new events to the subgraph schema.
+///
+/// The mapping and manifest reference one entity per event; without this the
+/// referenced types never exist in schema.graphql and codegen/build fail.
+fn add_schema_entities(
+    project_dir: &Path,
+    manifest: &serde_yaml::Value,
+    events: &[EventInfo],
+) -> Result<()> {
+    if events.is_empty() {
+        return Ok(());
+    }
+
+    let schema_file = manifest
+        .get("schema")
+        .and_then(|s| s.get("file"))
+        .and_then(|f| f.as_str())
+        .unwrap_or("schema.graphql");
+    let schema_path = project_dir.join(schema_file);
+
+    let mut additions = String::new();
+    for event in events {
+        additions.push('\n');
+        additions.push_str(&generate_event_entity(&event.name, &event.inputs));
+        additions.push('\n');
+    }
+
+    step(Step::Write, &format!("Updating {}", schema_path.display()));
+
+    use std::io::Write;
+    let mut file = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&schema_path)
+        .with_context(|| format!("Failed to open schema file: {}", schema_path.display()))?;
+    file.write_all(additions.as_bytes())
+        .context("Failed to append entities to schema")?;
 
     Ok(())
 }

--- a/gnd/src/commands/add.rs
+++ b/gnd/src/commands/add.rs
@@ -375,13 +375,15 @@ fn resolve_events(
     let mut resolved = disambiguate_events(events);
 
     for r in &mut resolved {
-        if !existing.contains(&r.event.name) {
+        // Check the name we would actually declare (the disambiguated alias),
+        // not the raw event name, so an overload alias like `Transfer1` that
+        // collides with an existing entity is still caught.
+        if !existing.contains(&r.entity_name) {
             continue;
         }
         if merge_entities {
-            // Reuse the existing entity. Merge is by name only, so a
-            // signature mismatch surfaces at codegen/build, not here.
-            r.entity_name = r.event.name.clone();
+            // Reuse the existing entity (entity_name already equals it). Merge is
+            // by name only, so a signature mismatch surfaces at codegen/build.
             r.declare_in_schema = false;
         } else {
             let prefixed = format!("{}{}", contract_name, r.alias);
@@ -389,7 +391,7 @@ fn resolve_events(
                 return Err(anyhow!(
                     "Entity '{}' already exists; cannot rename '{}' to avoid a collision. Choose a different contract name.",
                     prefixed,
-                    r.event.name
+                    r.entity_name
                 ));
             }
             r.entity_name = prefixed;
@@ -698,6 +700,23 @@ mod tests {
             false,
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_events_overload_alias_collision_renames() {
+        // The second overload's disambiguated alias (Transfer1) collides with an
+        // existing entity; the collision must be detected on the alias, not the
+        // raw event name.
+        let resolved = resolve_events(
+            vec![ev("Transfer"), ev("Transfer")],
+            &entities(&["Transfer1"]),
+            "Token",
+            false,
+        )
+        .unwrap();
+        assert_eq!(resolved[0].entity_name, "Transfer");
+        assert_eq!(resolved[1].alias, "Transfer1");
+        assert_eq!(resolved[1].entity_name, "TokenTransfer1");
     }
 
     #[test]

--- a/gnd/src/commands/add.rs
+++ b/gnd/src/commands/add.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
 use clap::Parser;
+use graphql_tools::parser::schema as gql;
 use serde_json::Value as JsonValue;
 
 use crate::config::networks::update_networks_file;
@@ -123,14 +124,13 @@ pub async fn run_add(opt: AddOpt) -> Result<()> {
     };
 
     // Extract events from the ABI and resolve their names against the entities
-    // already present in the subgraph (handles overloads and collisions).
+    // already present in the subgraph (handles overloads and collisions). Both
+    // the manifest's entity lists and the types declared in schema.graphql count
+    // as existing, since either can be the source of a name collision.
     let events = extract_events_from_abi(&scaffold_options);
-    let resolved = resolve_events(
-        events,
-        &existing_entities(&manifest),
-        &contract_name,
-        opt.merge_entities,
-    )?;
+    let mut existing = existing_entities(&manifest);
+    existing.extend(schema_entity_types(project_dir, &manifest));
+    let resolved = resolve_events(events, &existing, &contract_name, opt.merge_entities)?;
 
     // Add ABI file
     add_abi_file(project_dir, &contract_name, &abi)?;
@@ -320,6 +320,43 @@ fn existing_entities(manifest: &serde_yaml::Value) -> HashSet<String> {
         }
     }
     entities
+}
+
+/// Collect the `@entity` type names declared in the subgraph's schema.graphql.
+///
+/// The schema is the real source of truth for declared types, so a hand-written
+/// `type Foo @entity` that no mapping lists in its `entities` still counts as a
+/// collision. Returns empty on a missing or unparseable schema (falling back to
+/// the manifest's entity lists).
+fn schema_entity_types(project_dir: &Path, manifest: &serde_yaml::Value) -> HashSet<String> {
+    let schema_file = manifest
+        .get("schema")
+        .and_then(|s| s.get("file"))
+        .and_then(|f| f.as_str())
+        .unwrap_or("schema.graphql");
+    let Ok(content) = fs::read_to_string(project_dir.join(schema_file)) else {
+        return HashSet::new();
+    };
+    entity_types_in_schema(&content)
+}
+
+/// Parse GraphQL schema text and return the names of object types marked
+/// `@entity`. Returns empty if the schema does not parse.
+fn entity_types_in_schema(content: &str) -> HashSet<String> {
+    let Ok(ast) = gql::parse_schema::<String>(content) else {
+        return HashSet::new();
+    };
+    ast.definitions
+        .into_iter()
+        .filter_map(|def| match def {
+            gql::Definition::TypeDefinition(gql::TypeDefinition::Object(obj))
+                if obj.directives.iter().any(|d| d.name == "entity") =>
+            {
+                Some(obj.name)
+            }
+            _ => None,
+        })
+        .collect()
 }
 
 /// Resolve event names against the entities already present in the subgraph.
@@ -661,5 +698,20 @@ mod tests {
             false,
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_entity_types_in_schema() {
+        let schema = r#"
+            type Foo @entity { id: Bytes! }
+            type Bar @entity(immutable: true) { id: Bytes! }
+            type NotAnEntity { id: Bytes! }
+        "#;
+        let types = entity_types_in_schema(schema);
+        assert!(types.contains("Foo"));
+        assert!(types.contains("Bar"));
+        assert!(!types.contains("NotAnEntity"));
+        // A schema that doesn't parse yields no types rather than erroring.
+        assert!(entity_types_in_schema("this is not graphql {{{").is_empty());
     }
 }

--- a/gnd/src/commands/add.rs
+++ b/gnd/src/commands/add.rs
@@ -350,9 +350,8 @@ fn resolve_events(
 
         let (entity_name, declare_in_schema) = if existing.contains(&event.name) {
             if merge_entities {
-                // Reuse the existing entity. NOTE: this does not verify that the
-                // two events share a signature; an incompatible merge surfaces at
-                // codegen/build.
+                // Reuse the existing entity. Merge is by name only, so a
+                // signature mismatch surfaces at codegen/build, not here.
                 (event.name.clone(), false)
             } else {
                 let prefixed = format!("{}{}", contract_name, alias);

--- a/gnd/src/scaffold/manifest.rs
+++ b/gnd/src/scaffold/manifest.rs
@@ -111,11 +111,14 @@ pub struct EventInfo {
 /// - `entity_name` names the GraphQL entity type, the `new` expression and the
 ///   schema import; it gains a contract prefix when it collides with an entity
 ///   that already exists in the subgraph.
+/// - `declare_in_schema` is false when the event reuses an entity that already
+///   exists (a merge), so the type must not be redeclared.
 #[derive(Debug, Clone)]
 pub struct ResolvedEvent {
     pub event: EventInfo,
     pub alias: String,
     pub entity_name: String,
+    pub declare_in_schema: bool,
 }
 
 impl ResolvedEvent {
@@ -128,6 +131,7 @@ impl ResolvedEvent {
             event,
             alias: name.clone(),
             entity_name: name,
+            declare_in_schema: true,
         }
     }
 }

--- a/gnd/src/scaffold/manifest.rs
+++ b/gnd/src/scaffold/manifest.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 
 use super::ScaffoldOptions;
+use crate::shared::handle_reserved_word;
 
 /// Generate the subgraph.yaml manifest content.
 pub fn generate_manifest(options: &ScaffoldOptions) -> String {
@@ -140,6 +141,33 @@ pub fn disambiguate_events(events: Vec<EventInfo>) -> Vec<ResolvedEvent> {
                 entity_name,
                 declare_in_schema: true,
             }
+        })
+        .collect()
+}
+
+/// The `event.params.<name>` accessor for each input, mirroring the names the
+/// ABI codegen gives the generated getters: reserved words are escaped and
+/// unnamed params become `param<index>`, with a counter for any collisions.
+/// Keeps the mapping's right-hand side in sync with the generated bindings.
+pub fn event_param_accessors(inputs: &[EventInput]) -> Vec<String> {
+    let mut seen: HashMap<String, u32> = HashMap::new();
+    inputs
+        .iter()
+        .enumerate()
+        .map(|(index, input)| {
+            let base = if input.name.is_empty() {
+                format!("param{index}")
+            } else {
+                handle_reserved_word(&input.name)
+            };
+            let count = seen.entry(base.clone()).or_insert(0);
+            let name = if *count == 0 {
+                base.clone()
+            } else {
+                format!("{base}{count}")
+            };
+            *count += 1;
+            name
         })
         .collect()
 }

--- a/gnd/src/scaffold/manifest.rs
+++ b/gnd/src/scaffold/manifest.rs
@@ -25,7 +25,7 @@ pub fn generate_manifest(options: &ScaffoldOptions) -> String {
     let event_handlers = get_event_handlers(options);
 
     format!(
-        r#"specVersion: 1.3.0
+        r#"specVersion: {spec_version}
 indexerHints:
   prune: auto
 schema:
@@ -37,7 +37,7 @@ dataSources:
     source:
 {source}    mapping:
       kind: ethereum/events
-      apiVersion: 0.0.9
+      apiVersion: {api_version}
       language: wasm/assemblyscript
       entities:{entities}
       abis:
@@ -46,6 +46,8 @@ dataSources:
       eventHandlers:{event_handlers}
       file: {mapping_file}
 "#,
+        spec_version = super::SPEC_VERSION,
+        api_version = super::MAPPING_API_VERSION,
         entities = get_entities(options),
     )
 }
@@ -93,11 +95,41 @@ fn get_entities(options: &ScaffoldOptions) -> String {
 }
 
 /// Event info extracted from ABI.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EventInfo {
     pub name: String,
     pub signature: String,
     pub inputs: Vec<EventInput>,
+}
+
+/// An event resolved to the concrete names the generators render.
+///
+/// Decided once (here / by collision resolution) so the schema, mapping and
+/// manifest generators never derive names independently:
+/// - `alias` names the handler function and the ABI event-type import; it is
+///   disambiguated for events overloaded within a single ABI.
+/// - `entity_name` names the GraphQL entity type, the `new` expression and the
+///   schema import; it gains a contract prefix when it collides with an entity
+///   that already exists in the subgraph.
+#[derive(Debug, Clone)]
+pub struct ResolvedEvent {
+    pub event: EventInfo,
+    pub alias: String,
+    pub entity_name: String,
+}
+
+impl ResolvedEvent {
+    /// Resolve an event with no disambiguation or collision handling: all names
+    /// equal the raw event name. Used where there are no existing entities to
+    /// collide with (a fresh scaffold).
+    pub fn passthrough(event: EventInfo) -> Self {
+        let name = event.name.clone();
+        Self {
+            event,
+            alias: name.clone(),
+            entity_name: name,
+        }
+    }
 }
 
 /// Event input parameter.

--- a/gnd/src/scaffold/manifest.rs
+++ b/gnd/src/scaffold/manifest.rs
@@ -1,5 +1,7 @@
 //! Manifest (subgraph.yaml) generation for scaffold.
 
+use std::collections::HashMap;
+
 use super::ScaffoldOptions;
 
 /// Generate the subgraph.yaml manifest content.
@@ -21,8 +23,10 @@ pub fn generate_manifest(options: &ScaffoldOptions) -> String {
         source.push_str(&format!("      startBlock: {}\n", start_block));
     }
 
-    // Get event handlers from ABI
-    let event_handlers = get_event_handlers(options);
+    // Resolve events once (disambiguating overloaded names) so the handlers and
+    // entities lists stay consistent.
+    let events = disambiguate_events(extract_events_from_abi(options));
+    let event_handlers = get_event_handlers(contract_name, &events);
 
     format!(
         r#"specVersion: {spec_version}
@@ -48,15 +52,12 @@ dataSources:
 "#,
         spec_version = super::SPEC_VERSION,
         api_version = super::MAPPING_API_VERSION,
-        entities = get_entities(options),
+        entities = get_entities(&events),
     )
 }
 
-/// Get event handlers from ABI.
-fn get_event_handlers(options: &ScaffoldOptions) -> String {
-    let contract_name = &options.contract_name;
-    let events = extract_events_from_abi(options);
-
+/// Get event handlers for the manifest.
+fn get_event_handlers(contract_name: &str, events: &[ResolvedEvent]) -> String {
     if events.is_empty() {
         // Default placeholder handler
         return format!(
@@ -68,28 +69,24 @@ fn get_event_handlers(options: &ScaffoldOptions) -> String {
 
     let mut handlers = String::new();
     for event in events {
-        let handler_name = format!("handle{}", event.name);
         handlers.push_str(&format!(
-            "\n        - event: {}\n          handler: {}",
-            event.signature, handler_name
+            "\n        - event: {}\n          handler: handle{}",
+            event.event.signature, event.alias
         ));
     }
 
     handlers
 }
 
-/// Get entities list for manifest.
-fn get_entities(options: &ScaffoldOptions) -> String {
-    let events = extract_events_from_abi(options);
-
+/// Get entities list for the manifest.
+fn get_entities(events: &[ResolvedEvent]) -> String {
     if events.is_empty() {
         return "\n        - ExampleEntity".to_string();
     }
 
-    // Always use event names from ABI, regardless of index_events
     let mut entities = String::new();
     for event in events {
-        entities.push_str(&format!("\n        - {}", event.name));
+        entities.push_str(&format!("\n        - {}", event.entity_name));
     }
     entities
 }
@@ -121,19 +118,30 @@ pub struct ResolvedEvent {
     pub declare_in_schema: bool,
 }
 
-impl ResolvedEvent {
-    /// Resolve an event with no disambiguation or collision handling: all names
-    /// equal the raw event name. Used where there are no existing entities to
-    /// collide with (a fresh scaffold).
-    pub fn passthrough(event: EventInfo) -> Self {
-        let name = event.name.clone();
-        Self {
-            event,
-            alias: name.clone(),
-            entity_name: name,
-            declare_in_schema: true,
-        }
-    }
+/// Resolve events for a fresh scaffold, disambiguating names that are overloaded
+/// within one ABI by suffixing repeats (`Transfer`, `Transfer1`, ...). There are
+/// no existing entities to collide with, so each entity is declared as-is.
+pub fn disambiguate_events(events: Vec<EventInfo>) -> Vec<ResolvedEvent> {
+    let mut seen: HashMap<String, usize> = HashMap::new();
+    events
+        .into_iter()
+        .map(|event| {
+            let count = seen.entry(event.name.clone()).or_insert(0);
+            let alias = if *count == 0 {
+                event.name.clone()
+            } else {
+                format!("{}{}", event.name, count)
+            };
+            *count += 1;
+            let entity_name = alias.clone();
+            ResolvedEvent {
+                event,
+                alias,
+                entity_name,
+                declare_in_schema: true,
+            }
+        })
+        .collect()
 }
 
 /// Event input parameter.
@@ -359,5 +367,22 @@ mod tests {
 
         let sig = format_event_signature("Transfer", &inputs);
         assert_eq!(sig, "Transfer(indexed address,uint256)");
+    }
+
+    #[test]
+    fn test_disambiguate_events() {
+        let ev = |name: &str| EventInfo {
+            name: name.to_string(),
+            signature: format!("{}()", name),
+            inputs: vec![],
+        };
+        let resolved = disambiguate_events(vec![ev("Transfer"), ev("Transfer"), ev("Approval")]);
+        // Repeated names are suffixed; the first occurrence is unchanged.
+        assert_eq!(resolved[0].alias, "Transfer");
+        assert_eq!(resolved[0].entity_name, "Transfer");
+        assert_eq!(resolved[1].alias, "Transfer1");
+        assert_eq!(resolved[1].entity_name, "Transfer1");
+        assert_eq!(resolved[2].alias, "Approval");
+        assert!(resolved.iter().all(|r| r.declare_in_schema));
     }
 }

--- a/gnd/src/scaffold/mapping.rs
+++ b/gnd/src/scaffold/mapping.rs
@@ -17,7 +17,7 @@ pub fn generate_mapping(options: &ScaffoldOptions) -> String {
         return generate_placeholder_mapping(contract_name, &events, options);
     }
 
-    let resolved: Vec<ResolvedEvent> = events.into_iter().map(ResolvedEvent::passthrough).collect();
+    let resolved = super::disambiguate_events(events);
     generate_event_handlers(contract_name, &resolved)
 }
 
@@ -53,18 +53,20 @@ fn generate_placeholder_mapping(
     events: &[EventInfo],
     options: &ScaffoldOptions,
 ) -> String {
+    let resolved = super::disambiguate_events(events.to_vec());
+
     let mut output = String::new();
 
     // Import graph-ts types
     output.push_str("import {\n  BigInt,\n  Bytes\n} from \"@graphprotocol/graph-ts\"\n");
 
-    // Import contract class and all events
+    // Import contract class and all events (by disambiguated alias).
     output.push_str(&format!("import {{\n  {contract_name},\n"));
-    for (i, event) in events.iter().enumerate() {
-        let suffix = if i < events.len() - 1 { ",\n" } else { "\n" };
+    for (i, event) in resolved.iter().enumerate() {
+        let suffix = if i < resolved.len() - 1 { ",\n" } else { "\n" };
         output.push_str(&format!(
             "  {} as {}Event{}",
-            event.name, event.name, suffix
+            event.alias, event.alias, suffix
         ));
     }
     output.push_str(&format!(
@@ -75,18 +77,17 @@ fn generate_placeholder_mapping(
     output.push_str("import { ExampleEntity } from \"../generated/schema\"\n");
 
     // Generate first handler with full example code
-    let first_event = &events[0];
     output.push_str(&generate_first_placeholder_handler(
-        first_event,
+        &resolved[0],
         contract_name,
         options,
     ));
 
     // Generate empty stub handlers for remaining events
-    for event in events.iter().skip(1) {
+    for event in resolved.iter().skip(1) {
         output.push_str(&format!(
             "\nexport function handle{}(event: {}Event): void {{}}\n",
-            event.name, event.name
+            event.alias, event.alias
         ));
     }
 
@@ -95,15 +96,15 @@ fn generate_placeholder_mapping(
 
 /// Generate the first handler with full example code.
 fn generate_first_placeholder_handler(
-    event: &EventInfo,
+    event: &ResolvedEvent,
     contract_name: &str,
     options: &ScaffoldOptions,
 ) -> String {
-    let event_name = &event.name;
+    let event_name = &event.alias;
 
     // Generate field assignments for first 2 event params
     let mut field_assignments = String::new();
-    for input in event.inputs.iter().take(2) {
+    for input in event.event.inputs.iter().take(2) {
         let field_name = sanitize_field_name(&input.name);
         field_assignments.push_str(&format!(
             "  entity.{} = event.params.{}\n",

--- a/gnd/src/scaffold/mapping.rs
+++ b/gnd/src/scaffold/mapping.rs
@@ -104,11 +104,12 @@ fn generate_first_placeholder_handler(
 
     // Generate field assignments for first 2 event params
     let mut field_assignments = String::new();
-    for input in event.event.inputs.iter().take(2) {
+    let accessors = super::event_param_accessors(&event.event.inputs);
+    for (input, accessor) in event.event.inputs.iter().zip(&accessors).take(2) {
         let field_name = sanitize_field_name(&input.name);
         field_assignments.push_str(&format!(
             "  entity.{} = event.params.{}\n",
-            field_name, input.name
+            field_name, accessor
         ));
     }
 
@@ -200,13 +201,15 @@ fn generate_single_handler(resolved: &ResolvedEvent) -> String {
     let alias = &resolved.alias;
     let entity_name = &resolved.entity_name;
 
-    // Generate field assignments from event parameters.
+    // Generate field assignments from event parameters. The accessor mirrors the
+    // generated binding getter (escaped reserved words, param<index> for unnamed).
     let mut field_assignments = String::new();
-    for input in &resolved.event.inputs {
+    let accessors = super::event_param_accessors(&resolved.event.inputs);
+    for (input, accessor) in resolved.event.inputs.iter().zip(&accessors) {
         let field_name = sanitize_field_name(&input.name);
         field_assignments.push_str(&format!(
             "  entity.{} = event.params.{}\n",
-            field_name, input.name
+            field_name, accessor
         ));
     }
 
@@ -397,5 +400,39 @@ mod tests {
         assert!(functions.contains("totalSupply"));
         // transfer is nonpayable, should not be included
         assert!(!functions.contains("transfer"));
+    }
+
+    #[test]
+    fn test_generate_mapping_reserved_and_unnamed_params() {
+        let abi = json!([
+            {
+                "type": "event",
+                "name": "Act",
+                "inputs": [
+                    {"name": "new", "type": "uint256", "indexed": false},
+                    {"name": "", "type": "address", "indexed": false}
+                ]
+            }
+        ]);
+
+        let options = ScaffoldOptions {
+            contract_name: "RW".to_string(),
+            abi: Some(abi),
+            index_events: true,
+            ..Default::default()
+        };
+
+        let mapping = generate_mapping(&options);
+        // The RHS must match the generated getter: `new` -> `new_`, unnamed -> `param1`.
+        assert!(
+            mapping.contains("event.params.new_"),
+            "reserved param accessor should be escaped, got:\n{}",
+            mapping
+        );
+        assert!(
+            mapping.contains("event.params.param1"),
+            "unnamed param accessor should be param<index>, got:\n{}",
+            mapping
+        );
     }
 }

--- a/gnd/src/scaffold/mapping.rs
+++ b/gnd/src/scaffold/mapping.rs
@@ -1,7 +1,8 @@
 //! Mapping (AssemblyScript) generation for scaffold.
 
 use super::ScaffoldOptions;
-use super::manifest::{EventInfo, extract_events_from_abi};
+use super::manifest::{EventInfo, ResolvedEvent, extract_events_from_abi};
+use super::sanitize_field_name;
 
 /// Generate the mapping.ts content.
 pub fn generate_mapping(options: &ScaffoldOptions) -> String {
@@ -16,7 +17,8 @@ pub fn generate_mapping(options: &ScaffoldOptions) -> String {
         return generate_placeholder_mapping(contract_name, &events, options);
     }
 
-    generate_event_handlers(contract_name, &events, options)
+    let resolved: Vec<ResolvedEvent> = events.into_iter().map(ResolvedEvent::passthrough).collect();
+    generate_event_handlers(contract_name, &resolved)
 }
 
 /// Generate a fallback mapping when no events are found in ABI.
@@ -102,7 +104,7 @@ fn generate_first_placeholder_handler(
     // Generate field assignments for first 2 event params
     let mut field_assignments = String::new();
     for input in event.inputs.iter().take(2) {
-        let field_name = sanitize_param_name(&input.name);
+        let field_name = sanitize_field_name(&input.name);
         field_assignments.push_str(&format!(
             "  entity.{} = event.params.{}\n",
             field_name, input.name
@@ -153,22 +155,18 @@ export function handle{event_name}(event: {event_name}Event): void {{
     )
 }
 
-/// Generate event handlers for all events in the ABI.
-fn generate_event_handlers(
-    contract_name: &str,
-    events: &[super::manifest::EventInfo],
-    _options: &ScaffoldOptions,
-) -> String {
-    let mut imports = String::new();
-    let mut handlers = String::new();
+/// Generate event handlers for all resolved events.
+pub fn generate_event_handlers(contract_name: &str, events: &[ResolvedEvent]) -> String {
+    let mut imports = String::from("import { BigInt, Bytes } from \"@graphprotocol/graph-ts\"\n");
 
-    // Import graph-ts types
-    imports.push_str("import { BigInt, Bytes } from \"@graphprotocol/graph-ts\"\n");
+    if events.is_empty() {
+        return imports;
+    }
 
-    // Import event types
+    // Import event types (by ABI alias).
     let event_imports: Vec<String> = events
         .iter()
-        .map(|e| format!("{} as {}Event", e.name, e.name))
+        .map(|e| format!("{} as {}Event", e.alias, e.alias))
         .collect();
 
     imports.push_str(&format!(
@@ -178,15 +176,16 @@ fn generate_event_handlers(
         contract_name
     ));
 
-    // Import entity types
-    let entity_imports: Vec<String> = events.iter().map(|e| e.name.clone()).collect();
+    // Import entity types.
+    let entity_imports: Vec<String> = events.iter().map(|e| e.entity_name.clone()).collect();
 
     imports.push_str(&format!(
         "import {{ {} }} from \"../generated/schema\"\n",
         entity_imports.join(", ")
     ));
 
-    // Generate handler for each event
+    // Generate handler for each event.
+    let mut handlers = String::new();
     for event in events {
         handlers.push('\n');
         handlers.push_str(&generate_single_handler(event));
@@ -195,14 +194,15 @@ fn generate_event_handlers(
     format!("{}\n{}", imports, handlers)
 }
 
-/// Generate a handler function for a single event.
-fn generate_single_handler(event: &super::manifest::EventInfo) -> String {
-    let event_name = &event.name;
+/// Generate a handler function for a single resolved event.
+fn generate_single_handler(resolved: &ResolvedEvent) -> String {
+    let alias = &resolved.alias;
+    let entity_name = &resolved.entity_name;
 
-    // Generate field assignments from event parameters
+    // Generate field assignments from event parameters.
     let mut field_assignments = String::new();
-    for input in &event.inputs {
-        let field_name = sanitize_param_name(&input.name);
+    for input in &resolved.event.inputs {
+        let field_name = sanitize_field_name(&input.name);
         field_assignments.push_str(&format!(
             "  entity.{} = event.params.{}\n",
             field_name, input.name
@@ -210,8 +210,8 @@ fn generate_single_handler(event: &super::manifest::EventInfo) -> String {
     }
 
     format!(
-        r#"export function handle{event_name}(event: {event_name}Event): void {{
-  let entity = new {event_name}(
+        r#"export function handle{alias}(event: {alias}Event): void {{
+  let entity = new {entity_name}(
     event.transaction.hash.concatI32(event.logIndex.toI32())
   )
 
@@ -223,34 +223,6 @@ fn generate_single_handler(event: &super::manifest::EventInfo) -> String {
 }}
 "#
     )
-}
-
-/// Sanitize parameter name for use in AssemblyScript.
-fn sanitize_param_name(name: &str) -> String {
-    if name.is_empty() {
-        return "value".to_string();
-    }
-
-    // Convert to camelCase if starts with uppercase
-    let mut result = name.to_string();
-    if result
-        .chars()
-        .next()
-        .map(|c| c.is_uppercase())
-        .unwrap_or(false)
-    {
-        let mut chars = result.chars();
-        if let Some(first) = chars.next() {
-            result = first.to_lowercase().collect::<String>() + chars.as_str();
-        }
-    }
-
-    // Avoid reserved words
-    match result.as_str() {
-        "id" => "eventId".to_string(),
-        "type" => "eventType".to_string(),
-        _ => result,
-    }
 }
 
 /// Extract callable functions from ABI for documentation comments.
@@ -392,14 +364,6 @@ mod tests {
         assert!(mapping.contains("event.params.from"));
         assert!(mapping.contains("event.params.to"));
         assert!(mapping.contains("event.params.value"));
-    }
-
-    #[test]
-    fn test_sanitize_param_name() {
-        assert_eq!(sanitize_param_name("from"), "from");
-        assert_eq!(sanitize_param_name("TokenId"), "tokenId");
-        assert_eq!(sanitize_param_name("id"), "eventId");
-        assert_eq!(sanitize_param_name(""), "value");
     }
 
     #[test]

--- a/gnd/src/scaffold/mod.rs
+++ b/gnd/src/scaffold/mod.rs
@@ -9,8 +9,8 @@ mod naming;
 mod schema;
 
 pub use manifest::{
-    EventInfo, EventInput, ResolvedEvent, disambiguate_events, extract_events_from_abi,
-    generate_manifest,
+    EventInfo, EventInput, ResolvedEvent, disambiguate_events, event_param_accessors,
+    extract_events_from_abi, generate_manifest,
 };
 pub use mapping::{generate_event_handlers, generate_mapping};
 pub(crate) use naming::sanitize_field_name;

--- a/gnd/src/scaffold/mod.rs
+++ b/gnd/src/scaffold/mod.rs
@@ -9,7 +9,8 @@ mod naming;
 mod schema;
 
 pub use manifest::{
-    EventInfo, EventInput, ResolvedEvent, extract_events_from_abi, generate_manifest,
+    EventInfo, EventInput, ResolvedEvent, disambiguate_events, extract_events_from_abi,
+    generate_manifest,
 };
 pub use mapping::{generate_event_handlers, generate_mapping};
 pub(crate) use naming::sanitize_field_name;

--- a/gnd/src/scaffold/mod.rs
+++ b/gnd/src/scaffold/mod.rs
@@ -13,7 +13,7 @@ pub use manifest::{
 };
 pub use mapping::{generate_event_handlers, generate_mapping};
 pub(crate) use naming::sanitize_field_name;
-pub use schema::generate_schema;
+pub use schema::{generate_event_entity, generate_schema};
 
 use std::fs;
 use std::path::Path;

--- a/gnd/src/scaffold/mod.rs
+++ b/gnd/src/scaffold/mod.rs
@@ -5,10 +5,14 @@
 
 pub mod manifest;
 mod mapping;
+mod naming;
 mod schema;
 
-pub use manifest::{EventInfo, EventInput, extract_events_from_abi, generate_manifest};
-pub use mapping::generate_mapping;
+pub use manifest::{
+    EventInfo, EventInput, ResolvedEvent, extract_events_from_abi, generate_manifest,
+};
+pub use mapping::{generate_event_handlers, generate_mapping};
+pub(crate) use naming::sanitize_field_name;
 pub use schema::generate_schema;
 
 use std::fs;
@@ -59,6 +63,10 @@ impl Default for ScaffoldOptions {
 const GRAPH_CLI_VERSION: &str = "0.98.0";
 const GRAPH_TS_VERSION: &str = "0.37.0";
 const MATCHSTICK_VERSION: &str = "0.6.0";
+
+/// Manifest format versions emitted by the scaffolder.
+pub(crate) const SPEC_VERSION: &str = "1.3.0";
+pub(crate) const MAPPING_API_VERSION: &str = "0.0.9";
 
 /// Generate all scaffold files and write to directory.
 pub fn generate_scaffold(dir: &Path, options: &ScaffoldOptions) -> Result<()> {

--- a/gnd/src/scaffold/naming.rs
+++ b/gnd/src/scaffold/naming.rs
@@ -1,0 +1,69 @@
+//! Shared name sanitization for scaffold code generation.
+//!
+//! A single source of truth for turning ABI parameter names into valid GraphQL
+//! field / AssemblyScript identifiers, used by both the schema and mapping
+//! generators so the two never disagree.
+
+/// Sanitize a parameter name into a valid GraphQL/AssemblyScript field identifier.
+pub(crate) fn sanitize_field_name(name: &str) -> String {
+    if name.is_empty() {
+        return "value".to_string();
+    }
+
+    // Identifiers must start with a letter or underscore; replace anything else.
+    let mut result = String::new();
+    for (i, c) in name.chars().enumerate() {
+        if i == 0 && c.is_ascii_digit() {
+            result.push('_');
+        }
+        if c.is_alphanumeric() || c == '_' {
+            result.push(c);
+        } else {
+            result.push('_');
+        }
+    }
+
+    // Convert a leading uppercase to camelCase.
+    if result
+        .chars()
+        .next()
+        .map(|c| c.is_uppercase())
+        .unwrap_or(false)
+    {
+        let mut chars = result.chars();
+        if let Some(first) = chars.next() {
+            result = first.to_lowercase().collect::<String>() + chars.as_str();
+        }
+    }
+
+    // Avoid GraphQL reserved field names.
+    match result.as_str() {
+        "id" => "eventId".to_string(),
+        "type" => "eventType".to_string(),
+        _ => result,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_field_name() {
+        // Normal names pass through.
+        assert_eq!(sanitize_field_name("owner"), "owner");
+        assert_eq!(sanitize_field_name("from"), "from");
+        // Empty -> placeholder.
+        assert_eq!(sanitize_field_name(""), "value");
+        // Leading uppercase -> camelCase.
+        assert_eq!(sanitize_field_name("Owner"), "owner");
+        assert_eq!(sanitize_field_name("TokenId"), "tokenId");
+        // Reserved words.
+        assert_eq!(sanitize_field_name("id"), "eventId");
+        assert_eq!(sanitize_field_name("type"), "eventType");
+        // Leading digit -> underscore prefix.
+        assert_eq!(sanitize_field_name("0value"), "_0value");
+        // Non-alphanumeric -> underscore.
+        assert_eq!(sanitize_field_name("a-b"), "a_b");
+    }
+}

--- a/gnd/src/scaffold/naming.rs
+++ b/gnd/src/scaffold/naming.rs
@@ -43,58 +43,10 @@ pub(crate) fn sanitize_field_name(name: &str) -> String {
         _ => result,
     };
 
-    // Suffix reserved words so the generated AssemblyScript stays valid.
-    if RESERVED_WORDS.contains(&result.as_str()) {
-        format!("{result}_")
-    } else {
-        result
-    }
+    // Escape reserved words via the shared list, so the entity field name
+    // matches the member the schema/ABI codegen generates from the same list.
+    crate::shared::handle_reserved_word(&result)
 }
-
-/// Words reserved in JS / AssemblyScript that cannot be used as identifiers as-is.
-const RESERVED_WORDS: &[&str] = &[
-    "await",
-    "break",
-    "case",
-    "catch",
-    "class",
-    "const",
-    "continue",
-    "debugger",
-    "delete",
-    "do",
-    "else",
-    "enum",
-    "export",
-    "extends",
-    "false",
-    "finally",
-    "function",
-    "if",
-    "implements",
-    "import",
-    "in",
-    "interface",
-    "let",
-    "new",
-    "package",
-    "private",
-    "protected",
-    "public",
-    "return",
-    "super",
-    "switch",
-    "static",
-    "this",
-    "throw",
-    "true",
-    "try",
-    "typeof",
-    "var",
-    "while",
-    "with",
-    "yield",
-];
 
 #[cfg(test)]
 mod tests {
@@ -113,10 +65,17 @@ mod tests {
         // Names that clash with the entity id / GraphQL keyword.
         assert_eq!(sanitize_field_name("id"), "eventId");
         assert_eq!(sanitize_field_name("type"), "eventType");
-        // Reserved words are suffixed so the generated code compiles.
+        // Reserved words are suffixed so the generated code compiles. These use
+        // the shared list, so words only in it (for/default/null/void/instanceof)
+        // are covered too — and stay consistent with the schema/ABI codegen.
         assert_eq!(sanitize_field_name("new"), "new_");
         assert_eq!(sanitize_field_name("class"), "class_");
         assert_eq!(sanitize_field_name("return"), "return_");
+        assert_eq!(sanitize_field_name("for"), "for_");
+        assert_eq!(sanitize_field_name("default"), "default_");
+        assert_eq!(sanitize_field_name("null"), "null_");
+        assert_eq!(sanitize_field_name("void"), "void_");
+        assert_eq!(sanitize_field_name("instanceof"), "instanceof_");
         // Leading uppercase reserved word still resolves after camelCasing.
         assert_eq!(sanitize_field_name("New"), "new_");
         // Leading digit -> underscore prefix.

--- a/gnd/src/scaffold/naming.rs
+++ b/gnd/src/scaffold/naming.rs
@@ -36,13 +36,65 @@ pub(crate) fn sanitize_field_name(name: &str) -> String {
         }
     }
 
-    // Avoid GraphQL reserved field names.
-    match result.as_str() {
+    // Avoid clashing with the entity `id` field and the GraphQL `type` keyword.
+    let result = match result.as_str() {
         "id" => "eventId".to_string(),
         "type" => "eventType".to_string(),
         _ => result,
+    };
+
+    // Suffix reserved words so the generated AssemblyScript stays valid.
+    if RESERVED_WORDS.contains(&result.as_str()) {
+        format!("{result}_")
+    } else {
+        result
     }
 }
+
+/// Words reserved in JS / AssemblyScript that cannot be used as identifiers as-is.
+const RESERVED_WORDS: &[&str] = &[
+    "await",
+    "break",
+    "case",
+    "catch",
+    "class",
+    "const",
+    "continue",
+    "debugger",
+    "delete",
+    "do",
+    "else",
+    "enum",
+    "export",
+    "extends",
+    "false",
+    "finally",
+    "function",
+    "if",
+    "implements",
+    "import",
+    "in",
+    "interface",
+    "let",
+    "new",
+    "package",
+    "private",
+    "protected",
+    "public",
+    "return",
+    "super",
+    "switch",
+    "static",
+    "this",
+    "throw",
+    "true",
+    "try",
+    "typeof",
+    "var",
+    "while",
+    "with",
+    "yield",
+];
 
 #[cfg(test)]
 mod tests {
@@ -58,9 +110,15 @@ mod tests {
         // Leading uppercase -> camelCase.
         assert_eq!(sanitize_field_name("Owner"), "owner");
         assert_eq!(sanitize_field_name("TokenId"), "tokenId");
-        // Reserved words.
+        // Names that clash with the entity id / GraphQL keyword.
         assert_eq!(sanitize_field_name("id"), "eventId");
         assert_eq!(sanitize_field_name("type"), "eventType");
+        // Reserved words are suffixed so the generated code compiles.
+        assert_eq!(sanitize_field_name("new"), "new_");
+        assert_eq!(sanitize_field_name("class"), "class_");
+        assert_eq!(sanitize_field_name("return"), "return_");
+        // Leading uppercase reserved word still resolves after camelCasing.
+        assert_eq!(sanitize_field_name("New"), "new_");
         // Leading digit -> underscore prefix.
         assert_eq!(sanitize_field_name("0value"), "_0value");
         // Non-alphanumeric -> underscore.

--- a/gnd/src/scaffold/schema.rs
+++ b/gnd/src/scaffold/schema.rs
@@ -2,6 +2,7 @@
 
 use super::ScaffoldOptions;
 use super::manifest::{EventInput, extract_events_from_abi};
+use super::sanitize_field_name;
 
 /// Generate the schema.graphql content.
 pub fn generate_schema(options: &ScaffoldOptions) -> String {
@@ -55,7 +56,7 @@ fn generate_example_entity(inputs: &[EventInput]) -> String {
 }
 
 /// Generate an entity type for an event.
-fn generate_event_entity(event_name: &str, inputs: &[EventInput]) -> String {
+pub fn generate_event_entity(entity_name: &str, inputs: &[EventInput]) -> String {
     let mut fields = String::new();
 
     // ID field
@@ -76,7 +77,7 @@ fn generate_event_entity(event_name: &str, inputs: &[EventInput]) -> String {
     format!(
         "# Declare entity types as immutable when possible for better performance\n\
          type {} @entity(immutable: true) {{\n{}\n}}",
-        event_name, fields
+        entity_name, fields
     )
 }
 
@@ -117,47 +118,6 @@ fn solidity_to_graphql(solidity_type: &str) -> &'static str {
 
         // Default to Bytes for unknown types
         _ => "Bytes",
-    }
-}
-
-/// Sanitize a field name to be a valid GraphQL identifier.
-fn sanitize_field_name(name: &str) -> String {
-    if name.is_empty() {
-        return "value".to_string();
-    }
-
-    // GraphQL field names must start with a letter or underscore
-    let mut result = String::new();
-
-    for (i, c) in name.chars().enumerate() {
-        if i == 0 && c.is_ascii_digit() {
-            result.push('_');
-        }
-        if c.is_alphanumeric() || c == '_' {
-            result.push(c);
-        } else {
-            result.push('_');
-        }
-    }
-
-    // Convert to camelCase if starts with uppercase
-    if result
-        .chars()
-        .next()
-        .map(|c| c.is_uppercase())
-        .unwrap_or(false)
-    {
-        let mut chars = result.chars();
-        if let Some(first) = chars.next() {
-            result = first.to_lowercase().collect::<String>() + chars.as_str();
-        }
-    }
-
-    // Avoid reserved words
-    match result.as_str() {
-        "id" => "eventId".to_string(),
-        "type" => "eventType".to_string(),
-        _ => result,
     }
 }
 
@@ -276,15 +236,5 @@ mod tests {
         assert_eq!(solidity_to_graphql("bytes"), "Bytes");
         assert_eq!(solidity_to_graphql("address[]"), "[Bytes!]");
         assert_eq!(solidity_to_graphql("uint256[]"), "[BigInt!]");
-    }
-
-    #[test]
-    fn test_sanitize_field_name() {
-        assert_eq!(sanitize_field_name("from"), "from");
-        assert_eq!(sanitize_field_name("tokenId"), "tokenId");
-        assert_eq!(sanitize_field_name("TokenId"), "tokenId");
-        assert_eq!(sanitize_field_name("123value"), "_123value");
-        assert_eq!(sanitize_field_name("id"), "eventId");
-        assert_eq!(sanitize_field_name(""), "value");
     }
 }

--- a/gnd/src/scaffold/schema.rs
+++ b/gnd/src/scaffold/schema.rs
@@ -18,11 +18,11 @@ pub fn generate_schema(options: &ScaffoldOptions) -> String {
         return generate_example_entity(&events[0].inputs);
     }
 
-    // Generate entity for each event
+    // Generate an entity for each event, disambiguating overloaded names.
     let mut schema = String::new();
 
-    for event in events {
-        let entity = generate_event_entity(&event.name, &event.inputs);
+    for resolved in super::disambiguate_events(events) {
+        let entity = generate_event_entity(&resolved.entity_name, &resolved.event.inputs);
         schema.push_str(&entity);
         schema.push_str("\n\n");
     }

--- a/gnd/src/scaffold/schema.rs
+++ b/gnd/src/scaffold/schema.rs
@@ -89,6 +89,7 @@ fn solidity_to_graphql(solidity_type: &str) -> &'static str {
         return match solidity_to_graphql(inner) {
             "Bytes" => "[Bytes!]",
             "BigInt" => "[BigInt!]",
+            "Int" => "[Int!]",
             "String" => "[String!]",
             "Boolean" => "[Boolean!]",
             _ => "[Bytes!]",
@@ -113,12 +114,35 @@ fn solidity_to_graphql(solidity_type: &str) -> &'static str {
         | "bytes23" | "bytes24" | "bytes25" | "bytes26" | "bytes27" | "bytes28" | "bytes29"
         | "bytes30" | "bytes31" | "bytes32" => "Bytes",
 
-        // Integer types - all map to BigInt for simplicity
-        t if t.starts_with("uint") || t.starts_with("int") => "BigInt",
+        // Integers: small widths fit in an i32 (GraphQL Int), the rest need BigInt.
+        t if t.starts_with("uint") || t.starts_with("int") => int_to_graphql(t),
 
         // Default to Bytes for unknown types
         _ => "Bytes",
     }
+}
+
+/// Map a Solidity integer type to GraphQL `Int` when it fits in an i32, else
+/// `BigInt`. An i32 holds signed ints up to 32 bits and unsigned ints up to 24
+/// bits, matching graph-cli's AssemblyScript type conversion.
+fn int_to_graphql(solidity_type: &str) -> &'static str {
+    let (signed, width) = match solidity_type.strip_prefix("uint") {
+        Some(rest) => (false, rest),
+        None => match solidity_type.strip_prefix("int") {
+            Some(rest) => (true, rest),
+            None => return "BigInt",
+        },
+    };
+
+    // A bare `int` / `uint` is 256 bits.
+    let bits: u32 = if width.is_empty() {
+        256
+    } else {
+        width.parse().unwrap_or(256)
+    };
+
+    let fits_i32 = if signed { bits <= 32 } else { bits <= 24 };
+    if fits_i32 { "Int" } else { "BigInt" }
 }
 
 #[cfg(test)]
@@ -230,11 +254,27 @@ mod tests {
         assert_eq!(solidity_to_graphql("address"), "Bytes");
         assert_eq!(solidity_to_graphql("bool"), "Boolean");
         assert_eq!(solidity_to_graphql("string"), "String");
-        assert_eq!(solidity_to_graphql("uint256"), "BigInt");
-        assert_eq!(solidity_to_graphql("int8"), "BigInt");
         assert_eq!(solidity_to_graphql("bytes32"), "Bytes");
         assert_eq!(solidity_to_graphql("bytes"), "Bytes");
         assert_eq!(solidity_to_graphql("address[]"), "[Bytes!]");
         assert_eq!(solidity_to_graphql("uint256[]"), "[BigInt!]");
+    }
+
+    #[test]
+    fn test_integer_width_mapping() {
+        // Small widths that fit in an i32 map to Int.
+        assert_eq!(solidity_to_graphql("int8"), "Int");
+        assert_eq!(solidity_to_graphql("int32"), "Int");
+        assert_eq!(solidity_to_graphql("uint8"), "Int");
+        assert_eq!(solidity_to_graphql("uint24"), "Int");
+        // Wider integers need BigInt (uint32 does not fit an i32).
+        assert_eq!(solidity_to_graphql("uint32"), "BigInt");
+        assert_eq!(solidity_to_graphql("int40"), "BigInt");
+        assert_eq!(solidity_to_graphql("uint256"), "BigInt");
+        assert_eq!(solidity_to_graphql("int"), "BigInt");
+        assert_eq!(solidity_to_graphql("uint"), "BigInt");
+        // Arrays follow the element type.
+        assert_eq!(solidity_to_graphql("int8[]"), "[Int!]");
+        assert_eq!(solidity_to_graphql("uint64[]"), "[BigInt!]");
     }
 }

--- a/gnd/tests/cli_commands.rs
+++ b/gnd/tests/cli_commands.rs
@@ -603,6 +603,55 @@ fn test_add_overloaded_events_disambiguate() {
 }
 
 #[test]
+fn test_init_overloaded_events_disambiguate() {
+    let temp_dir = TempDir::new().unwrap();
+    let subgraph_dir = temp_dir.path().join("over-init");
+
+    // An ABI with two events of the same name (a Solidity overload).
+    let overloaded_abi = temp_dir.path().join("Overloaded.json");
+    fs::write(
+        &overloaded_abi,
+        r#"[
+          {"type":"event","name":"Ping","inputs":[{"name":"account","type":"address","indexed":true}]},
+          {"type":"event","name":"Ping","inputs":[{"name":"amount","type":"uint256","indexed":false}]}
+        ]"#,
+    )
+    .unwrap();
+
+    run_gnd_success(
+        &[
+            "init",
+            "--from-contract",
+            "0x1111111111111111111111111111111111111111",
+            "--abi",
+            overloaded_abi.to_str().unwrap(),
+            "--network",
+            "mainnet",
+            "--contract-name",
+            "Over",
+            "--index-events",
+            "over-init",
+        ],
+        temp_dir.path(),
+    );
+
+    // init must disambiguate too, or it emits duplicate types / handlers.
+    let schema = fs::read_to_string(subgraph_dir.join("schema.graphql")).unwrap();
+    assert!(
+        schema.contains("type Ping @entity") && schema.contains("type Ping1 @entity"),
+        "init should disambiguate overloaded events, got:\n{}",
+        schema
+    );
+
+    let mapping = fs::read_to_string(subgraph_dir.join("src").join("over.ts")).unwrap();
+    assert!(
+        mapping.contains("handlePing(") && mapping.contains("handlePing1("),
+        "init mapping should disambiguate overloaded handlers, got:\n{}",
+        mapping
+    );
+}
+
+#[test]
 fn test_add_duplicate_name_errors() {
     let temp_dir = TempDir::new().unwrap();
     let subgraph_dir = temp_dir.path().join("dup-test");

--- a/gnd/tests/cli_commands.rs
+++ b/gnd/tests/cli_commands.rs
@@ -431,6 +431,13 @@ fn test_add_datasource() {
         "Initial manifest should not have SecondContract"
     );
 
+    // The added contract's event entity should not exist in the schema yet.
+    let schema_before = fs::read_to_string(subgraph_dir.join("schema.graphql")).unwrap();
+    assert!(
+        !schema_before.contains("type Trigger"),
+        "Initial schema should not have the Trigger entity"
+    );
+
     // Now add another datasource
     let second_abi_path = test_abis_path().join("LimitedContract.json");
     let output = run_gnd(
@@ -464,6 +471,62 @@ fn test_add_datasource() {
     assert!(
         manifest_after.contains("0x2222222222222222222222222222222222222222"),
         "Updated manifest should have second contract address"
+    );
+
+    // The new event entity must be declared in the schema so codegen/build work.
+    let schema_after = fs::read_to_string(subgraph_dir.join("schema.graphql")).unwrap();
+    assert!(
+        schema_after.contains("type Trigger @entity"),
+        "Updated schema should declare the Trigger entity, got:\n{}",
+        schema_after
+    );
+}
+
+#[test]
+fn test_add_duplicate_name_errors() {
+    let temp_dir = TempDir::new().unwrap();
+    let subgraph_dir = temp_dir.path().join("dup-test");
+
+    let abi_path = test_abis_path().join("SimpleContract.json");
+    run_gnd_success(
+        &[
+            "init",
+            "--from-contract",
+            "0x1111111111111111111111111111111111111111",
+            "--abi",
+            abi_path.to_str().unwrap(),
+            "--network",
+            "mainnet",
+            "--contract-name",
+            "FirstContract",
+            "dup-test",
+        ],
+        temp_dir.path(),
+    );
+
+    // Adding a data source whose name already exists must fail.
+    let second_abi_path = test_abis_path().join("LimitedContract.json");
+    let output = run_gnd(
+        &[
+            "add",
+            "0x2222222222222222222222222222222222222222",
+            "--abi",
+            second_abi_path.to_str().unwrap(),
+            "--contract-name",
+            "FirstContract",
+        ],
+        &subgraph_dir,
+    );
+
+    assert!(
+        !output.status.success(),
+        "gnd add should fail when the data source name already exists"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("already exists"),
+        "error should mention the name already exists, got: {}",
+        stderr
     );
 }
 

--- a/gnd/tests/cli_commands.rs
+++ b/gnd/tests/cli_commands.rs
@@ -473,12 +473,70 @@ fn test_add_datasource() {
         "Updated manifest should have second contract address"
     );
 
-    // The new event entity must be declared in the schema so codegen/build work.
+    // The added Trigger event collides with the first contract's Trigger entity;
+    // without --merge-entities it is renamed with the contract prefix so both
+    // can coexist, and declared in the schema.
     let schema_after = fs::read_to_string(subgraph_dir.join("schema.graphql")).unwrap();
     assert!(
-        schema_after.contains("type Trigger @entity"),
-        "Updated schema should declare the Trigger entity, got:\n{}",
+        schema_after.contains("type SecondContractTrigger @entity"),
+        "Updated schema should declare the renamed entity, got:\n{}",
         schema_after
+    );
+}
+
+#[test]
+fn test_add_merge_entities_reuses_existing() {
+    let temp_dir = TempDir::new().unwrap();
+    let subgraph_dir = temp_dir.path().join("merge-test");
+
+    // Init with --index-events so the schema actually declares the event entities.
+    let abi_path = test_abis_path().join("SimpleContract.json");
+    run_gnd_success(
+        &[
+            "init",
+            "--from-contract",
+            "0x1111111111111111111111111111111111111111",
+            "--abi",
+            abi_path.to_str().unwrap(),
+            "--network",
+            "mainnet",
+            "--contract-name",
+            "FirstContract",
+            "--index-events",
+            "merge-test",
+        ],
+        temp_dir.path(),
+    );
+
+    // Add a contract whose Trigger event collides, with --merge-entities.
+    let second_abi_path = test_abis_path().join("LimitedContract.json");
+    run_gnd_success(
+        &[
+            "add",
+            "0x2222222222222222222222222222222222222222",
+            "--abi",
+            second_abi_path.to_str().unwrap(),
+            "--contract-name",
+            "SecondContract",
+            "--merge-entities",
+        ],
+        &subgraph_dir,
+    );
+
+    // Merge reuses the existing Trigger entity: no renamed type is declared...
+    let schema_after = fs::read_to_string(subgraph_dir.join("schema.graphql")).unwrap();
+    assert!(
+        !schema_after.contains("SecondContractTrigger"),
+        "merge should reuse Trigger, not declare a renamed entity, got:\n{}",
+        schema_after
+    );
+
+    // ...but the handler is still generated, writing into the shared entity.
+    let mapping = fs::read_to_string(subgraph_dir.join("src").join("second-contract.ts")).unwrap();
+    assert!(
+        mapping.contains("new Trigger("),
+        "merged handler should write into the existing Trigger entity, got:\n{}",
+        mapping
     );
 }
 

--- a/gnd/tests/cli_commands.rs
+++ b/gnd/tests/cli_commands.rs
@@ -541,6 +541,68 @@ fn test_add_merge_entities_reuses_existing() {
 }
 
 #[test]
+fn test_add_overloaded_events_disambiguate() {
+    let temp_dir = TempDir::new().unwrap();
+    let subgraph_dir = temp_dir.path().join("over-test");
+
+    // A base subgraph without overloaded events.
+    let abi_path = test_abis_path().join("LimitedContract.json");
+    run_gnd_success(
+        &[
+            "init",
+            "--from-contract",
+            "0x1111111111111111111111111111111111111111",
+            "--abi",
+            abi_path.to_str().unwrap(),
+            "--network",
+            "mainnet",
+            "--contract-name",
+            "Base",
+            "over-test",
+        ],
+        temp_dir.path(),
+    );
+
+    // An ABI with two events of the same name (a Solidity overload).
+    let overloaded_abi = temp_dir.path().join("Overloaded.json");
+    fs::write(
+        &overloaded_abi,
+        r#"[
+          {"type":"event","name":"Ping","inputs":[{"name":"account","type":"address","indexed":true}]},
+          {"type":"event","name":"Ping","inputs":[{"name":"amount","type":"uint256","indexed":false}]}
+        ]"#,
+    )
+    .unwrap();
+
+    run_gnd_success(
+        &[
+            "add",
+            "0x2222222222222222222222222222222222222222",
+            "--abi",
+            overloaded_abi.to_str().unwrap(),
+            "--contract-name",
+            "Over",
+        ],
+        &subgraph_dir,
+    );
+
+    // The two Ping events get distinct entities and handlers.
+    let schema = fs::read_to_string(subgraph_dir.join("schema.graphql")).unwrap();
+    assert!(
+        schema.contains("type Ping @entity") && schema.contains("type Ping1 @entity"),
+        "overloaded events should produce Ping and Ping1 entities, got:\n{}",
+        schema
+    );
+
+    let mapping = fs::read_to_string(subgraph_dir.join("src").join("over.ts")).unwrap();
+    assert!(
+        mapping.contains("handlePing(") && mapping.contains("handlePing1("),
+        "overloaded events should produce handlePing and handlePing1, got:\n{}",
+        mapping
+    );
+}
+
+#[test]
 fn test_add_duplicate_name_errors() {
     let temp_dir = TempDir::new().unwrap();
     let subgraph_dir = temp_dir.path().join("dup-test");


### PR DESCRIPTION
`gnd add` was a drifted copy of the `init`/scaffold code generation, and the copy never wrote `schema.graphql` — so adding a data source produced a subgraph that fails `codegen`/`build`. This unifies the two paths and fixes a cluster of related codegen bugs.

The scaffolder now decides every event's names once (a `ResolvedEvent`) and feeds one set of generators (schema, mapping, manifest), instead of `init` and `add` each rolling their own.

What's fixed:
- `add` now writes the event entities to `schema.graphql` (the main bug)
- Event-name collisions across data sources: renamed with the contract prefix by default, or merged into the existing entity with `--merge-entities` (previously a dead flag), keeping the handler so the new contract's events are still indexed
- Overloaded events (same name, different params) are disambiguated (`Transfer`, `Transfer1`) in both `add` and `init`
- Small integer types (`uint8`, `int32`, …) map to GraphQL `Int` instead of `BigInt`
- Reserved-word parameter names (`new`, `class`, …) are escaped so the generated code compiles
- `add` errors on a duplicate data-source name, and only updates `networks.json` when it exists

Cleanup:
- One field-name sanitizer (was three), one mapping generator (was two), shared version constants

Notes:
- Kept gnd's existing field-name conventions (camelCase, `eventId`) rather than graph-cli's (`internal_id`) — deliberate.
- Tuple/struct params and a codegen-time entity-vs-schema check are intentionally left for follow-up PRs.
