### PR TITLE
firehose: fix optimism check in extended blocks check

### DIFF
--- a/graph/src/firehose/endpoints.rs
+++ b/graph/src/firehose/endpoints.rs
@@ -89,13 +89,12 @@ impl NetworkDetails for Arc<FirehoseEndpoint> {
 
     async fn provides_extended_blocks(&self) -> anyhow::Result<bool> {
         let info = self.clone().info().await?;
-        let pred = if info.chain_name.contains("arbitrum-one")
-            || info.chain_name.contains("optimism-mainnet")
-        {
-            |x: &String| x.starts_with("extended") || x == "hybrid"
-        } else {
-            |x: &String| x == "extended"
-        };
+        let pred =
+            if info.chain_name.contains("arbitrum-one") || info.chain_name.contains("optimism") {
+                |x: &String| x.starts_with("extended") || x == "hybrid"
+            } else {
+                |x: &String| x == "extended"
+            };
 
         Ok(info.block_features.iter().any(pred))
     }


### PR DESCRIPTION
## Problem

`provides_extended_blocks()` matches on `optimism-mainnet`, while on Firehose endpoints by convention we are using `optimism` id from the [Networks Registry](https://github.com/graphprotocol/networks-registry/blob/191a07efa04e196a8859bcee7ce050d2459530d5/registry/eip155/optimism.json#L2). Same as in [Graph Explorer](https://thegraph.com/explorer?indexedNetwork=optimism) and elsewhere in The Graph ecosystem.
```
❯ grpcurl optimism.firehose.pinax.network:443 sf.firehose.v2.EndpointInfo/Info
{
  "chainName": "optimism",
  "chainNameAliases": [
    "evm-10",
    "op-mainnet",
    "optimism-mainnet"
  ],
  "firstStreamableBlockId": "7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b",
  "blockIdEncoding": "BLOCK_ID_ENCODING_HEX",
  "blockFeatures": [
    "hybrid",
    "extended@105235064"
  ]
}

❯ grpcurl -H "X-Api-Key: $SF_API_KEY" mainnet.optimism.streamingfast.io:443 sf.firehose.v2.EndpointInfo/Info
{
  "chainName": "optimism",
  "chainNameAliases": [
    "evm-10",
    "op-mainnet",
    "optimism-mainnet"
  ],
  "firstStreamableBlockId": "7ca38a1916c42007829c55e69d3e9a73265554b586a499015373241b8a3fa48b",
  "blockIdEncoding": "BLOCK_ID_ENCODING_HEX",
  "blockFeatures": [
    "hybrid",
    "extended@105235064"
  ]
}
```

This PR just changes the hardcoded value for Optimism but IMO the cleaner way would be to just check for `starts_with("extended")` without hardcoding Optimism and Arbitrum ONE chain names at all.

Can change to that if needed.