### PR TITLE
gnd: Restrict deploy key config permissions

### DIFF
--- a/gnd/src/commands/auth.rs
+++ b/gnd/src/commands/auth.rs
@@ -1,5 +1,11 @@
 use std::collections::HashMap;
 use std::fs;
+#[cfg(unix)]
+use std::fs::{OpenOptions, Permissions};
+#[cfg(unix)]
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
@@ -10,10 +16,10 @@ use url::Url;
 const SUBGRAPH_STUDIO_URL: &str = "https://api.studio.thegraph.com/deploy/";
 
 /// Get the path to the config file (~/.graph-cli.json)
-fn config_path() -> PathBuf {
-    std::env::home_dir()
-        .expect("Could not determine home directory")
-        .join(".graph-cli.json")
+fn config_path() -> Result<PathBuf> {
+    Ok(std::env::home_dir()
+        .context("Could not determine home directory")?
+        .join(".graph-cli.json"))
 }
 
 /// Normalize a node URL by parsing and re-serializing it
@@ -38,13 +44,37 @@ fn load_config_from(path: &PathBuf) -> Result<HashMap<String, String>> {
 /// Save the config file to a specific path
 fn save_config_to(path: &PathBuf, config: &HashMap<String, String>) -> Result<()> {
     let content = serde_json::to_string(config).context("Failed to serialize config")?;
-    fs::write(path, content)
-        .with_context(|| format!("Failed to write config file: {}", path.display()))
+
+    #[cfg(unix)]
+    {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(0o600)
+            .open(path)
+            .with_context(|| format!("Failed to open config file: {}", path.display()))?;
+
+        file.set_permissions(Permissions::from_mode(0o600))
+            .with_context(|| {
+                format!("Failed to set config file permissions: {}", path.display())
+            })?;
+        file.set_len(0)
+            .with_context(|| format!("Failed to truncate config file: {}", path.display()))?;
+        file.write_all(content.as_bytes())
+            .with_context(|| format!("Failed to write config file: {}", path.display()))
+    }
+
+    #[cfg(not(unix))]
+    {
+        fs::write(path, content)
+            .with_context(|| format!("Failed to write config file: {}", path.display()))
+    }
 }
 
 /// Save a deploy key for a node (uses default config path)
 pub fn save_deploy_key(node: &str, deploy_key: &str) -> Result<()> {
-    save_deploy_key_to(&config_path(), node, deploy_key)
+    save_deploy_key_to(&config_path()?, node, deploy_key)
 }
 
 /// Save a deploy key for a node to a specific config file
@@ -97,7 +127,7 @@ pub fn run_auth(opt: AuthOpt) -> Result<()> {
 
 /// Get the deploy key for a node, if one is saved (uses default config path)
 pub fn get_deploy_key(node: &str) -> Result<Option<String>> {
-    get_deploy_key_from(&config_path(), node)
+    get_deploy_key_from(&config_path()?, node)
 }
 
 /// Get the deploy key for a node from a specific config file
@@ -154,6 +184,41 @@ mod tests {
         assert_eq!(
             get_deploy_key_from(&config_file, node).unwrap(),
             Some(key.to_string())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_save_deploy_key_restricts_existing_file_permissions() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let config_file = temp_dir.path().join(".graph-cli.json");
+        let existing_node = "https://existing.example.com/";
+        let new_node = "https://new.example.com/";
+
+        fs::write(
+            &config_file,
+            serde_json::json!({ existing_node: "existing-key" }).to_string(),
+        )
+        .unwrap();
+        fs::set_permissions(&config_file, Permissions::from_mode(0o666)).unwrap();
+        assert_eq!(
+            fs::metadata(&config_file).unwrap().permissions().mode() & 0o777,
+            0o666
+        );
+
+        save_deploy_key_to(&config_file, new_node, "new-key").unwrap();
+
+        assert_eq!(
+            fs::metadata(&config_file).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(
+            get_deploy_key_from(&config_file, existing_node).unwrap(),
+            Some("existing-key".to_string())
+        );
+        assert_eq!(
+            get_deploy_key_from(&config_file, new_node).unwrap(),
+            Some("new-key".to_string())
         );
     }
 

--- a/gnd/src/commands/auth.rs
+++ b/gnd/src/commands/auth.rs
@@ -130,6 +130,25 @@ pub fn get_deploy_key(node: &str) -> Result<Option<String>> {
     get_deploy_key_from(&config_path()?, node)
 }
 
+/// Resolve an explicit access token or load the stored deploy key.
+pub(super) fn resolve_access_token(
+    access_token: Option<&str>,
+    node: &str,
+) -> Result<Option<String>> {
+    resolve_access_token_with_loader(access_token, node, get_deploy_key)
+}
+
+fn resolve_access_token_with_loader(
+    access_token: Option<&str>,
+    node: &str,
+    load_deploy_key: impl FnOnce(&str) -> Result<Option<String>>,
+) -> Result<Option<String>> {
+    match access_token {
+        Some(token) => Ok(Some(token.to_owned())),
+        None => load_deploy_key(node),
+    }
+}
+
 /// Get the deploy key for a node from a specific config file
 fn get_deploy_key_from(config_file: &PathBuf, node: &str) -> Result<Option<String>> {
     let normalized_node = normalize_node_url(node)?;
@@ -234,6 +253,34 @@ mod tests {
             get_deploy_key_from(&config_file, new_node).unwrap(),
             Some("new-key".to_string())
         );
+    }
+
+    #[test]
+    fn test_resolve_access_token_propagates_config_error() {
+        let result = resolve_access_token_with_loader(None, "https://example.com", |_| {
+            Err(anyhow::anyhow!("config unavailable"))
+        });
+
+        assert_eq!(result.unwrap_err().to_string(), "config unavailable");
+    }
+
+    #[test]
+    fn test_resolve_access_token_preserves_missing_key() {
+        let result =
+            resolve_access_token_with_loader(None, "https://example.com", |_| Ok(None)).unwrap();
+
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_resolve_access_token_prefers_explicit_token() {
+        let result =
+            resolve_access_token_with_loader(Some("explicit-token"), "https://example.com", |_| {
+                panic!("stored key lookup should not run")
+            })
+            .unwrap();
+
+        assert_eq!(result.as_deref(), Some("explicit-token"));
     }
 
     #[test]

--- a/gnd/src/commands/auth.rs
+++ b/gnd/src/commands/auth.rs
@@ -189,6 +189,20 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn test_save_deploy_key_creates_private_file() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let config_file = temp_dir.path().join(".graph-cli.json");
+
+        save_deploy_key_to(&config_file, "https://example.com/", "new-key").unwrap();
+
+        assert_eq!(
+            fs::metadata(&config_file).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn test_save_deploy_key_restricts_existing_file_permissions() {
         let temp_dir = tempfile::TempDir::new().unwrap();
         let config_file = temp_dir.path().join(".graph-cli.json");

--- a/gnd/src/commands/create.rs
+++ b/gnd/src/commands/create.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 
-use crate::commands::auth::get_deploy_key;
+use crate::commands::auth::resolve_access_token;
 use crate::services::GraphNodeClient;
 
 #[derive(Clone, Debug, Parser)]
@@ -25,13 +25,7 @@ pub async fn run_create(opt: CreateOpt) -> Result<()> {
     println!("Creating subgraph in Graph node: {}", opt.node);
 
     // Get access token (from flag or from config)
-    let access_token = match &opt.access_token {
-        Some(token) => Some(token.clone()),
-        None => get_deploy_key(&opt.node)
-            .ok()
-            .flatten()
-            .map(|key| key.to_string()),
-    };
+    let access_token = resolve_access_token(opt.access_token.as_deref(), &opt.node)?;
 
     let client = GraphNodeClient::new(&opt.node, access_token.as_deref())
         .context("Failed to create Graph Node client")?;

--- a/gnd/src/commands/remove.rs
+++ b/gnd/src/commands/remove.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 
-use crate::commands::auth::get_deploy_key;
+use crate::commands::auth::resolve_access_token;
 use crate::services::GraphNodeClient;
 
 #[derive(Clone, Debug, Parser)]
@@ -25,13 +25,7 @@ pub async fn run_remove(opt: RemoveOpt) -> Result<()> {
     println!("Removing subgraph from Graph node: {}", opt.node);
 
     // Get access token (from flag or from config)
-    let access_token = match &opt.access_token {
-        Some(token) => Some(token.clone()),
-        None => get_deploy_key(&opt.node)
-            .ok()
-            .flatten()
-            .map(|key| key.to_string()),
-    };
+    let access_token = resolve_access_token(opt.access_token.as_deref(), &opt.node)?;
 
     let client = GraphNodeClient::new(&opt.node, access_token.as_deref())
         .context("Failed to create Graph Node client")?;


### PR DESCRIPTION
## 1. What & Why

`gnd auth` stores deploy keys in `~/.graph-cli.json`. Before this change:

- Newly created files could inherit permissive mode bits.
- Existing group/world-readable files remained permissive after later writes.
- Missing-home and other auth configuration errors could be discarded by `gnd create` and `gnd remove`, causing those mutation requests to proceed without authentication.

On Unix, auth config writes now create files with mode `0600` and explicitly restrict existing files before modifying their contents. Home-directory lookup is fallible rather than panicking, and create/remove propagate stored-key lookup errors instead of converting them into anonymous requests.

## 2. Implementation and Behavior

Permission handling remains within `gnd/src/commands/auth.rs`:

- **Unix:** open/create without truncating, set mode `0600`, truncate, then write compact JSON.
- **Non-Unix:** retain the existing `fs::write` behavior.
- **Write ordering:** permissions are restricted before truncation so a permission-change failure leaves existing deploy keys intact.

Authentication resolution now consistently:

1. Uses an explicit `--access-token` when supplied.
2. Otherwise loads the stored deploy key.
3. Preserves `Ok(None)` as a legitimate unauthenticated configuration.
4. Propagates configuration lookup failures before constructing `GraphNodeClient`.

`gnd deploy` already propagated stored-key lookup errors and is unchanged. Existing config location, JSON format, node URL normalization, map merge behavior, CLI flags, and public APIs remain unchanged.

## 3. Review Guide

Suggested review order:

1. `gnd/src/commands/auth.rs`
   - Verify new and existing Unix files end with mode `0600`.
   - Confirm permissions are narrowed before existing contents are truncated.
   - Check fallible home-directory lookup and access-token resolution.
2. `gnd/src/commands/create.rs`
   - Confirm auth configuration errors stop the command before client construction.
3. `gnd/src/commands/remove.rs`
   - Confirm the same behavior for the destructive remove operation.
4. Tests in `gnd/src/commands/auth.rs`
   - Confirm permission behavior, existing-entry preservation, error propagation, `Ok(None)`, and explicit-token precedence.

### Reviewer checklist

- [ ] New Unix auth files are created as `0600`.
- [ ] Existing permissive files are narrowed before truncation.
- [ ] Existing config entries survive updates.
- [ ] Create/remove do not downgrade configuration errors to anonymous requests.
- [ ] Explicit access tokens bypass stored-key lookup.
- [ ] `Ok(None)` remains a valid unauthenticated result.
- [ ] The non-Unix fallback remains unchanged.

## 4. Risk and Non-Goals

The main risk is filesystem behavior across platforms. Unix behavior is covered directly; non-Unix continues using the previous implementation.

No atomic-write, locking, symlink-policy, directory-creation, credential-format, schema, CLI flag, or broader authentication-policy changes are intended.

## 5. Validation

- `just format`
- `just lint`
- `just check --release`
- `cargo test -p gnd commands::auth` — 9 passed
- `cargo test -p gnd --lib` — 273 passed

The full workspace `just test-unit` run requires the externally managed test configuration and services and was not available locally.
