### PR TITLE
chain/ethereum: Log reproducible call details on call failures 

### DIFF
--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -854,13 +854,28 @@ impl DataSource {
                         )
                     })?;
 
+                // Details that let a subgraph developer identify and reproduce the
+                // exact on-chain call that failed to decode. Shared by both the input
+                // and the output decoding errors below.
+                let call_context = format!(
+                    "contract: {:#x}, from: {:#x}, block: #{} ({:#x}), transaction: {}, \
+                    raw input: 0x{}",
+                    call.to,
+                    call.from,
+                    call.block_number,
+                    call.block_hash,
+                    call.transaction_hash
+                        .map(|hash| format!("{:#x}", hash))
+                        .unwrap_or_else(|| "none".to_string()),
+                    hex::encode(&call.input.0),
+                );
+
                 let values = match function_abi
                     .abi_decode_input(&call.input.0[4..])
                     .with_context(|| {
                         format!(
-                            "Generating function inputs for the call {:?} failed, raw input: {}",
-                            &function_abi,
-                            hex::encode(&call.input.0)
+                            "Generating function inputs for the call {:?} failed, {}",
+                            &function_abi, call_context
                         )
                     }) {
                     Ok(val) => val,
@@ -890,8 +905,10 @@ impl DataSource {
                     .abi_decode_output(&call.output.0)
                     .with_context(|| {
                         format!(
-                            "Decoding function outputs for the call {:?} failed, raw output: {}",
+                            "Decoding function outputs for the call {:?} failed, {}, \
+                            raw output: 0x{}",
                             &function_abi,
+                            call_context,
                             hex::encode(&call.output.0)
                         )
                     })?;

--- a/chain/ethereum/src/data_source.rs
+++ b/chain/ethereum/src/data_source.rs
@@ -874,8 +874,9 @@ impl DataSource {
                     .abi_decode_input(&call.input.0[4..])
                     .with_context(|| {
                         format!(
-                            "Generating function inputs for the call {:?} failed, {}",
-                            &function_abi, call_context
+                            "Generating function inputs for the call {} failed, {}",
+                            function_abi.signature_with_outputs(),
+                            call_context
                         )
                     }) {
                     Ok(val) => val,
@@ -905,9 +906,9 @@ impl DataSource {
                     .abi_decode_output(&call.output.0)
                     .with_context(|| {
                         format!(
-                            "Decoding function outputs for the call {:?} failed, {}, \
+                            "Decoding function outputs for the call {} failed, {}, \
                             raw output: 0x{}",
-                            &function_abi,
+                            function_abi.signature_with_outputs(),
                             call_context,
                             hex::encode(&call.output.0)
                         )

--- a/chain/ethereum/src/ethereum_adapter.rs
+++ b/chain/ethereum/src/ethereum_adapter.rs
@@ -1528,9 +1528,9 @@ impl EthereumAdapterTrait for EthereumAdapter {
 
             trace!(logger, "eth_call";
                 "fn" => &call.function.name,
-                "address" => hex::encode(call.address),
-                "data" => hex::encode(req.encoded_call.as_ref()),
-                "block_hash" => call.block_ptr.hash_hex(),
+                "address" => format!("{:#x}", call.address),
+                "data" => format!("0x{}", hex::encode(req.encoded_call.as_ref())),
+                "block_hash" => format!("0x{}", call.block_ptr.hash_hex()),
                 "block_number" => call.block_ptr.block_number()
             );
             Ok(req)
@@ -1544,8 +1544,13 @@ impl EthereumAdapterTrait for EthereumAdapter {
             let call::Response {
                 retval,
                 source,
-                req: _,
+                req,
             } = resp;
+            // Details of the `eth_call` that failed, so that it can be reproduced by
+            // hand. Mirrors the field names used by the `eth_call` trace above.
+            let address = format!("{:#x}", req.address);
+            let data = format!("0x{}", hex::encode(req.encoded_call.as_ref()));
+            let block_hash = format!("0x{}", call.block_ptr.hash_hex());
             match retval {
                 call::Retval::Value(output) => match call.function.abi_decode_output(&output) {
                     Ok(tokens) => (Some(tokens), source),
@@ -1553,7 +1558,15 @@ impl EthereumAdapterTrait for EthereumAdapter {
                         // Decode failures are reverts. The reasoning is that if Solidity fails to
                         // decode an argument, that's a revert, so the same goes for the output.
                         let reason = format!("failed to decode output: {}", e);
-                        info!(logger, "Contract call reverted"; "reason" => reason);
+                        info!(logger, "Contract call reverted";
+                            "reason" => reason,
+                            "fn" => &call.function.name,
+                            "address" => address,
+                            "data" => data,
+                            "output" => format!("0x{}", hex::encode(&output)),
+                            "block_hash" => block_hash,
+                            "block_number" => call.block_ptr.block_number()
+                        );
                         (None, call::Source::Rpc)
                     }
                 },
@@ -1561,33 +1574,64 @@ impl EthereumAdapterTrait for EthereumAdapter {
                     // We got a `0x` response. For old Geth, this can mean a revert. It can also be
                     // that the contract actually returned an empty response. A view call is meant
                     // to return something, so we treat empty responses the same as reverts.
-                    info!(logger, "Contract call reverted"; "reason" => "empty response");
+                    info!(logger, "Contract call reverted";
+                        "reason" => "empty response",
+                        "fn" => &call.function.name,
+                        "address" => address,
+                        "data" => data,
+                        "output" => "0x",
+                        "block_hash" => block_hash,
+                        "block_number" => call.block_ptr.block_number()
+                    );
                     (None, call::Source::Rpc)
                 }
             }
         }
 
         fn log_call_error(logger: &ProviderLogger, e: &ContractCallError, call: &ContractCall) {
+            // Identify the call that failed so it can be reproduced by hand. The
+            // calldata is re-encoded here because the request may have failed before
+            // one was built; encoding errors are reported rather than propagated
+            // since this is only ever run on an error path.
+            let address = format!("{:#x}", call.address);
+            let data = match call.function.abi_encode_input(&call.args) {
+                Ok(encoded) => format!("0x{}", hex::encode(encoded)),
+                Err(e) => format!("<failed to encode: {}>", e),
+            };
+            let block_hash = format!("0x{}", call.block_ptr.hash_hex());
+            let block_number = call.block_ptr.block_number();
             match e {
                 ContractCallError::AlloyError(e) => error!(
                     logger,
                     "Ethereum node returned an error when calling function \"{}\" of contract \"{}\": {}",
                     call.function.name,
                     call.contract_name,
-                    e
+                    e;
+                    "address" => address,
+                    "data" => data,
+                    "block_hash" => block_hash,
+                    "block_number" => block_number
                 ),
                 ContractCallError::Timeout => error!(
                     logger,
                     "Ethereum node did not respond when calling function \"{}\" of contract \"{}\"",
                     call.function.name,
-                    call.contract_name
+                    call.contract_name;
+                    "address" => address,
+                    "data" => data,
+                    "block_hash" => block_hash,
+                    "block_number" => block_number
                 ),
                 _ => error!(
                     logger,
                     "Failed to call function \"{}\" of contract \"{}\": {}",
                     call.function.name,
                     call.contract_name,
-                    e
+                    e;
+                    "address" => address,
+                    "data" => data,
+                    "block_hash" => block_hash,
+                    "block_number" => block_number
                 ),
             }
         }


### PR DESCRIPTION
Fixes #3404.

### Problem

When a call handler fails to decode its trigger, the error tells you the function
ABI and nothing else:

```
failed to process trigger: block #21041413 (0x0000…b378), transaction a44fa185…:
Decoding function outputs for the call Function { name: "withdraw", inputs: [],
outputs: [Param { name: "", kind: Uint(256), internal_type: None }],
constant: None, state_mutability: NonPayable } failed, raw output: :
Invalid name: please ensure the contract and method you're calling exist!
```

There is no contract address and no calldata, so you cannot retry the call to see
what happened. `raw output:` has nothing after it, which looks like a broken
format string. What it actually means is that the call returned no data.

The address is already available where this error is raised. `data_source.rs`
builds a `logging_extras` block with the contract address and transaction hash in
the same `EthereumTrigger::Call` arm, but it builds it after both decode errors
have returned, so those errors never get it.

The `eth_call` path has the same problem for a different reason. `decode()` in
`ethereum_adapter.rs` threw away the request:

```rust
let call::Response { retval, source, req: _ } = resp;
```

`req` is the `call::Request`, and it holds the address and the encoded calldata.
Both failure branches then logged just a reason:

```rust
info!(logger, "Contract call reverted"; "reason" => "empty response");
```

There is already a log line with the right fields (`fn`, `address`, `data`,
`block_hash`, `block_number`), but it is on the success path and it is `trace!`,
so it is not there when a call fails in production.

### Fix

`chain/ethereum/src/data_source.rs`: build one context string in the
`EthereumTrigger::Call` arm with the contract address, `from`, block number and
hash, transaction hash and calldata, and use it in both decode errors. That way
the field list is not written twice and the calldata is not printed twice. Hex is
`0x`-prefixed so you can paste it into an RPC request. Empty output now prints as
`0x`. A missing `transaction_hash` prints as `none` instead of `None`.

`chain/ethereum/src/ethereum_adapter.rs`: keep `req` and log its address and
calldata on both revert branches, along with `fn`, `output`, `block_hash` and
`block_number`. These are slog key/value fields and use the same names as the
existing `eth_call` trace. `log_call_error` gets the same fields. I also
`0x`-prefixed the existing trace so both lines look the same.

The second commit swaps the `{:?}` dump of the function for
`Function::signature_with_outputs()`. It is a separate commit so you can drop it
if you think it does not belong here.

### Result

Before:

```
Decoding function outputs for the call Function { name: "withdraw", inputs: [],
outputs: [Param { name: "", kind: Uint(256), internal_type: None }],
constant: None, state_mutability: NonPayable } failed, raw output: : Invalid name: ...
```

After:

```
Decoding function outputs for the call withdraw()(uint256) failed,
contract: 0x5f4ec3df…, from: 0x1f98431c…, block: #21041413 (0x0000…b378),
transaction: 0xa44fa185…, raw input: 0x3ccfd60b, raw output: 0x : Invalid name: ...
```

It is shorter than before and you can rebuild the call from it.

### Verification

The second commit changes the text of an error that can become a deterministic
subgraph failure, so I checked whether that text is used in Proof of Indexing. It
is not. `ProofOfIndexingEvent::DeterministicError` only holds
`redacted_events: u64` and has no message field, and both `StableHash` impls hash
only that number (`graph/src/components/subgraph/proof_of_indexing/event.rs`). The
only place it is written is `core/src/subgraph/trigger_processor.rs`, which passes
a count from `deterministic_errors.len()` and never the error itself. So this does
not break consensus.

It does change the id of rows in the local `subgraph_error` table, because
`insert_subgraph_error` hashes the message into the primary key. That id is local
to one node and the insert uses `on_conflict_do_nothing`.

This only touches logging. No changes to control flow, error variants,
determinism classification (`Deterministic` vs `PossibleReorg`), or whether a call
counts as a revert.

Checks I ran: `cargo fmt --all -- --check`,
`cargo clippy -p graph-chain-ethereum -- -D warnings` (no warnings),
`cargo test -p graph-chain-ethereum` (59 passed), and
`cargo check --workspace --all-targets`.

### One question

`"Contract call reverted"` is `info!`, and reverts are common rather than rare.
Subgraphs that probe `symbol()` or `decimals()` on odd tokens, or use `try_` calls
that are meant to revert, will hit it a lot. This adds about 150 to 250 bytes per
line. I can drop `block_hash`, since you can get the block from `block_number`, or
move the calldata to `debug!` if that is too much.