### PR TITLE
v0.45.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "gnd"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "graph"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "Inflector",
  "ahash",
@@ -3971,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-common"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-ethereum"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4007,7 +4007,7 @@ dependencies = [
 
 [[package]]
 name = "graph-chain-near"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4024,7 +4024,7 @@ dependencies = [
 
 [[package]]
 name = "graph-core"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "graph-graphql"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4071,7 +4071,7 @@ dependencies = [
 
 [[package]]
 name = "graph-node"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-derive"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-test"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "async-trait",
  "graph",
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "graph-runtime-wasm"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-http"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "async-trait",
  "graph",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-index-node"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "async-trait",
  "blake3 1.8.5",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "graph-server-json-rpc"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "axum",
  "graph",
@@ -4184,14 +4184,14 @@ dependencies = [
 
 [[package]]
 name = "graph-server-metrics"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "graph",
 ]
 
 [[package]]
 name = "graph-store-postgres"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -4234,7 +4234,7 @@ dependencies = [
 
 [[package]]
 name = "graph-tests"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "graph_derive"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "proc-macro-utils",
  "proc-macro2",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "graphman"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "diesel",
@@ -4285,7 +4285,7 @@ dependencies = [
 
 [[package]]
 name = "graphman-server"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "graphman-store"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8191,7 +8191,7 @@ dependencies = [
 
 [[package]]
 name = "test-store"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "async-trait",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.44.0"
+version = "0.45.0"
 edition = "2024"
 authors = ["The Graph core developers & contributors"]
 readme = "README.md"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,50 @@
 # NEWS
 
+## v0.45.0
+
+```
+$ docker pull graphprotocol/graph-node:v0.45.0
+```
+
+### Breaking Changes
+
+- **`GRAPH_GETH_ETH_CALL_ERRORS` renamed to `GRAPH_RPC_ETH_CALL_ERRORS`.** The env var (and internal config field) controlling which `eth_call` error messages are treated as reverts is renamed for provider-neutral naming. Update it before upgrading, or the setting is silently ignored and defaults apply. ([#6487](https://github.com/graphprotocol/graph-node/pull/6487))
+
+### What's New
+
+- **Postponed attribute index creation re-enabled, now built in the background.** `GRAPH_POSTPONE_ATTRIBUTE_INDEX_CREATION` (introduced in v0.44.0 but inert — hardcoded off) now actually defers non-critical attribute indexes until a new deployment nears chain head (`GRAPH_POSTPONE_INDEXES_CREATION_THRESHOLD`, default 10000 blocks from head). Index creation now runs in a background task instead of blocking block processing, and interrupted `CREATE INDEX CONCURRENTLY` runs are detected and rebuilt on retry instead of being silently skipped. ([#6608](https://github.com/graphprotocol/graph-node/pull/6608))
+- **`ethereum.decodeParams` host function.** Decodes calldata/event data whose top-level type is a dynamic tuple (e.g. Gnosis Safe's `execTransaction`), which `ethereum.decode` cannot handle since it expects a single ABI value with a leading offset word. Gated behind apiVersion 0.0.10; `ethereum.decode` itself is unchanged. ([#6649](https://github.com/graphprotocol/graph-node/pull/6649))
+
+### Bug Fixes
+
+- Fixed `EthereumLogFilter` merging per-handler `receipt` flags with overwrite instead of OR semantics, so a handler declaring `receipt: true` could silently run with `event.receipt == null` if another handler on the same filter key declared `receipt: false`. ([#6558](https://github.com/graphprotocol/graph-node/pull/6558))
+- Fixed grafts silently succeeding when the graft block was below the base deployment's earliest available block, leaving the destination missing pre-graft entity versions and producing `unexpected null in handler` errors on every event; `Graft::validate` now rejects these upfront. ([#6610](https://github.com/graphprotocol/graph-node/pull/6610))
+- Fixed `_logs` queries returning an empty result (indistinguishable from a subgraph producing no logs) when no log store is configured; now returns a `NotSupported` error. ([#6637](https://github.com/graphprotocol/graph-node/pull/6637))
+- Fixed startup panicking when a shard is configured with `pool_size = 0`; such shards' chains are now skipped instead of erroring. ([#6648](https://github.com/graphprotocol/graph-node/pull/6648))
+- Fixed the Firehose extended-blocks check matching on `optimism-mainnet` instead of the `optimism` chain ID used by Firehose endpoints, so Optimism's extended block data went undetected. ([#6662](https://github.com/graphprotocol/graph-node/pull/6662))
+- Fixed fulltext (`tsvector`) search columns being silently dropped when copying or grafting a subgraph, leaving the destination's fulltext index empty. ([#6687](https://github.com/graphprotocol/graph-node/pull/6687))
+- Fixed Reth `StackUnderflow`/`StackOverflow`/`OpcodeNotFound` EVM halts being misclassified as non-deterministic — Reth surfaces them via its `Debug` format (e.g. `EVM error: StackUnderflow`), which didn't match graph-node's space-separated deterministic-error patterns, so subgraphs indexing via Reth-backed RPC providers stalled and retried instead of recording a deterministic revert. ([#6645](https://github.com/graphprotocol/graph-node/pull/6645))
+
+### Graphman
+
+- Fixed `graphman dump` panicking on tables with more than ~2 GiB in a single string/binary column; batches are now split into byte-bounded slices before conversion to Arrow. ([#6646](https://github.com/graphprotocol/graph-node/pull/6646))
+
+### gnd (Graph Node Dev)
+
+- Fixed `gnd add` producing a subgraph that failed `codegen`/`build` because it never wrote new event entities to `schema.graphql`; unified `add` and `init` onto one scaffolding path, which also fixes event-name collisions across data sources, overloaded-event disambiguation, small-integer type mapping, and reserved-word parameter names. ([#6660](https://github.com/graphprotocol/graph-node/pull/6660))
+
+### Upgrade Notes
+
+- If you set `GRAPH_GETH_ETH_CALL_ERRORS`, rename it to `GRAPH_RPC_ETH_CALL_ERRORS` before upgrading. ([#6487](https://github.com/graphprotocol/graph-node/pull/6487))
+- `GRAPH_POSTPONE_ATTRIBUTE_INDEX_CREATION` now actually takes effect (it was a no-op in v0.44.0). If you already set it expecting no behavior change, be aware new deployments will now defer some attribute indexes until near chain head. ([#6608](https://github.com/graphprotocol/graph-node/pull/6608))
+- If a subgraph was grafted from a base block below the base deployment's earliest available block before this release, it may be missing pre-graft entity versions; re-create the graft from a valid earliest block. ([#6610](https://github.com/graphprotocol/graph-node/pull/6610))
+
+### Contributors
+
+Thanks to all contributors for this release: @cargopete, @dimitrovmaksim, @fordN, @incrypto32, @lutter, @YaroShkvorets
+
+**Full Changelog**: https://github.com/graphprotocol/graph-node/compare/v0.44.0...v0.45.0
+
 ## v0.44.0
 
 ```


### PR DESCRIPTION
Version bump and release notes for v0.45.0.

- Bumps workspace version to 0.45.0
- Adds NEWS.md entry for v0.45.0