### PR TITLE
ci: bind gnd-binary-build workflow inputs via env before shell

### DIFF
--- a/.github/workflows/gnd-binary-build.yml
+++ b/.github/workflows/gnd-binary-build.yml
@@ -366,5 +366,8 @@ jobs:
           EOF
 
       - name: Publish
-        run: npm publish --provenance --access public --tag ${{ steps.version.outputs.tag }} ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          DRY_RUN_FLAG: ${{ inputs.dry_run && '--dry-run' || '' }}
+          NPM_TAG: ${{ steps.version.outputs.tag }}
+        run: npm publish --provenance --access public --tag "$NPM_TAG" $DRY_RUN_FLAG
         working-directory: pkg

--- a/.github/workflows/gnd-binary-build.yml
+++ b/.github/workflows/gnd-binary-build.yml
@@ -160,8 +160,9 @@ jobs:
       - name: Upload Assets to Release
         env:
           VERSION: ${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload $VERSION --clobber --repo $GITHUB_REPOSITORY \
+          gh release upload "$VERSION" --clobber --repo "$GITHUB_REPOSITORY" \
             artifacts/gnd-linux-x86_64/gnd-linux-x86_64.gz \
             artifacts/gnd-linux-aarch64/gnd-linux-aarch64.gz \
             artifacts/gnd-macos-x86_64/gnd-macos-x86_64.gz \

--- a/.github/workflows/gnd-binary-build.yml
+++ b/.github/workflows/gnd-binary-build.yml
@@ -158,9 +158,9 @@ jobs:
         run: ls -R artifacts
 
       - name: Upload Assets to Release
+        env:
+          VERSION: ${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}
         run: |
-          VERSION="${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}"
-
           gh release upload $VERSION --clobber --repo $GITHUB_REPOSITORY \
             artifacts/gnd-linux-x86_64/gnd-linux-x86_64.gz \
             artifacts/gnd-linux-aarch64/gnd-linux-aarch64.gz \
@@ -215,16 +215,20 @@ jobs:
       - name: Download gnd binary
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}
+          MATRIX_ASSET: ${{ matrix.asset }}
         run: |
-          gh release download "${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}" \
+          gh release download "$VERSION" \
             --repo "${{ github.repository }}" \
-            --pattern "${{ matrix.asset }}" \
+            --pattern "$MATRIX_ASSET" \
             --output ./binary-archive
 
       - name: Extract binary
+        env:
+          MATRIX_EXTRACT: ${{ matrix.extract }}
         run: |
           mkdir -p pkg/bin
-          if [ "${{ matrix.extract }}" = "gunzip" ]; then
+          if [ "$MATRIX_EXTRACT" = "gunzip" ]; then
             gunzip -c ./binary-archive > pkg/bin/gnd
             chmod +x pkg/bin/gnd
           else
@@ -235,8 +239,9 @@ jobs:
       - name: Determine version and npm tag
         id: version
         shell: bash
+        env:
+          VERSION: ${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}
         run: |
-          VERSION="${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}"
           VERSION="${VERSION#v}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           # Prerelease versions (e.g. 0.42.2-dev.1) need an explicit --tag
@@ -251,8 +256,13 @@ jobs:
 
       - name: Create package.json
         shell: bash
+        env:
+          MATRIX_OS_FIELD: ${{ matrix.os_field }}
+          MATRIX_PLATFORM: ${{ matrix.platform }}
+          MATRIX_CPU_FIELD: ${{ matrix.cpu_field }}
+          PKG_VERSION: ${{ steps.version.outputs.version }}
         run: |
-          if [ "${{ matrix.os_field }}" = "win32" ]; then
+          if [ "${MATRIX_OS_FIELD}" = "win32" ]; then
             BIN_PATH="./bin/gnd.exe"
           else
             BIN_PATH="./bin/gnd"
@@ -260,11 +270,11 @@ jobs:
 
           cat > pkg/package.json << EOF
           {
-            "name": "@graphprotocol/gnd-${{ matrix.platform }}",
-            "version": "${{ steps.version.outputs.version }}",
-            "description": "gnd binary for ${{ matrix.platform }}",
-            "os": ["${{ matrix.os_field }}"],
-            "cpu": ["${{ matrix.cpu_field }}"],
+            "name": "@graphprotocol/gnd-${MATRIX_PLATFORM}",
+            "version": "${PKG_VERSION}",
+            "description": "gnd binary for ${MATRIX_PLATFORM}",
+            "os": ["${MATRIX_OS_FIELD}"],
+            "cpu": ["${MATRIX_CPU_FIELD}"],
             "bin": {
               "gnd": "${BIN_PATH}"
             },
@@ -281,7 +291,10 @@ jobs:
           EOF
 
       - name: Publish
-        run: npm publish --provenance --access public --tag ${{ steps.version.outputs.tag }} ${{ inputs.dry_run && '--dry-run' || '' }}
+        env:
+          DRY_RUN_FLAG: ${{ inputs.dry_run && '--dry-run' || '' }}
+          NPM_TAG: ${{ steps.version.outputs.tag }}
+        run: npm publish --provenance --access public --tag "$NPM_TAG" $DRY_RUN_FLAG
         working-directory: pkg
 
   publish-npm-wrapper:
@@ -302,8 +315,9 @@ jobs:
       - name: Determine version and npm tag
         id: version
         shell: bash
+        env:
+          VERSION: ${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}
         run: |
-          VERSION="${{ inputs.release_tag != '' && inputs.release_tag || github.ref_name }}"
           VERSION="${VERSION#v}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           if [[ "$VERSION" == *-* ]]; then


### PR DESCRIPTION
## Summary
- Bind `inputs.release_tag` (with `github.ref_name` fallback) through `env:` before release upload/download/version shell steps.
- Bind related matrix/step values and `inputs.dry_run` through `env:` before extract/package/publish shell steps.
- Same class as GitHub’s documented script-injection guidance for interpolating workflow inputs into `run:` scripts.

## Test plan
- [ ] Tag/release upload still publishes the expected gnd artifacts
- [ ] npm platform packages and wrapper still resolve version/tag correctly
- [ ] `dry_run` still adds `--dry-run` to npm publish when set


Made with [Cursor](https://cursor.com)