### PR TITLE
fix(store): deterministic LFU cache eviction (tie-break by key)

### DIFF
--- a/graph/src/util/lfu_cache.rs
+++ b/graph/src/util/lfu_cache.rs
@@ -54,9 +54,13 @@ impl<K: CacheWeight, V: Default + CacheWeight> CacheEntry<K, V> {
     }
 }
 
-// The priorities are `(stale, frequency)` tuples, first all stale entries will be popped and
-// then non-stale entries by least frequency.
-type Priority = (bool, Reverse<u64>);
+// The priorities are `(stale, frequency, key)` triples. First all stale entries will be popped
+// and then non-stale entries by least frequency. Ties on the first two components are broken by
+// the key so that eviction is deterministic and independent of the order in which entries were
+// inserted; without the key tie-breaker the `PriorityQueue` would break ties by heap position,
+// which depends on insertion order and therefore makes the eviction set differ between otherwise
+// identical runs. See https://github.com/graphprotocol/graph-node/issues/6706
+type Priority<K> = (bool, Reverse<u64>, Reverse<K>);
 
 /// Statistics about what happened during cache eviction
 pub struct EvictStats {
@@ -96,7 +100,7 @@ impl EvictStats {
 /// evictions entities are checked for staleness.
 #[derive(Debug)]
 pub struct LfuCache<K: Eq + Hash, V> {
-    queue: PriorityQueue<CacheEntry<K, V>, Priority>,
+    queue: PriorityQueue<CacheEntry<K, V>, Priority<K>>,
     total_weight: usize,
     stale_counter: u64,
     dead_weight: bool,
@@ -135,6 +139,9 @@ impl<K: Clone + Ord + Eq + Hash + Debug + CacheWeight, V: CacheWeight + Default>
         match self.get_mut(key.clone()) {
             None => {
                 self.total_weight += weight;
+                // Clone the key once more to break eviction-priority ties
+                // deterministically; see `type Priority<K>`.
+                let tie_break_key = key.clone();
                 self.queue.push(
                     CacheEntry {
                         weight,
@@ -142,7 +149,7 @@ impl<K: Clone + Ord + Eq + Hash + Debug + CacheWeight, V: CacheWeight + Default>
                         value,
                         will_stale: false,
                     },
-                    (false, Reverse(1)),
+                    (false, Reverse(1), Reverse(tie_break_key)),
                 );
             }
             Some(entry) => {
@@ -168,7 +175,7 @@ impl<K: Clone + Ord + Eq + Hash + Debug + CacheWeight, V: CacheWeight + Default>
         // Increment the frequency by 1
         let key_entry = CacheEntry::cache_key(key);
         self.queue
-            .change_priority_by(&key_entry, |(_, Reverse(f))| {
+            .change_priority_by(&key_entry, |(_, Reverse(f), _)| {
                 *f += 1;
             });
         self.accesses += 1;
@@ -194,7 +201,7 @@ impl<K: Clone + Ord + Eq + Hash + Debug + CacheWeight, V: CacheWeight + Default>
         // the absolute minimum and popping.
         let key_entry = CacheEntry::cache_key(key.clone());
         self.queue
-            .change_priority(&key_entry, (true, Reverse(u64::MIN)))
+            .change_priority(&key_entry, (true, Reverse(u64::MIN), Reverse(key.clone())))
             .and_then(|_| {
                 self.queue.pop().map(|(e, _)| {
                     assert_eq!(e.key, key_entry.key);
@@ -306,7 +313,7 @@ impl<K: Clone + Ord + Eq + Hash + Debug + CacheWeight, V: CacheWeight + Default>
 }
 
 impl<K: Ord + Eq + Hash + 'static, V: 'static> IntoIterator for LfuCache<K, V> {
-    type Item = (CacheEntry<K, V>, Priority);
+    type Item = (CacheEntry<K, V>, Priority<K>);
     type IntoIter = Box<dyn Iterator<Item = Self::Item>>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -314,8 +321,8 @@ impl<K: Ord + Eq + Hash + 'static, V: 'static> IntoIterator for LfuCache<K, V> {
     }
 }
 
-impl<K: Ord + Eq + Hash, V> Extend<(CacheEntry<K, V>, Priority)> for LfuCache<K, V> {
-    fn extend<T: IntoIterator<Item = (CacheEntry<K, V>, Priority)>>(&mut self, iter: T) {
+impl<K: Ord + Eq + Hash, V> Extend<(CacheEntry<K, V>, Priority<K>)> for LfuCache<K, V> {
+    fn extend<T: IntoIterator<Item = (CacheEntry<K, V>, Priority<K>)>>(&mut self, iter: T) {
         self.queue.extend(iter);
     }
 }

--- a/graph/tests/lfu_cache_determinism.rs
+++ b/graph/tests/lfu_cache_determinism.rs
@@ -1,0 +1,50 @@
+//! Regression test for https://github.com/graphprotocol/graph-node/issues/6706
+//!
+//! Eviction ties on the `(stale, frequency)` priority are the normal case, not
+//! the exception. Which of the tied entries is evicted must not depend on the
+//! order in which they were inserted: a caller can insert entries in an order
+//! that is nondeterministic per process (e.g. when iterating a `HashMap` whose
+//! iteration order is randomized per process), and that would otherwise make
+//! the eviction set — and therefore cache hit rates / store read counts —
+//! differ between otherwise identical runs.
+
+use graph::prelude::CacheWeight;
+use graph::util::lfu_cache::LfuCache;
+
+#[derive(Default, Debug, PartialEq, Eq)]
+struct Weight(usize);
+
+impl CacheWeight for Weight {
+    fn weight(&self) -> usize {
+        self.indirect_weight()
+    }
+
+    fn indirect_weight(&self) -> usize {
+        self.0
+    }
+}
+
+/// Insert the same six entries, each of equal weight and frequency 1, so every
+/// eviction candidate is tied on the priority, evict down to a max weight that
+/// leaves two entries, and return the surviving keys.
+fn survivors_in_order(order: &[&str]) -> Vec<String> {
+    let mut cache: LfuCache<String, Weight> = LfuCache::new();
+    for &key in order {
+        cache.insert(key.to_string(), Weight(1));
+    }
+    cache.evict(6);
+    let mut survivors: Vec<String> = cache.iter().map(|(k, _)| k.clone()).collect();
+    survivors.sort();
+    survivors
+}
+
+#[test]
+fn eviction_is_independent_of_insertion_order() {
+    let order_a = ["k1", "k2", "k3", "k4", "k5", "k6"];
+    let order_b = ["k6", "k5", "k4", "k3", "k2", "k1"];
+    let order_c = ["k3", "k6", "k2", "k5", "k1", "k4"];
+
+    let reference = survivors_in_order(&order_a);
+    assert_eq!(survivors_in_order(&order_b), reference);
+    assert_eq!(survivors_in_order(&order_c), reference);
+}


### PR DESCRIPTION
## Root cause (issue #6706)

`EntityCache`'s LFU cache (`LfuCache` in `graph/src/util/lfu_cache.rs`) evicts a *different set of entries* on every process for the same deployment, the same blocks and the same binary.

The chain, as analyzed in the issue:
1. `EntityCache.updates` is a `std::collections::HashMap` (RandomState, seeded once per process), so `as_modifications` iterates it in a different order on every run.
2. That iteration order becomes the LFU insertion order: entities are (re-)inserted into `self.current` as the loop runs (`graph/src/components/store/entity_cache.rs`).
3. `LfuCache` uses a `priority_queue::PriorityQueue` whose eviction priority is `(stale, Reverse<frequency>)`. Ties on that priority are the normal case, not the exception — within one block the overwhelming majority of entries sit at exactly `(false, Reverse(1))`.
4. `PriorityQueue::pop()` breaks priority ties by heap position, which is determined by insertion order. So which tied entry is evicted depends on the random HashMap iteration order → different eviction sets per process.

The indexing **result** is unaffected (entity data, modification counts, PoI digests are identical across runs); what moves is *provenance* — which reads are served from the cache vs. from the store. That makes cache hit rate and store read counts non-reproducible between otherwise identical runs (see the issue's measurements).

## The fix

Break eviction-priority ties deterministically on the cache key. The priority type becomes `(stale, Reverse<frequency>, Reverse<K>)`. Keys are unique in the cache and `K: Ord`, so the priority is now a strict total order and `PriorityQueue::pop()` no longer falls back to the insertion-order-dependent heap layout for ties.

This fixes all callers of `LfuCache` at once (today that is `EntityCache` via the `EntityLfuCache` alias), regardless of the order in which they insert entries.

## Test

Adds `graph/tests/lfu_cache_determinism.rs` → `eviction_is_independent_of_insertion_order`: insert the same six entries (equal weight, equal frequency → every candidate tied), in three different orders, evict down to a fixed max weight, and assert the same entries survive each time. On the old code the eviction set changes with insertion order (the test fails); on the new code it is deterministic.

## Scope note

* Indexing output (modifications, PoI digests) is unchanged — this only makes read-path counters (cache hit rate, store read volume) reproducible.
* The tie-break policy is "evict the lexicographically smallest key among equal `(stale, frequency)` entries". The specific order is arbitrary; the important property is that it is deterministic.
* Memory: the priority now holds one extra copy of the key per entry. `EntityKey` is interned/cheap to clone (an `InputSchema` handle + interned atoms + `CausalityRegion(i32)` + an interned `Id`), so the per-entry overhead is on the order of a small struct and is not counted toward `max_weight`. If that is a concern for very large caches, a caller-side fix (deterministically ordered iteration in `as_modifications`) could be layered on, but the cache-level fix is sufficient and covers every caller.