### PR TITLE
fix(store): cast entity id to bytea in FindPossibleDeletionsQuery UNION

### DIFF
--- a/store/postgres/src/relational/query_tests.rs
+++ b/store/postgres/src/relational/query_tests.rs
@@ -13,7 +13,9 @@ use crate::{
     block_range::BoundSide,
     layout_for_tests::{Namespace, make_dummy_site},
     relational::{Catalog, ColumnType, Layout},
-    relational_queries::{FindRangeQuery, FromColumnValue, InsertQuery},
+    relational_queries::{
+        FindPossibleDeletionsQuery, FindRangeQuery, FromColumnValue, InsertQuery,
+    },
 };
 
 use crate::relational_queries::Filter;
@@ -189,6 +191,112 @@ fn test_id_type_casting(table: &crate::relational::Table, expected_cast: &str, t
 
     let tables = vec![table];
     let query = FindRangeQuery::new(&tables, causality_region, bound_side, block_range);
+    let sql = debug_query::<Pg, _>(&query).to_string();
+
+    assert!(
+        sql.contains(expected_cast),
+        "{}: Expected '{}' in SQL, got: {}",
+        test_name,
+        expected_cast,
+        sql
+    );
+}
+
+#[test]
+fn find_possible_deletions_query_id_type_casting() {
+    let string_schema = "
+    type StringEntity @entity {
+        id: String!,
+        name: String
+    }";
+
+    let bytes_schema = "
+    type BytesEntity @entity {
+        id: Bytes!,
+        address: Bytes
+    }";
+
+    let int8_schema = "
+    type Int8Entity @entity {
+        id: Int8!,
+        value: Int8
+    }";
+
+    let string_layout = test_layout(string_schema);
+    let bytes_layout = test_layout(bytes_schema);
+    let int8_layout = test_layout(int8_schema);
+
+    let string_table = string_layout
+        .table_for_entity(
+            &string_layout
+                .input_schema
+                .entity_type("StringEntity")
+                .unwrap(),
+        )
+        .unwrap();
+    let bytes_table = bytes_layout
+        .table_for_entity(
+            &bytes_layout
+                .input_schema
+                .entity_type("BytesEntity")
+                .unwrap(),
+        )
+        .unwrap();
+    let int8_table = int8_layout
+        .table_for_entity(&int8_layout.input_schema.entity_type("Int8Entity").unwrap())
+        .unwrap();
+
+    test_possible_deletions_id_type_casting(
+        string_table.as_ref(),
+        "e.id::bytea",
+        "String ID should be cast to bytea",
+    );
+    test_possible_deletions_id_type_casting(
+        bytes_table.as_ref(),
+        "e.id",
+        "Bytes ID should remain as e.id",
+    );
+    test_possible_deletions_id_type_casting(
+        int8_table.as_ref(),
+        "e.id::text::bytea",
+        "Int8 ID should be cast to text then bytea",
+    );
+
+    let tables = vec![
+        string_table.as_ref(),
+        bytes_table.as_ref(),
+        int8_table.as_ref(),
+    ];
+    let query = FindPossibleDeletionsQuery::new(&tables, 100);
+    let sql = debug_query::<Pg, _>(&query).to_string();
+
+    assert!(
+        sql.contains("id::bytea"),
+        "String entity ID casting should be present in possible-deletions UNION query, got: {}",
+        sql
+    );
+    assert!(
+        sql.contains("e.id"),
+        "Bytes entity ID should be present in possible-deletions UNION query"
+    );
+    assert!(
+        sql.contains("id::text::bytea"),
+        "Int8 entity ID casting should be present in possible-deletions UNION query, got: {}",
+        sql
+    );
+    assert!(
+        sql.contains("union all"),
+        "Multiple tables should generate UNION ALL queries"
+    );
+}
+
+fn test_possible_deletions_id_type_casting(
+    table: &crate::relational::Table,
+    expected_cast: &str,
+    test_name: &str,
+) {
+    let tables = vec![table];
+    let query = FindPossibleDeletionsQuery::new(&tables, 100);
     let sql = debug_query::<Pg, _>(&query).to_string();
 
     assert!(

--- a/store/postgres/src/relational_queries.rs
+++ b/store/postgres/src/relational_queries.rs
@@ -2090,7 +2090,18 @@ impl<'a> QueryFragment<Pg> for FindPossibleDeletionsQuery<'a> {
             } else {
                 out.push_sql("0 as causality_region, ");
             }
-            out.push_sql("e.id\n");
+            let pk_column = table.primary_key();
+
+            // Cast id to bytea so that every branch of the UNION has the same
+            // column type; the id can be text, bytea, or numeric depending on the
+            // entity type, and `UNION ALL` requires a common type per column.
+            match pk_column.column_type {
+                ColumnType::String => out.push_sql("e.id::bytea"),
+                ColumnType::Bytes => out.push_sql("e.id"),
+                ColumnType::Int8 => out.push_sql("e.id::text::bytea"),
+                _ => out.push_sql("e.id::bytea"),
+            }
+            out.push_sql("\n");
             out.push_sql("  from ");
             out.push_sql(table.qualified_name.as_str());
             out.push_sql(" e\n where ");


### PR DESCRIPTION
## Summary

Fixes #6695 - `entityChangesInBlock` fails with `UNION types bytea and text cannot be matched` on deployments whose entity types use different ID types (some `Bytes`, some `String`/`ID`).

## Root cause

`FindPossibleDeletionsQuery` (`store/postgres/src/relational_queries.rs`) builds one `UNION ALL` statement per deployment with one branch per entity table:

```sql
select 'Transfer' as entity, 0 as causality_region, e.id from sgdN.transfer e where ...
union all
select 'Account'  as entity, 0 as causality_region, e.id from sgdN.account  e where ...
```

`e.id` is selected raw, so its column type follows the entity: `text` for `ID`/`String` ids and `bytea` for `Bytes` ids (and `int8` for `Int8` ids). `UNION ALL` requires a common type per column position, so any schema mixing `text` and `bytea` ids is rejected by Postgres before a single row is read.

This is the same class of bug that `FindRangeQuery` already guards against - its `walk_ast` selects the id through a per-type cast (`id::bytea` / `id` / `id::text::bytea` via the `match pk_column.column_type` block). `FindPossibleDeletionsQuery` never got the same treatment.

## The fix

Mirror `FindRangeQuery`: select the primary-key column through a per-type cast so every branch of the `UNION ALL` produces a `bytea` id column:

| ID type | Column SQL |
| --- | --- |
| `String`/`ID` | `e.id::bytea` |
| `Bytes` | `e.id` |
| `Int8` | `e.id::text::bytea` |
| other | `e.id::bytea` |

Only the deletions query is affected. `FindChangesQuery` selects `to_jsonb(e.*)` (always `jsonb`), which is why it never trips on this error.

## Test

Adds `find_possible_deletions_query_id_type_casting` to `store/postgres/src/relational/query_tests.rs` (alongside the existing `find_range_query_id_type_casting`). It builds layouts with `String`, `Bytes`, and `Int8` ids, renders `FindPossibleDeletionsQuery` for each id type individually and combined, and asserts the id column carries the correct cast so the `UNION ALL` branches share a common `bytea` type. On the pre-fix code the test fails (no cast emitted); on the fixed code it passes.

## Impact

Read-only query path (`entityChangesInBlock` -> `SubgraphStore::entity_changes_in_block` -> `DeploymentStore::get_changes` -> `Layout::find_changes`). Indexing and query serving are unaffected.