### PR TITLE
ipfs: reject path traversal and query injection in content paths

### DIFF
--- a/graph/src/ipfs/content_path.rs
+++ b/graph/src/ipfs/content_path.rs
@@ -82,10 +82,20 @@ impl ContentPath {
                 source: anyhow::Error::from(err).context("invalid CID"),
             })?;
 
-        if path.contains('?') {
+        if path.contains('?') || path.contains('&') || path.contains('#') {
             return Err(IpfsError::InvalidContentPath {
                 input: input.to_string(),
                 source: anyhow!("query parameters not allowed"),
+            });
+        }
+
+        if path
+            .split('/')
+            .any(|segment| segment == "." || segment == "..")
+        {
+            return Err(IpfsError::InvalidContentPath {
+                input: input.to_string(),
+                source: anyhow!("path traversal is not allowed"),
             });
         }
 
@@ -233,6 +243,34 @@ mod tests {
             err.to_string(),
             format!(
                 "'{CID_V0}/readme.md?offline=true' is not a valid IPFS content path: query parameters not allowed"
+            )
+        );
+
+        let err = ContentPath::new(format!("{CID_V0}/readme.md&offline=true")).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "'{CID_V0}/readme.md&offline=true' is not a valid IPFS content path: query parameters not allowed"
+            )
+        );
+    }
+
+    #[test]
+    fn fails_on_path_traversal() {
+        let err = ContentPath::new(format!("{CID_V0}/../secret")).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            format!("'{CID_V0}/../secret' is not a valid IPFS content path: path traversal is not allowed")
+        );
+
+        let err = ContentPath::new(format!("{CID_V0}/foo/../../admin")).unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "'{CID_V0}/foo/../../admin' is not a valid IPFS content path: path traversal is not allowed"
             )
         );
     }


### PR DESCRIPTION
## Summary

`ContentPath` already rejects `?` after the CID. It still accepted `&` and `.` / `..` path segments.

Those values are interpolated into the operator IPFS URL:

- Gateway: `{server}ipfs/{cid}/{path}` (`IpfsGatewayClient::ipfs_url`)
- RPC: `cat?arg={path}` (`IpfsRpcClient::call`)

A mapping `ipfs.cat` (or a file data source) can therefore:

1. Walk out of `/ipfs/<cid>/` with `../` (HTTP clients normalize that before the request is sent)
2. Inject extra RPC flags with `&` (`cat?arg=<cid>/readme.md&offline=true`)

`readme.md` and other in-CID file paths are unchanged.

## Test plan

- [x] `cargo test -p graph --lib content_path` (15/15)
- [x] Revert-test: without the new checks, `fails_on_path_traversal` and the `&` case in `fails_on_attempts_to_pass_query_parameters` accept the crafted paths

I used an AI coding assistant to draft the tests and this description. I reviewed the interpolation sites and the revert-test.