### PR TITLE
node: warn, and name both node ids, when no block ingestion runs

### DIFF
--- a/node/src/launcher.rs
+++ b/node/src/launcher.rs
@@ -594,9 +594,13 @@ pub async fn run(
                 "Block ingestor disabled by --disable-block-ingestor"
             );
         } else {
-            info!(
+            warn!(
                 logger,
-                "Not running block ingestion, ingestor is `{}`", config.chains.ingestor
+                "Not running block ingestion: this node is `{}` but `[chains] ingestor` is `{}`. \
+                 Ingestion runs only on the node whose `--node-id` matches that value; if no \
+                 running node has it, the chain head will not advance",
+                config.node,
+                config.chains.ingestor
             );
         }
 


### PR DESCRIPTION
When `[chains] ingestor` names a node that is not running, nothing ingests blocks. The chain head stops advancing and every deployment sits at its current block reporting healthy, so nothing reports a problem anywhere. graph-node already logs this at INFO, but the line names only the configured ingestor and not the node's own id, so it reads as a correct statement of intent rather than a mismatch.

This caught an indexer upgrading 0.41.1 to 0.45.0, crossing #6447 where the field became load-bearing. Their config said `index-node-0`; the node ran as `index_node_0`. Both are valid node ids so validation passes, and the log line said "Not running block ingestion, ingestor is index-node-0", which reads as correct. It took two and three quarter hours to find.

This raises the line to WARN and names both ids, so the mismatch is visible in the line that already exists. Behaviour is unchanged, and `config::tests::is_block_ingestor` already covers the logic.

A node deliberately not the ingestor will now warn once at startup. If you would rather that stayed INFO, I will drop the level change and keep the message.
